### PR TITLE
Add 1/10th second delay between key events to VNC

### DIFF
--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -200,7 +200,9 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		}
 
 		c.KeyEvent(keyCode, true)
+                time.Sleep(time.Second/10)
 		c.KeyEvent(keyCode, false)
+                time.Sleep(time.Second/10)
 
 		if keyShift {
 			c.KeyEvent(KeyLeftShift, false)


### PR DESCRIPTION
If VNC keypress events are sent too quickly, ESXi can miss keypresses, resulting in the text passed through boot_command being garbled. 

This adds a 0.1s delay after each keypress event. It slows down boot_command a little, but it makes sure that the string is received reliably.