### PR TITLE
Add step export to esxi driver and enable to use artifacts from builder/vmware-esxi in vsphere post-processor

### DIFF
--- a/builder/vmware/common/step_output_dir.go
+++ b/builder/vmware/common/step_output_dir.go
@@ -60,15 +60,18 @@ func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 		dir := state.Get("dir").(OutputDir)
 		ui := state.Get("ui").(packer.Ui)
 
-		ui.Say("Deleting output directory...")
-		for i := 0; i < 5; i++ {
-			err := dir.RemoveAll()
-			if err == nil {
-				break
-			}
+		exists, _ := dir.DirExists()
+		if exists {
+			ui.Say("Deleting output directory...")
+			for i := 0; i < 5; i++ {
+				err := dir.RemoveAll()
+				if err == nil {
+					break
+				}
 
-			log.Printf("Error removing output dir: %s", err)
-			time.Sleep(2 * time.Second)
+				log.Printf("Error removing output dir: %s", err)
+				time.Sleep(2 * time.Second)
+			}
 		}
 	}
 }

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -99,8 +99,16 @@ func (d *ESX5Driver) SuppressMessages(vmxPath string) error {
 	return nil
 }
 
-func (d *ESX5Driver) Unregister(vmxPathLocal string) error {
-	return d.sh("vim-cmd", "vmsvc/unregister", d.vmId)
+func (d *ESX5Driver) Destroy() error {
+	return d.sh("vim-cmd", "vmsvc/destroy", d.vmId)
+}
+
+func (d *ESX5Driver) IsDestroied() (bool, error) {
+	err := d.sh("test", "-e", d.outputDir)
+	if err != nil {
+		return false, err
+	}
+	return true, err
 }
 
 func (d *ESX5Driver) UploadISO(localPath string, checksum string, checksumType string) (string, error) {

--- a/builder/vmware/iso/export_config.go
+++ b/builder/vmware/iso/export_config.go
@@ -1,0 +1,37 @@
+package iso
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+)
+
+type ExportConfig struct {
+	Format string `mapstruture:"format"`
+}
+
+func (c *ExportConfig) Prepare(t *packer.ConfigTemplate) []error {
+	if c.Format == "" {
+		c.Format = "ovf"
+	}
+
+	templates := map[string]*string{
+		"format": &c.Format,
+	}
+
+	errs := make([]error, 0)
+	for n, ptr := range templates {
+		var err error
+		*ptr, err = t.Process(*ptr, nil)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Error processing %s: %s", n, err))
+		}
+	}
+
+	if c.Format != "ovf" && c.Format != "ova" && c.Format != "vmx" {
+		errs = append(errs,
+			errors.New("invalid format, only 'vmx', 'ovf' or 'ova' are allowed"))
+	}
+
+	return errs
+}

--- a/builder/vmware/iso/remote_driver.go
+++ b/builder/vmware/iso/remote_driver.go
@@ -15,8 +15,11 @@ type RemoteDriver interface {
 	// Adds a VM to inventory specified by the path to the VMX given.
 	Register(string) error
 
-	// Removes a VM from inventory specified by the path to the VMX given.
-	Unregister(string) error
+	// Destroies a VM
+	Destroy() error
+
+	// Checks if the VM is destroied.
+	IsDestroied() (bool, error)
 
 	// Uploads a local file to remote side.
 	upload(dst, src string) error

--- a/builder/vmware/iso/remote_driver_mock.go
+++ b/builder/vmware/iso/remote_driver_mock.go
@@ -16,9 +16,12 @@ type RemoteDriverMock struct {
 	RegisterPath   string
 	RegisterErr    error
 
-	UnregisterCalled bool
-	UnregisterPath   string
-	UnregisterErr    error
+	DestroyCalled bool
+	DestroyErr    error
+
+	IsDestroiedCalled bool
+	IsDestroiedResult bool
+	IsDestroiedErr    error
 
 	uploadErr error
 
@@ -37,10 +40,14 @@ func (d *RemoteDriverMock) Register(path string) error {
 	return d.RegisterErr
 }
 
-func (d *RemoteDriverMock) Unregister(path string) error {
-	d.UnregisterCalled = true
-	d.UnregisterPath = path
-	return d.UnregisterErr
+func (d *RemoteDriverMock) Destroy() error {
+	d.DestroyCalled = true
+	return d.DestroyErr
+}
+
+func (d *RemoteDriverMock) IsDestroied() (bool, error) {
+	d.DestroyCalled = true
+	return d.IsDestroiedResult, d.IsDestroiedErr
 }
 
 func (d *RemoteDriverMock) upload(dst, src string) error {

--- a/builder/vmware/iso/step_export.go
+++ b/builder/vmware/iso/step_export.go
@@ -1,0 +1,62 @@
+package iso
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type StepExport struct {
+	Format string
+}
+
+func (s *StepExport) Run(state multistep.StateBag) multistep.StepAction {
+	c := state.Get("config").(*config)
+	ui := state.Get("ui").(packer.Ui)
+
+	if c.RemoteType != "esx5" {
+		return multistep.ActionContinue
+	}
+
+	if _, err := exec.LookPath("ovftool"); err != nil {
+		err := fmt.Errorf("Error ovftool not found: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Export the VM
+	outputPath := filepath.Join(c.VMName, c.VMName+"."+s.Format)
+
+	args := []string{
+		"--noSSLVerify=true",
+		"--skipManifestCheck",
+		"-tt=" + s.Format,
+		"vi://" + c.RemoteUser + ":" + c.RemotePassword + "@" + c.RemoteHost + "/" + c.VMName,
+		outputPath,
+	}
+
+	ui.Say("Exporting virtual machine...")
+	ui.Message(fmt.Sprintf("Executing: ovftool %s", strings.Join(args, " ")))
+	var out bytes.Buffer
+	cmd := exec.Command("ovftool", args...)
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		err := fmt.Errorf("Error exporting virtual machine: %s", err, out.String())
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	ui.Message(fmt.Sprintf("%s", out.String()))
+
+	state.Put("exportPath", outputPath)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepExport) Cleanup(state multistep.StateBag) {}

--- a/builder/vmware/iso/step_register_test.go
+++ b/builder/vmware/iso/step_register_test.go
@@ -50,16 +50,13 @@ func TestStepRegister_remoteDriver(t *testing.T) {
 	if driver.RegisterPath != "foo" {
 		t.Fatal("should call with correct path")
 	}
-	if driver.UnregisterCalled {
-		t.Fatal("unregister should not be called")
+	if driver.DestroyCalled {
+		t.Fatal("destroy should not be called")
 	}
 
 	// cleanup
 	step.Cleanup(state)
-	if !driver.UnregisterCalled {
-		t.Fatal("unregister should be called")
-	}
-	if driver.UnregisterPath != "foo" {
-		t.Fatal("should unregister proper path")
+	if !driver.DestroyCalled {
+		t.Fatal("destroy should be called")
 	}
 }

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -12,7 +12,8 @@ import (
 )
 
 var builtins = map[string]string{
-	"mitchellh.vmware": "vmware",
+	"mitchellh.vmware":     "vmware",
+	"mitchellh.vmware-esx": "vmware",
 }
 
 type Config struct {
@@ -65,14 +66,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	// First define all our templatable parameters that are _required_
 	templates := map[string]*string{
-		"cluster":       &p.config.Cluster,
-		"datacenter":    &p.config.Datacenter,
-		"diskmode":      &p.config.DiskMode,
-		"host":          &p.config.Host,
-		"password":      &p.config.Password,
-		"resource_pool": &p.config.ResourcePool,
-		"username":      &p.config.Username,
-		"vm_name":       &p.config.VMName,
+		"cluster":    &p.config.Cluster,
+		"datacenter": &p.config.Datacenter,
+		"diskmode":   &p.config.DiskMode,
+		"host":       &p.config.Host,
+		"password":   &p.config.Password,
+		"username":   &p.config.Username,
+		"vm_name":    &p.config.VMName,
 	}
 	for key, ptr := range templates {
 		if *ptr == "" {
@@ -82,6 +82,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	// Then define the ones that are optional
+	templates["resource_pool"] = &p.config.ResourcePool
 	templates["datastore"] = &p.config.Datastore
 	templates["vm_network"] = &p.config.VMNetwork
 	templates["vm_folder"] = &p.config.VMFolder
@@ -107,16 +108,16 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		return nil, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
 	}
 
-	vmx := ""
+	source := ""
 	for _, path := range artifact.Files() {
-		if strings.HasSuffix(path, ".vmx") {
-			vmx = path
+		if strings.HasSuffix(path, ".vmx") || strings.HasSuffix(path, ".ovf") || strings.HasSuffix(path, ".ova") {
+			source = path
 			break
 		}
 	}
 
-	if vmx == "" {
-		return nil, false, fmt.Errorf("VMX file not found")
+	if source == "" {
+		return nil, false, fmt.Errorf("VMX, OVF or OVA file not found")
 	}
 
 	args := []string{
@@ -127,8 +128,8 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		fmt.Sprintf("--diskMode=%s", p.config.DiskMode),
 		fmt.Sprintf("--network=%s", p.config.VMNetwork),
 		fmt.Sprintf("--vmFolder=%s", p.config.VMFolder),
-		fmt.Sprintf("%s", vmx),
-		fmt.Sprintf("vi://%s:%s@%s/%s/host/%s/Resources/%s/",
+		fmt.Sprintf("%s", source),
+		fmt.Sprintf("vi://%s:%s@%s/%s/host/%s/Resources/%s",
 			url.QueryEscape(p.config.Username),
 			url.QueryEscape(p.config.Password),
 			p.config.Host,
@@ -137,7 +138,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			p.config.ResourcePool),
 	}
 
-	ui.Message(fmt.Sprintf("Uploading %s to vSphere", vmx))
+	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
 	var out bytes.Buffer
 	log.Printf("Starting ovftool with parameters: %s", strings.Join(args, " "))
 	cmd := exec.Command("ovftool", args...)

--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -362,6 +362,8 @@ Before using a remote vSphere Hypervisor, you need to enable GuestIPHack by runn
 esxcli system settings advanced set -o /Net/GuestIPHack -i 1
 ```
 
+and install VMware OVF Tool on your local machine.
+
 When using a remote VMware Hypervisor, the builder still downloads the
 ISO and various files locally, and uploads these to the remote machine.
 Packer currently uses SSH to communicate to the ESXi machine rather than
@@ -381,6 +383,9 @@ fill in the required `remote_*` configurations:
 
 Additionally, there are some optional configurations that you'll likely
 have to modify as well:
+
+* `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
+  format of the exported virtual machine. This defaults to "ovf".
 
 * `remote_datastore` - The path to the datastore where the VM will be
   stored on the ESXi machine.


### PR DESCRIPTION
I guess builder/vmware-esxi should export artifacts from remote ESXi to local machine to use in post-processors.
This p-r enables following features:

* builder/vmware-esxi export specified format artifacts. (ovf, ova or vmx)
* post-processor/vsphere can use the artifacts from builder/vmware-esxi.