### PR TITLE
Additional Disk Support for vmware-iso Builder

### DIFF
--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -37,16 +37,16 @@ func (s StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 	
-	moreDisks := state.Get("additional_disk_paths").([]string)
-	if len(moreDisks) > 0 {
-		for i, path := range moreDisks {
-			ui.Say(fmt.Sprintf("Compacting additional disk image %d",i+1))
-			if err := driver.CompactDisk(path); err != nil {
-				state.Put("error", fmt.Errorf("Error compacting additional disk %d: %s", i+1, err))
-				return multistep.ActionHalt
+	if state.Get("additional_disk_paths") != nil {
+		if moreDisks := state.Get("additional_disk_paths").([]string); len(moreDisks) > 0 {
+			for i, path := range moreDisks {
+				ui.Say(fmt.Sprintf("Compacting additional disk image %d",i+1))
+				if err := driver.CompactDisk(path); err != nil {
+					state.Put("error", fmt.Errorf("Error compacting additional disk %d: %s", i+1, err))
+					return multistep.ActionHalt
+				}
 			}
 		}
-		
 	}
 
 	return multistep.ActionContinue

--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -36,6 +36,18 @@ func (s StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 		state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
 		return multistep.ActionHalt
 	}
+	
+	moreDisks := state.Get("additional_disk_paths").([]string)
+	if len(moreDisks) > 0 {
+		for i, path := range moreDisks {
+			ui.Say(fmt.Sprintf("Compacting additional disk image %d",i+1))
+			if err := driver.CompactDisk(path); err != nil {
+				state.Put("error", fmt.Errorf("Error compacting additional disk %d: %s", i+1, err))
+				return multistep.ActionHalt
+			}
+		}
+		
+	}
 
 	return multistep.ActionContinue
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -34,6 +34,7 @@ type config struct {
 
 	DiskName          string   `mapstructure:"vmdk_name"`
 	DiskSize          uint     `mapstructure:"disk_size"`
+  AdditionalDiskSize   []uint     `mapstructure:"additionaldisk_size"`
 	DiskTypeId        string   `mapstructure:"disk_type_id"`
 	FloppyFiles       []string `mapstructure:"floppy_files"`
 	GuestOSType       string   `mapstructure:"guest_os_type"`

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -32,26 +32,26 @@ type config struct {
 	vmwcommon.SSHConfig      `mapstructure:",squash"`
 	vmwcommon.VMXConfig      `mapstructure:",squash"`
 
-	DiskName          string   `mapstructure:"vmdk_name"`
-	DiskSize          uint     `mapstructure:"disk_size"`
-  AdditionalDiskSize   []uint     `mapstructure:"additionaldisk_size"`
-	DiskTypeId        string   `mapstructure:"disk_type_id"`
-	FloppyFiles       []string `mapstructure:"floppy_files"`
-	GuestOSType       string   `mapstructure:"guest_os_type"`
-	ISOChecksum       string   `mapstructure:"iso_checksum"`
-	ISOChecksumType   string   `mapstructure:"iso_checksum_type"`
-	ISOUrls           []string `mapstructure:"iso_urls"`
-	VMName            string   `mapstructure:"vm_name"`
-	HTTPDir           string   `mapstructure:"http_directory"`
-	HTTPPortMin       uint     `mapstructure:"http_port_min"`
-	HTTPPortMax       uint     `mapstructure:"http_port_max"`
-	BootCommand       []string `mapstructure:"boot_command"`
-	SkipCompaction    bool     `mapstructure:"skip_compaction"`
-	ToolsUploadFlavor string   `mapstructure:"tools_upload_flavor"`
-	ToolsUploadPath   string   `mapstructure:"tools_upload_path"`
-	VMXTemplatePath   string   `mapstructure:"vmx_template_path"`
-	VNCPortMin        uint     `mapstructure:"vnc_port_min"`
-	VNCPortMax        uint     `mapstructure:"vnc_port_max"`
+	DiskName           string   `mapstructure:"vmdk_name"`
+	DiskSize           uint     `mapstructure:"disk_size"`
+	AdditionalDiskSize []uint   `mapstructure:"additionaldisk_size"`
+	DiskTypeId         string   `mapstructure:"disk_type_id"`
+	FloppyFiles        []string `mapstructure:"floppy_files"`
+	GuestOSType        string   `mapstructure:"guest_os_type"`
+	ISOChecksum        string   `mapstructure:"iso_checksum"`
+	ISOChecksumType    string   `mapstructure:"iso_checksum_type"`
+	ISOUrls            []string `mapstructure:"iso_urls"`
+	VMName             string   `mapstructure:"vm_name"`
+	HTTPDir            string   `mapstructure:"http_directory"`
+	HTTPPortMin        uint     `mapstructure:"http_port_min"`
+	HTTPPortMax        uint     `mapstructure:"http_port_max"`
+	BootCommand        []string `mapstructure:"boot_command"`
+	SkipCompaction     bool     `mapstructure:"skip_compaction"`
+	ToolsUploadFlavor  string   `mapstructure:"tools_upload_flavor"`
+	ToolsUploadPath    string   `mapstructure:"tools_upload_path"`
+	VMXTemplatePath    string   `mapstructure:"vmx_template_path"`
+	VNCPortMin         uint     `mapstructure:"vnc_port_min"`
+	VNCPortMax         uint     `mapstructure:"vnc_port_max"`
 
 	RemoteType      string `mapstructure:"remote_type"`
 	RemoteDatastore string `mapstructure:"remote_datastore"`

--- a/builder/vmware/iso/step_create_disk.go
+++ b/builder/vmware/iso/step_create_disk.go
@@ -34,26 +34,26 @@ func (stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	state.Put("full_disk_path", full_disk_path)
-	
+
 	if len(config.AdditionalDiskSize) > 0 {
 		// stash the disk paths we create
-		additional_paths := make([]string,len(config.AdditionalDiskSize))
-		
+		additional_paths := make([]string, len(config.AdditionalDiskSize))
+
 		ui.Say("Creating additional hard drives...")
 		for i, additionalsize := range config.AdditionalDiskSize {
-	    	additionalpath := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk",config.DiskName,i+1))
+			additionalpath := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk", config.DiskName, i+1))
 			size := fmt.Sprintf("%dM", uint64(additionalsize))
-		
+
 			if err := driver.CreateDisk(additionalpath, size, config.DiskTypeId); err != nil {
 				err := fmt.Errorf("Error creating additional disk: %s", err)
-				state.Put("error",err)
+				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			
+
 			additional_paths[i] = additionalpath
 		}
-		
+
 		state.Put("additional_disk_paths", additional_paths)
 	}
 

--- a/builder/vmware/iso/step_create_disk.go
+++ b/builder/vmware/iso/step_create_disk.go
@@ -34,6 +34,28 @@ func (stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	state.Put("full_disk_path", full_disk_path)
+	
+	if len(config.AdditionalDiskSize) > 0 {
+		// stash the disk paths we create
+		additional_paths := make([]string,len(config.AdditionalDiskSize))
+		
+		ui.Say("Creating additional hard drives...")
+		for i, additionalsize := range config.AdditionalDiskSize {
+	    	additionalpath := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk",config.DiskName,i+1))
+			size := fmt.Sprintf("%dM", uint64(additionalsize))
+		
+			if err := driver.CreateDisk(additionalpath, size, config.DiskTypeId); err != nil {
+				err := fmt.Errorf("Error creating additional disk: %s", err)
+				state.Put("error",err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
+			
+			additional_paths[i] = additionalpath
+		}
+		
+		state.Put("additional_disk_paths", additional_paths)
+	}
 
 	return multistep.ActionContinue
 }

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -18,8 +18,8 @@ type vmxTemplateData struct {
 }
 
 type additionalDiskTemplateData struct {
-	DiskNumber	int
-	DiskName	string
+	DiskNumber int
+	DiskName   string
 }
 
 // This step creates the VMX file for the VM.
@@ -70,22 +70,22 @@ func (s *stepCreateVMX) Run(state multistep.StateBag) multistep.StepAction {
 
 		vmxTemplate = string(rawBytes)
 	}
-	
+
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, _ := range config.AdditionalDiskSize {
 			data := &additionalDiskTemplateData{
-				DiskNumber: 	i+1,
-				DiskName: 		config.DiskName,
+				DiskNumber: i + 1,
+				DiskName:   config.DiskName,
 			}
-			
-			diskTemplate, err := config.tpl.Process(DefaultAdditionalDiskTemplate,data)
+
+			diskTemplate, err := config.tpl.Process(DefaultAdditionalDiskTemplate, data)
 			if err != nil {
 				err := fmt.Errorf("Error preparing VMX template for additional disk: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			
+
 			vmxTemplate += diskTemplate
 		}
 	}


### PR DESCRIPTION
I'd like to reopen the discussion from #703 about adding support for specifying additional disks during Packer's build phase.  Unlike the Virtualbox builder, I don't think there's a vboxmanage-type workaround here.

My use case is that I'm packaging VM appliances, and need to end up with a system disk mounted at `/` and a disk for user data mounted at `/data`. In a previous iteration we used VMware Studio, and multiple disk support was one of the few things it did well.  

I went ahead and implemented the same syntax as was used in the earlier issue, but I'm definitely open to a discussion on what additional things you might want to specify about the disks.  For instance, I could definitely see an object that specifies both name and size:

```
    "additional_disks": [
        {
            "name": "data_disk",
            "size": "204800"
        }
    ]
```

I'm going to guess that this use case does come up for other people, so if we could unobtrusively come up with enough of an implementation to handle the basic case and get out of the way for those who don't need it, that would be awesome.