### PR TITLE
builder/parallels: Use most recent DHCP lease when determining IP.

### DIFF
--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -55,6 +55,7 @@ func NewDriver() (Driver, error) {
 	var drivers map[string]Driver
 	var prlctlPath string
 	var supportedVersions []string
+	dhcp_lease_file := "/Library/Preferences/Parallels/parallels_dhcp_leases"
 
 	if runtime.GOOS != "darwin" {
 		return nil, fmt.Errorf(
@@ -74,11 +75,13 @@ func NewDriver() (Driver, error) {
 	drivers = map[string]Driver{
 		"10": &Parallels10Driver{
 			Parallels9Driver: Parallels9Driver{
-				PrlctlPath: prlctlPath,
+				PrlctlPath:      prlctlPath,
+				dhcp_lease_file: dhcp_lease_file,
 			},
 		},
 		"9": &Parallels9Driver{
-			PrlctlPath: prlctlPath,
+			PrlctlPath:      prlctlPath,
+			dhcp_lease_file: dhcp_lease_file,
 		},
 	}
 

--- a/builder/parallels/common/driver_9_test.go
+++ b/builder/parallels/common/driver_9_test.go
@@ -1,9 +1,60 @@
 package common
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestParallels9Driver_impl(t *testing.T) {
 	var _ Driver = new(Parallels9Driver)
+}
+
+func TestIpAddress(t *testing.T) {
+	tf, err := ioutil.TempFile("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(tf.Name())
+
+	d := Parallels9Driver{
+		dhcp_lease_file: tf.Name(),
+	}
+
+	// No lease should be found in an empty file
+	ip, err := d.IpAddress("123456789012")
+	if err == nil {
+		t.Fatalf("Found IP: \"%v\". No IP should be found!\n", ip)
+	}
+
+	// The most recent lease, 10.211.55.126 should be found
+	c := []byte(`
+[vnic0]
+10.211.55.125="1418288000,1800,001c4235240c,ff4235240c000100011c1c10e7001c4235240c"
+10.211.55.126="1418288969,1800,001c4235240c,ff4235240c000100011c1c11ad001c4235240c"
+10.211.55.254="1411712008,1800,001c42a51419,01001c42a51419"
+`)
+	ioutil.WriteFile(tf.Name(), c, 0666)
+	ip, err = d.IpAddress("001C4235240c")
+	if err != nil {
+		t.Fatalf("Error: %v\n", err)
+	}
+	if ip != "10.211.55.126" {
+		t.Fatalf("Should have found 10.211.55.126, not %s!\n", ip)
+	}
+
+	// The most recent lease, 10.211.55.124 should be found
+	c = []byte(`[vnic0]
+10.211.55.124="1418288969,1800,001c4235240c,ff4235240c000100011c1c11ad001c4235240c"
+10.211.55.125="1418288000,1800,001c4235240c,ff4235240c000100011c1c10e7001c4235240c"
+10.211.55.254="1411712008,1800,001c42a51419,01001c42a51419"
+`)
+	ioutil.WriteFile(tf.Name(), c, 0666)
+	ip, err = d.IpAddress("001c4235240c")
+	if err != nil {
+		t.Fatalf("Error: %v\n", err)
+	}
+	if ip != "10.211.55.124" {
+		t.Fatalf("Should have found 10.211.55.124, not %s!\n", ip)
+	}
 }


### PR DESCRIPTION
Fixes #1746. Problem establishing SSH connection with Fedora 21 and Parallels