### PR TITLE
WinRM fixes

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -16,7 +16,41 @@ import (
 	"time"
 )
 
-const DefaultRemotePath = "/tmp/script.sh"
+const unixOsType = "unix"
+const windowsOsType = "windows"
+
+const defaultOsType = unixOsType
+
+type guestOsConfig struct {
+	hasChmod       bool
+	envVarJoiner   string
+	executeCommand string
+	inlinePrefix   string
+	inlineShebang  string
+	newline        string
+	remotePath     string
+}
+
+var guestOsConfigs = map[string]guestOsConfig{
+	unixOsType: guestOsConfig{
+		hasChmod:		true,
+		envVarJoiner:   " ",
+		executeCommand: "chmod +x {{.Path}}; {{.Vars}} {{.Path}}",
+		inlinePrefix:   "%!",
+		inlineShebang:  "/bin/sh",
+		newline:        "\n",
+		remotePath:     "/tmp/script.sh",
+	},
+	windowsOsType: guestOsConfig{
+		hasChmod:		false,
+		envVarJoiner:   " & ",
+		executeCommand: "{{.Vars}} & {{.Path}}",
+		inlinePrefix:   "",
+		inlineShebang:  "",
+		newline:        "\r\n",
+		remotePath:     "\\packer_temp.cmd",
+	},
+}
 
 type config struct {
 	common.PackerConfig `mapstructure:",squash"`
@@ -24,6 +58,9 @@ type config struct {
 	// If true, the script contains binary and line endings will not be
 	// converted from Windows to Unix-style.
 	Binary bool
+
+	// The type of OS the guest is running: unix or windows
+	GuestOsType string `mapstructure:"guest_os_type"`
 
 	// An inline script to execute. Multiple strings are all executed
 	// in the context of a single shell.
@@ -84,8 +121,20 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	// Accumulate any errors
 	errs := common.CheckUnusedConfig(md)
 
+	if p.config.GuestOsType == "" {
+		p.config.GuestOsType = defaultOsType
+	}
+
+	p.config.GuestOsType = strings.ToLower(p.config.GuestOsType)
+
+	guestOsConfig, ok := guestOsConfigs[p.config.GuestOsType]
+
+	if !ok {
+		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOsType)
+	}
+
 	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = "chmod +x {{.Path}}; {{.Vars}} {{.Path}}"
+		p.config.ExecuteCommand = guestOsConfig.executeCommand
 	}
 
 	if p.config.Inline != nil && len(p.config.Inline) == 0 {
@@ -93,7 +142,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.InlineShebang == "" {
-		p.config.InlineShebang = "/bin/sh"
+		p.config.InlineShebang = guestOsConfig.inlineShebang
 	}
 
 	if p.config.RawStartRetryTimeout == "" {
@@ -101,7 +150,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.RemotePath == "" {
-		p.config.RemotePath = DefaultRemotePath
+		p.config.RemotePath = guestOsConfig.remotePath
 	}
 
 	if p.config.Scripts == nil {
@@ -197,6 +246,8 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	scripts := make([]string, len(p.config.Scripts))
 	copy(scripts, p.config.Scripts)
 
+	guestOsConfig, _ := guestOsConfigs[p.config.GuestOsType]
+
 	// If we have an inline script, then turn that into a temporary
 	// shell script and use that.
 	if p.config.Inline != nil {
@@ -211,9 +262,12 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 		// Write our contents to it
 		writer := bufio.NewWriter(tf)
-		writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
+
+		sheBang := guestOsConfig.inlinePrefix + p.config.InlineShebang + guestOsConfig.newline
+
+		writer.WriteString(sheBang)
 		for _, command := range p.config.Inline {
-			if _, err := writer.WriteString(command + "\n"); err != nil {
+			if _, err := writer.WriteString(command + guestOsConfig.newline); err != nil {
 				return fmt.Errorf("Error preparing shell script: %s", err)
 			}
 		}
@@ -231,6 +285,18 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	envVars[1] = "PACKER_BUILDER_TYPE=" + p.config.PackerBuilderType
 	copy(envVars[2:], p.config.Vars)
 
+	if p.config.GuestOsType == windowsOsType {
+		for i, envVar := range envVars {
+			// see http://www.robvanderwoude.com/escapechars.php
+			for _, rune := range "^&<>|" {
+				old := string(rune)
+				new := "^" + old
+				envVar = strings.Replace(envVar, old, new, -1)
+			}
+			envVars[i] = "SET " + envVar
+		}
+	}
+
 	for _, path := range scripts {
 		ui.Say(fmt.Sprintf("Provisioning with shell script: %s", path))
 
@@ -242,7 +308,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		defer f.Close()
 
 		// Flatten the environment variables
-		flattendVars := strings.Join(envVars, " ")
+		flattendVars := strings.Join(envVars, guestOsConfig.envVarJoiner)
 
 		// Compile the command
 		command, err := p.config.tpl.Process(p.config.ExecuteCommand, &ExecuteCommandTemplate{
@@ -273,15 +339,17 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 				return fmt.Errorf("Error uploading script: %s", err)
 			}
 
-			cmd = &packer.RemoteCmd{
-				Command: fmt.Sprintf("chmod 0777 %s", p.config.RemotePath),
+			if guestOsConfig.hasChmod {
+				cmd = &packer.RemoteCmd{
+					Command: fmt.Sprintf("chmod 0777 %s", p.config.RemotePath),
+				}
+				if err := comm.Start(cmd); err != nil {
+					return fmt.Errorf(
+						"Error chmodding script file to 0777 in remote "+
+							"machine: %s", err)
+				}
+				cmd.Wait()
 			}
-			if err := comm.Start(cmd); err != nil {
-				return fmt.Errorf(
-					"Error chmodding script file to 0777 in remote "+
-						"machine: %s", err)
-			}
-			cmd.Wait()
 
 			cmd = &packer.RemoteCmd{Command: command}
 			return cmd.StartWithUi(comm, ui)

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -33,7 +33,7 @@ type guestOsConfig struct {
 
 var guestOsConfigs = map[string]guestOsConfig{
 	unixOsType: guestOsConfig{
-		hasChmod:		true,
+		hasChmod:       true,
 		envVarJoiner:   " ",
 		executeCommand: "chmod +x {{.Path}}; {{.Vars}} {{.Path}}",
 		inlinePrefix:   "%!",
@@ -42,7 +42,7 @@ var guestOsConfigs = map[string]guestOsConfig{
 		remotePath:     "/tmp/script.sh",
 	},
 	windowsOsType: guestOsConfig{
-		hasChmod:		false,
+		hasChmod:       false,
 		envVarJoiner:   " & ",
 		executeCommand: "{{.Vars}} & {{.Path}}",
 		inlinePrefix:   "",

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -36,7 +36,7 @@ var guestOsConfigs = map[string]guestOsConfig{
 		hasChmod:       true,
 		envVarJoiner:   " ",
 		executeCommand: "chmod +x {{.Path}}; {{.Vars}} {{.Path}}",
-		inlinePrefix:   "%!",
+		inlinePrefix:   "#!",
 		inlineShebang:  "/bin/sh",
 		newline:        "\n",
 		remotePath:     "/tmp/script.sh",

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -43,11 +43,14 @@ var guestOsConfigs = map[string]guestOsConfig{
 	},
 	windowsOsType: guestOsConfig{
 		hasChmod:       false,
-		envVarJoiner:   " & ",
-		executeCommand: "{{.Vars}} & {{.Path}}",
+		// a leading space here will create vars with trailing spaces
+		envVarJoiner:   "& ",
+		// a leading space here will create a var with a trailing space
+		executeCommand: "{{.Vars}}& {{.Path}}",
 		inlinePrefix:   "",
 		inlineShebang:  "",
 		newline:        "\r\n",
+		// leave off C:, as Autounattend.xml may define a different drive
 		remotePath:     "\\packer_temp.cmd",
 	},
 }

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -30,8 +30,20 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.RemotePath != DefaultRemotePath {
-		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
+	if p.config.GuestOsType != defaultOsType {
+		t.Errorf("defaultOsType: expecting %s, found %s", defaultOsType, p.config.GuestOsType)
+	}
+
+	if p.config.ExecuteCommand != guestOsConfigs[defaultOsType].executeCommand {
+		t.Errorf("ExecuteCommand: expecting %s, found %s", guestOsConfigs[defaultOsType].executeCommand, p.config.ExecuteCommand)
+	}
+
+	if p.config.InlineShebang != guestOsConfigs[defaultOsType].inlineShebang {
+		t.Errorf("InlineShebang: expecting %s, found %s", guestOsConfigs[defaultOsType].inlineShebang, p.config.InlineShebang)
+	}
+
+	if p.config.RemotePath != guestOsConfigs[defaultOsType].remotePath {
+		t.Errorf("RemotePath: expecting %s, found %s", guestOsConfigs[defaultOsType].remotePath, p.config.RemotePath)
 	}
 }
 
@@ -45,8 +57,8 @@ func TestProvisionerPrepare_InlineShebang(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if p.config.InlineShebang != "/bin/sh" {
-		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	if p.config.InlineShebang != guestOsConfigs[defaultOsType].inlineShebang {
+		t.Errorf("InlineShebang: expecting %s, found %s", guestOsConfigs[defaultOsType].inlineShebang, p.config.InlineShebang)
 	}
 
 	// Test with a good one

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -65,7 +65,7 @@ Optional parameters:
   When `guest_os_type` is `windows`, this defaults to `{{ .Vars }} & {{ .Path }}`.
 
 * `guest_os_type` (string) - The type of the guest OS, either `unix`, and `windows`.
-  Currently, `unix` can be used for any unix-like OS, including OSX.
+  Currently, `unix` should be used for any unix-like OS, including Cygwin, and OSX.
   This defaults to `unix`.
 
 * `inline_shebang` (string) - The

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -57,19 +57,29 @@ Optional parameters:
   into the environment, as well, which are covered in the section below.
 
 * `execute_command` (string) - The command to use to execute the script.
-  By default this is `chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}`. The value of this is
-  treated as [configuration template](/docs/templates/configuration-templates.html). There are two available variables: `Path`, which is
+  The value of this is treated as [configuration template](/docs/templates/configuration-templates.html).
+  There are two available variables: `Path`, which is
   the path to the script to run, and `Vars`, which is the list of
   `environment_vars`, if configured.
+  When `guest_os_type` is `unix`, this defaults to `chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}`.
+  When `guest_os_type` is `windows`, this defaults to `{{ .Vars }} & {{ .Path }}`.
+
+* `guest_os_type` (string) - The type of the guest OS, either `unix`, and `windows`.
+  Currently, `unix` can be used for any unix-like OS, including OSX.
+  This defaults to `unix`.
 
 * `inline_shebang` (string) - The
   [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) value to use when
-  running commands specified by `inline`. By default, this is `/bin/sh`.
+  running commands specified by `inline`.
   If you're not using `inline`, then this configuration has no effect.
+  When `guest_os_type` is `unix`, this defaults to `/bin/sh`.
+  When `guest_os_type` is `windows`, this defaults to an empty string.
 
 * `remote_path` (string) - The path where the script will be uploaded to
-  in the machine. This defaults to "/tmp/script.sh". This value must be
+  in the machine. This value must be
   a writable location and any parent directories must already exist.
+  When `guest_os_type` is `unix`, this defaults to `/tmp/script.sh`.
+  When `guest_os_type` is `windows`, this defaults to `\packer_temp.cmd`.
 
 * `start_retry_timeout` (string) - The amount of time to attempt to
   _start_ the remote process. By default this is "5m" or 5 minutes. This


### PR DESCRIPTION
This PR is backwards compatible, so it won't break anything if we merge it in prior to #1175 being accepted.

This PR allows #1175 to work with the following provisioners:
````
    {
      "type": "shell",
      "guest_os_type": "windows",
      "inline": ["mklink /d C:\\tmp C:\\Windows\\Temp"]
    },
    {
      "type": "shell",
      "guest_os_type": "windows",
      "script": "test.cmd",
      "binary": "true"
    },
    {
      "type": "shell",
      "guest_os_type": "windows",
      "scripts": ["test.cmd"],
      "binary": "true"
    }
````
It's regrettable that the `guest_os_type` needs to be repeated in each provisioner, but as @sneal pointed out, we don't have access to the builder's `communicator_type` setting. Note that `communicator_type` will also need to be repeated for each builder, so it seems we need a higher level setting, perhaps a `guest_os_type`, at the same level as the `builders`, and `provisioners`.