### PR TITLE
Additional Disk Functionality For vmware-iso builder

### DIFF
--- a/builder/vmware/common/driver_mock.go
+++ b/builder/vmware/common/driver_mock.go
@@ -15,7 +15,7 @@ type DriverMock struct {
 	CloneErr    error
 
 	CompactDiskCalled bool
-	CompactDiskPath   string
+	CompactDiskPath   []string
 	CompactDiskErr    error
 
 	CreateDiskCalled bool
@@ -71,7 +71,7 @@ func (d *DriverMock) Clone(dst string, src string) error {
 
 func (d *DriverMock) CompactDisk(path string) error {
 	d.CompactDiskCalled = true
-	d.CompactDiskPath = path
+	d.CompactDiskPath = append(d.CompactDiskPath, path)
 	return d.CompactDiskErr
 }
 

--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -24,17 +24,19 @@ type StepCompactDisk struct {
 func (s StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	full_disk_path := state.Get("full_disk_path").(string)
+	full_disk_paths := state.Get("full_disk_paths").([]string)
 
 	if s.Skip {
 		log.Println("Skipping disk compaction step...")
 		return multistep.ActionContinue
 	}
 
-	ui.Say("Compacting the disk image")
-	if err := driver.CompactDisk(full_disk_path); err != nil {
-		state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
-		return multistep.ActionHalt
+	ui.Say("Compacting the disk image(s)")
+	for i, disk := range full_disk_paths {
+		if err := driver.CompactDisk(disk); err != nil {
+			state.Put("error", fmt.Errorf("Error compacting disk[%d]: %s", i, err))
+			return multistep.ActionHalt
+		}
 	}
 
 	return multistep.ActionContinue

--- a/builder/vmware/common/step_compact_disk_test.go
+++ b/builder/vmware/common/step_compact_disk_test.go
@@ -14,7 +14,9 @@ func TestStepCompactDisk(t *testing.T) {
 	state := testState(t)
 	step := new(StepCompactDisk)
 
-	state.Put("full_disk_path", "foo")
+	full_disk_paths := make([]string, 0)
+	full_disk_paths = append(full_disk_paths, "foo", "bar")
+	state.Put("full_disk_paths", full_disk_paths)
 
 	driver := state.Get("driver").(*DriverMock)
 
@@ -30,7 +32,7 @@ func TestStepCompactDisk(t *testing.T) {
 	if !driver.CompactDiskCalled {
 		t.Fatal("should've called")
 	}
-	if driver.CompactDiskPath != "foo" {
+	if driver.CompactDiskPath[0] != "foo" && driver.CompactDiskPath[1] != "bar" {
 		t.Fatal("should call with right path")
 	}
 }
@@ -40,7 +42,9 @@ func TestStepCompactDisk_skip(t *testing.T) {
 	step := new(StepCompactDisk)
 	step.Skip = true
 
-	state.Put("full_disk_path", "foo")
+	full_disk_paths := make([]string, 0)
+	full_disk_paths = append(full_disk_paths, "foo", "bar")
+	state.Put("full_disk_paths", full_disk_paths)
 
 	driver := state.Get("driver").(*DriverMock)
 

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/multistep"
@@ -18,6 +19,7 @@ import (
 //   vmx_path string
 type StepConfigureVMX struct {
 	CustomData map[string]string
+	NewDisks   [][]string
 }
 
 func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
@@ -47,6 +49,17 @@ func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
 		if addrRegex.MatchString(k) {
 			delete(vmxData, k)
 		}
+	}
+
+	// set additional disks
+	for i, disk := range s.NewDisks {
+		k1 := "scsi0:" + strconv.Itoa(i+1) + ".fileName"
+		v1 := disk[0] + ".vmdk"
+		log.Printf("Setting VMX: '%s' = '%s'", k1, v1)
+		k2 := "scsi0:" + strconv.Itoa(i+1) + ".present"
+		v2 := "TRUE"
+		vmxData[k1] = v1
+		vmxData[k2] = v2
 	}
 
 	// Set custom data

--- a/builder/vmware/iso/adddisks_config.go
+++ b/builder/vmware/iso/adddisks_config.go
@@ -1,0 +1,29 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+)
+
+type AddDisksConfig struct {
+	NewDisks [][]string `mapstructure:"add_disks"`
+}
+
+func (c *AddDisksConfig) Prepare(t *packer.ConfigTemplate) []error {
+	if c.NewDisks == nil {
+		c.NewDisks = make([][]string, 0)
+	}
+	errs := make([]error, 0)
+	for i, args := range c.NewDisks {
+		if len(args) != 3 {
+			errs = append(errs, fmt.Errorf("Error processing AddDisk[%d]: Incorrect number of arguments", i))
+		}
+		for j, arg := range args {
+			if err := t.Validate(arg); err != nil {
+				errs = append(errs,
+					fmt.Errorf("Error processing vdiskmanager[%d][%d]: %s", i, j, err))
+			}
+		}
+	}
+	return errs
+}

--- a/builder/vmware/iso/step_adddisks.go
+++ b/builder/vmware/iso/step_adddisks.go
@@ -17,27 +17,30 @@ import (
 //
 // Produces:
 //   full_disk_path (string) - The full path to the created disk.
-type stepCreateDisk struct{}
 
-func (stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
+type stepAddDisks struct{}
+
+func (stepAddDisks) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*config)
 	driver := state.Get("driver").(vmwcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
 	full_disk_paths := state.Get("full_disk_paths").([]string)
 
-	ui.Say("Creating virtual machine disk")
-	full_disk_path := filepath.Join(config.OutputDir, config.DiskName+".vmdk")
-	if err := driver.CreateDisk(full_disk_path, fmt.Sprintf("%dM", config.DiskSize), config.DiskTypeId); err != nil {
-		err := fmt.Errorf("Error creating disk: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	ui.Say("Creating additional virtual machine disks...")
+	for i, args := range config.AddDisksConfig.NewDisks {
+		full_disk_path := filepath.Join(config.OutputDir, args[0]+".vmdk")
+		if err := driver.CreateDisk(full_disk_path, fmt.Sprintf("%sM", args[1]), args[2]); err != nil {
+			err := fmt.Errorf("Error creating disk[%d]: %s", i, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		full_disk_paths = append(full_disk_paths, full_disk_path)
+
 	}
 
-	full_disk_paths = append(full_disk_paths, full_disk_path)
 	state.Put("full_disk_paths", full_disk_paths)
-
 	return multistep.ActionContinue
 }
 
-func (stepCreateDisk) Cleanup(multistep.StateBag) {}
+func (stepAddDisks) Cleanup(multistep.StateBag) {}


### PR DESCRIPTION
Using two disks in a VM is not an uncommon situation and a few other people have showed interest in a method that works for vmware builder. 

Adding additional disks to your VM can be done by adding the "add_disks" property as shown:

``` 
"add_disks": [
			["disk1", 100000, 0],
			["disk2", 100000, 0]
],
```
Each array represents one disk and it's parameters. The parameters are disk name, size, and disk type, respectively.