### PR TITLE
Chef provisioner windows

### DIFF
--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -23,8 +23,8 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 	},
 	WindowsOSType: guestOSTypeCommand{
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
-		mkdir:     "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s",
-		removeDir: "rm %s -recurse -force",
+		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
+		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
 	},
 }
 

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -1,0 +1,72 @@
+package provisioner
+
+import (
+	"fmt"
+	"strings"
+)
+
+const UnixOSType = "unix"
+const WindowsOSType = "windows"
+const DefaultOSType = UnixOSType
+
+type guestOSTypeCommand struct {
+	chmod     string
+	mkdir     string
+	removeDir string
+}
+
+var guestOSTypeCommands = map[string]guestOSTypeCommand{
+	UnixOSType: guestOSTypeCommand{
+		chmod:     "chmod %s '%s'",
+		mkdir:     "mkdir -p '%s'",
+		removeDir: "rm -rf '%s'",
+	},
+	WindowsOSType: guestOSTypeCommand{
+		chmod:     "echo 'skipping chmod %s %s'", // no-op
+		mkdir:     "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s",
+		removeDir: "rm %s -recurse -force",
+	},
+}
+
+type GuestCommands struct {
+	GuestOSType string
+	Sudo        bool
+}
+
+func NewGuestCommands(osType string, sudo bool) (*GuestCommands, error) {
+	_, ok := guestOSTypeCommands[osType]
+	if !ok {
+		return nil, fmt.Errorf("Invalid osType: \"%s\"", osType)
+	}
+	return &GuestCommands{GuestOSType: osType, Sudo: sudo}, nil
+}
+
+func (g *GuestCommands) Chmod(path string, mode string) string {
+	return g.sudo(fmt.Sprintf(g.commands().chmod, mode, g.escapePath(path)))
+}
+
+func (g *GuestCommands) CreateDir(path string) string {
+	return g.sudo(fmt.Sprintf(g.commands().mkdir, g.escapePath(path)))
+}
+
+func (g *GuestCommands) RemoveDir(path string) string {
+	return g.sudo(fmt.Sprintf(g.commands().removeDir, g.escapePath(path)))
+}
+
+func (g *GuestCommands) commands() guestOSTypeCommand {
+	return guestOSTypeCommands[g.GuestOSType]
+}
+
+func (g *GuestCommands) escapePath(path string) string {
+	if g.GuestOSType == WindowsOSType {
+		return strings.Replace(path, " ", "` ", -1)
+	}
+	return path
+}
+
+func (g *GuestCommands) sudo(cmd string) string {
+	if g.GuestOSType == UnixOSType && g.Sudo {
+		return "sudo " + cmd
+	}
+	return cmd
+}

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -38,13 +38,13 @@ func TestCreateDir(t *testing.T) {
 		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
 	}
 	cmd = guestCmd.CreateDir("C:\\Windows\\Temp\\tempdir")
-	if cmd != "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\tempdir" {
+	if cmd != "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\tempdir\"" {
 		t.Fatalf("Unexpected Windows create dir cmd: %s", cmd)
 	}
 
 	// Windows OS w/ space in path
 	cmd = guestCmd.CreateDir("C:\\Windows\\Temp\\temp dir")
-	if cmd != "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\temp` dir" {
+	if cmd != "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\temp` dir\"" {
 		t.Fatalf("Unexpected Windows create dir cmd: %s", cmd)
 	}
 }
@@ -108,13 +108,13 @@ func TestRemoveDir(t *testing.T) {
 		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
 	}
 	cmd = guestCmd.RemoveDir("C:\\Temp\\SomeDir")
-	if cmd != "rm C:\\Temp\\SomeDir -recurse -force" {
+	if cmd != "powershell.exe -Command \"rm C:\\Temp\\SomeDir -recurse -force\"" {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 
 	// Windows OS w/ space in path
 	cmd = guestCmd.RemoveDir("C:\\Temp\\Some Dir")
-	if cmd != "rm C:\\Temp\\Some` Dir -recurse -force" {
+	if cmd != "powershell.exe -Command \"rm C:\\Temp\\Some` Dir -recurse -force\"" {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 }

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -1,0 +1,120 @@
+package provisioner
+
+import (
+	"testing"
+)
+
+func TestNewGuestCommands(t *testing.T) {
+	_, err := NewGuestCommands("Amiga", true)
+	if err == nil {
+		t.Fatalf("Should have returned an err for unsupported OS type")
+	}
+}
+
+func TestCreateDir(t *testing.T) {
+	// *nix OS
+	guestCmd, err := NewGuestCommands(UnixOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd := guestCmd.CreateDir("/tmp/tempdir")
+	if cmd != "mkdir -p '/tmp/tempdir'" {
+		t.Fatalf("Unexpected Unix create dir cmd: %s", cmd)
+	}
+
+	// *nix OS w/sudo
+	guestCmd, err = NewGuestCommands(UnixOSType, true)
+	if err != nil {
+		t.Fatalf("Failed to create new sudo GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd = guestCmd.CreateDir("/tmp/tempdir")
+	if cmd != "sudo mkdir -p '/tmp/tempdir'" {
+		t.Fatalf("Unexpected Unix sudo create dir cmd: %s", cmd)
+	}
+
+	// Windows OS
+	guestCmd, err = NewGuestCommands(WindowsOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
+	}
+	cmd = guestCmd.CreateDir("C:\\Windows\\Temp\\tempdir")
+	if cmd != "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\tempdir" {
+		t.Fatalf("Unexpected Windows create dir cmd: %s", cmd)
+	}
+
+	// Windows OS w/ space in path
+	cmd = guestCmd.CreateDir("C:\\Windows\\Temp\\temp dir")
+	if cmd != "New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path C:\\Windows\\Temp\\temp` dir" {
+		t.Fatalf("Unexpected Windows create dir cmd: %s", cmd)
+	}
+}
+
+func TestChmod(t *testing.T) {
+	// *nix
+	guestCmd, err := NewGuestCommands(UnixOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd := guestCmd.Chmod("/usr/local/bin/script.sh", "0666")
+	if cmd != "chmod 0666 '/usr/local/bin/script.sh'" {
+		t.Fatalf("Unexpected Unix chmod 0666 cmd: %s", cmd)
+	}
+
+	// sudo *nix
+	guestCmd, err = NewGuestCommands(UnixOSType, true)
+	if err != nil {
+		t.Fatalf("Failed to create new sudo GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd = guestCmd.Chmod("/usr/local/bin/script.sh", "+x")
+	if cmd != "sudo chmod +x '/usr/local/bin/script.sh'" {
+		t.Fatalf("Unexpected Unix chmod +x cmd: %s", cmd)
+	}
+
+	// Windows
+	guestCmd, err = NewGuestCommands(WindowsOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
+	}
+	cmd = guestCmd.Chmod("C:\\Program Files\\SomeApp\\someapp.exe", "+x")
+	if cmd != "echo 'skipping chmod +x C:\\Program` Files\\SomeApp\\someapp.exe'" {
+		t.Fatalf("Unexpected Windows chmod +x cmd: %s", cmd)
+	}
+}
+
+func TestRemoveDir(t *testing.T) {
+	// *nix
+	guestCmd, err := NewGuestCommands(UnixOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd := guestCmd.RemoveDir("/tmp/somedir")
+	if cmd != "rm -rf '/tmp/somedir'" {
+		t.Fatalf("Unexpected Unix remove dir cmd: %s", cmd)
+	}
+
+	// sudo *nix
+	guestCmd, err = NewGuestCommands(UnixOSType, true)
+	if err != nil {
+		t.Fatalf("Failed to create new sudo GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd = guestCmd.RemoveDir("/tmp/somedir")
+	if cmd != "sudo rm -rf '/tmp/somedir'" {
+		t.Fatalf("Unexpected Unix sudo remove dir cmd: %s", cmd)
+	}
+
+	// Windows OS
+	guestCmd, err = NewGuestCommands(WindowsOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
+	}
+	cmd = guestCmd.RemoveDir("C:\\Temp\\SomeDir")
+	if cmd != "rm C:\\Temp\\SomeDir -recurse -force" {
+		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
+	}
+
+	// Windows OS w/ space in path
+	cmd = guestCmd.RemoveDir("C:\\Temp\\Some Dir")
+	if cmd != "rm C:\\Temp\\Some` Dir -recurse -force" {
+		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
+	}
+}

--- a/website/source/docs/provisioners/chef-client.html.markdown
+++ b/website/source/docs/provisioners/chef-client.html.markdown
@@ -50,10 +50,18 @@ configuration is actually required.
     should use a custom configuration template. See the dedicated "Chef
     Configuration" section below for more details.
 
+-   `encrypted_data_bag_secret_path` (string) - The path to the file containing
+    the secret for encrypted data bags. By default, this is empty, so no
+    secret will be available.
+
 -   `execute_command` (string) - The command used to execute Chef. This has
     various [configuration template
     variables](/docs/templates/configuration-templates.html) available. See
     below for more information.
+
+-   `guest_os_type` (string) - The target guest OS type, either "unix" or
+    "windows". Setting this to "windows" will cause the provisioner to use
+     Windows friendly paths and commands. By default, this is "unix".
 
 -   `install_command` (string) - The command used to install Chef. This has
     various [configuration template
@@ -68,7 +76,8 @@ configuration is actually required.
 
 -   `prevent_sudo` (boolean) - By default, the configured commands that are
     executed to install and run Chef are executed with `sudo`. If this is true,
-    then the sudo will be omitted.
+    then the sudo will be omitted. This has no effect when guest_os_type is
+    windows.
 
 -   `run_list` (array of strings) - The [run
     list](http://docs.chef.io/essentials_node_object_run_lists.html)
@@ -87,11 +96,12 @@ configuration is actually required.
     on the machine using the Chef omnibus installers.
 
 -   `staging_directory` (string) - This is the directory where all the
-    configuration of Chef by Packer will be placed. By default this
-    is "/tmp/packer-chef-client". This directory doesn't need to exist but must
-    have proper permissions so that the SSH user that Packer uses is able to
-    create directories and write into this folder. If the permissions are not
-    correct, use a shell provisioner prior to this to configure it properly.
+    configuration of Chef by Packer will be placed. By default this is
+    "/tmp/packer-chef-client" when guest_os_type unix and
+    "$env:TEMP/packer-chef-client" when windows. This directory doesn't need to
+    exist but must have proper permissions so that the user that Packer uses is
+    able to create directories and write into this folder. By default the
+    provisioner will create and chmod 0777 this directory.
 
 -   `client_key` (string) - Path to client key. If not set, this defaults to a
     file named client.pem in `staging_directory`.
@@ -119,6 +129,10 @@ The default value for the configuration template is:
 log_level        :info
 log_location     STDOUT
 chef_server_url  "{{.ServerUrl}}"
+client_key       "{{.ClientKey}}"
+{{if ne .EncryptedDataBagSecretPath ""}}
+encrypted_data_bag_secret "{{.EncryptedDataBagSecretPath}}"
+{{end}}
 {{if ne .ValidationClientName ""}}
 validation_client_name "{{.ValidationClientName}}"
 {{else}}
@@ -127,8 +141,12 @@ validation_client_name "chef-validator"
 {{if ne .ValidationKeyPath ""}}
 validation_key "{{.ValidationKeyPath}}"
 {{end}}
-{{if ne .NodeName ""}}
 node_name "{{.NodeName}}"
+{{if ne .ChefEnvironment ""}}
+environment "{{.ChefEnvironment}}"
+{{end}}
+{{if ne .SslVerifyMode ""}}
+ssl_verify_mode :{{.SslVerifyMode}}
 {{end}}
 ```
 
@@ -136,8 +154,13 @@ This template is a [configuration
 template](/docs/templates/configuration-templates.html) and has a set of
 variables available to use:
 
+-   `ChefEnvironment` - The Chef environment name.
+-   `EncryptedDataBagSecretPath` - The path to the secret key file to decrypt
+     encrypted data bags.
 -   `NodeName` - The node name set in the configuration.
 -   `ServerUrl` - The URL of the Chef Server set in the configuration.
+-   `SslVerifyMode` - Whether Chef SSL verify mode is on or off.
+-   `ValidationClientName` - The name of the client used for validation.
 -   `ValidationKeyPath` - Path to the validation key, if it is set.
 
 ## Execute Command
@@ -147,6 +170,17 @@ readability) to execute Chef:
 
 ``` {.liquid}
 {{if .Sudo}}sudo {{end}}chef-client \
+  --no-color \
+  -c {{.ConfigPath}} \
+  -j {{.JsonPath}}
+```
+
+When guest_os_type is set to "windows", Packer uses the following command to
+execute Chef. The full path to Chef is required because the PATH environment
+variable changes don't immediately propogate to running processes.
+
+``` {.liquid}
+c:/opscode/chef/bin/chef-client.bat \
   --no-color \
   -c {{.ConfigPath}} \
   -j {{.JsonPath}}
@@ -170,6 +204,13 @@ install Chef in another way.
 ``` {.text}
 curl -L https://www.chef.io/chef/install.sh | \
   {{if .Sudo}}sudo{{end}} bash
+```
+
+When guest_os_type is set to "windows", Packer uses the following command to
+install the latest version of Chef:
+
+``` {.text}
+powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('http://chef.io/chef/install.msi', 'C:\\Windows\\Temp\\chef.msi');Start-Process 'msiexec' -ArgumentList '/qb /i C:\\Windows\\Temp\\chef.msi' -NoNewWindow -Wait"
 ```
 
 This command can be customized using the `install_command` configuration.


### PR DESCRIPTION
Added native Windows guest support for Chef provisioners following the same pattern as the shell provisioner. This was tested against Windows guests over WinRM. This PR basically does two things:

- Sane Windows defaults for provisioner config values
- Added GuestCommands abstraction around guest file system commands (that are commonly used by provisioners).

NOTE - I did change behavior of the chef-client provisioner so that is does _not_ use sudo when creating or removing directories because the chef-solo provisioner does not use sudo and the default staging directory shouldn't require it. Thoughts?