### PR TITLE
website/intro/getting-started: clarify that multiple builders of the same type must have a unique name

### DIFF
--- a/website/source/intro/getting-started/parallel-builds.html.markdown
+++ b/website/source/intro/getting-started/parallel-builds.html.markdown
@@ -83,7 +83,7 @@ The entire template should now [look like this](https://gist.github.com/pearkes/
 Additional builders are simply added to the `builders` array in the template.
 This tells Packer to build multiple images. The builder `type` values don't
 even need to be different! In fact, if you wanted to build multiple AMIs,
-you can do that as well.
+you can do that as long as you specify a unique `name` for each build.
 
 Validate the template with `packer validate`. This is always a good practice.
 


### PR DESCRIPTION
Closes #1718 