### PR TITLE
Fixing transient AWS errors during EBS builds

### DIFF
--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -63,9 +63,9 @@ func AMIStateRefreshFunc(conn *ec2.EC2, imageId string) StateRefreshFunc {
 
 // InstanceStateRefreshFunc returns a StateRefreshFunc that is used to watch
 // an EC2 instance.
-func InstanceStateRefreshFunc(conn *ec2.EC2, i *ec2.Instance) StateRefreshFunc {
+func InstanceStateRefreshFunc(conn *ec2.EC2, instanceId string) StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := conn.Instances([]string{i.InstanceId}, ec2.NewFilter())
+		resp, err := conn.Instances([]string{instanceId}, ec2.NewFilter())
 		if err != nil {
 			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidInstanceID.NotFound" {
 				// Set this to nil as if we didn't find anything.
@@ -85,7 +85,7 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, i *ec2.Instance) StateRefreshFunc {
 			return nil, "", nil
 		}
 
-		i = &resp.Reservations[0].Instances[0]
+		i := &resp.Reservations[0].Instances[0]
 		return i, i.State.Name, nil
 	}
 }

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -87,7 +87,7 @@ func (s *stepCreateAMI) Cleanup(state multistep.StateBag) {
 		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %s", err))
 		return
 	} else if resp.Return == false {
-		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %t", resp.Return))
+		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around"))
 		return
 	}
 }

--- a/builder/amazon/ebs/step_stop_instance.go
+++ b/builder/amazon/ebs/step_stop_instance.go
@@ -37,7 +37,7 @@ func (s *stepStopInstance) Run(state multistep.StateBag) multistep.StepAction {
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"running", "stopping"},
 		Target:    "stopped",
-		Refresh:   awscommon.InstanceStateRefreshFunc(ec2conn, instance),
+		Refresh:   awscommon.InstanceStateRefreshFunc(ec2conn, instance.InstanceId),
 		StepState: state,
 	}
 	_, err = awscommon.WaitForState(&stateChange)


### PR DESCRIPTION
Relates to #1539 

AWS is eventually consistent and instance can be not visibile for
some time after creation. This fix eliminates describe-instances
call before going to the proper wait loop