### PR TITLE
Add option to apply grains before running highstate

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -29,6 +29,9 @@ type Config struct {
 	// Local path to the salt pillar roots
 	LocalPillarRoots string `mapstructure:"local_pillar_roots"`
 
+        // Grains to be applied before running highstate
+        Grains string `mapstructure:"grains"`
+
 	// Where files will be copied before moving to the /srv/salt directory
 	TempConfigDir string `mapstructure:"temp_config_dir"`
 
@@ -171,6 +174,19 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		if err = p.moveFile(ui, comm, dst, src); err != nil {
 			return fmt.Errorf("Unable to move %s/pillar to /srv/pillar: %d", p.config.TempConfigDir, err)
 		}
+	}
+
+	if p.config.Grains != "" {
+                ui.Message("Applying grains")
+		src = p.config.Grains
+                cmd := &packer.RemoteCmd{Command: fmt.Sprintf("sudo salt-call --local grains.setvals %s -l info", src)}
+                if err = cmd.StartWithUi(comm, ui); err != nil || cmd.ExitStatus != 0 {
+                        if err == nil {
+                                err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus)
+                        }
+
+                        return fmt.Errorf("Error applying grains: %s", err)
+                }
 	}
 
 	ui.Message("Running highstate")


### PR DESCRIPTION
This PR is to allows for the setting of grains within packer templates. This approach allows better control over the selection of states applied during highstate runs. 

The new option would be used like so: 

```json
{
    "variables": {},
    "builders": [{}],
    "provisioners": [{
        "type": "salt-masterless",
        "local_state_tree": "./salt-states",
        "pause_before": "20s",
        "minion_config": "./minion",
        "grains": "{'app':'myawesomeapp'}",
        "local_pillar_roots": "./pillar"
    }]
}
```

Using this option will allow for the following to be usable in a salt `top.sls`:

```yaml
base:
  '*':
    - core
    - apt
  'app:myawesomeapp':
    - match: grain
    - awesomeapp
```

WIP will be removed once:
  - [ ] there's testing around the grains config
  - [ ] docs updated