### PR TITLE
Local shell provisioner 

### DIFF
--- a/plugin/provisioner-shell-local/main.go
+++ b/plugin/provisioner-shell-local/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-  "github.com/mitchellh/packer/packer/plugin"
-  "github.com/mitchellh/packer/provisioner/shell-local"
+	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/mitchellh/packer/provisioner/shell-local"
 )
 
 func main() {
-  server, err := plugin.Server()
-  if err != nil {
-    panic(err)
-  }
-  server.RegisterProvisioner(new(shelllocal.Provisioner))
-  server.Serve()
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterProvisioner(new(shelllocal.Provisioner))
+	server.Serve()
 }

--- a/plugin/provisioner-shell-local/main.go
+++ b/plugin/provisioner-shell-local/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+  "github.com/mitchellh/packer/packer/plugin"
+  "github.com/mitchellh/packer/provisioner/shell-local"
+)
+
+func main() {
+  server, err := plugin.Server()
+  if err != nil {
+    panic(err)
+  }
+  server.RegisterProvisioner(new(shelllocal.Provisioner))
+  server.Serve()
+}

--- a/plugin/provisioner-shell-local/main_test.go
+++ b/plugin/provisioner-shell-local/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -3,162 +3,161 @@
 package shelllocal
 
 import (
-  "bufio"
-  "errors"
-  "fmt"
-  "github.com/mitchellh/packer/common"
-  "github.com/mitchellh/packer/packer"
-  // "io"
-  "io/ioutil"
-  "log"
-  "os"
-  "os/exec"
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	// "io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
 )
 
 const DefaultSheBang = "/bin/sh"
 
 type config struct {
-  common.PackerConfig `mapstructure:",squash"`
+	common.PackerConfig `mapstructure:",squash"`
 
+	// An inline script to execute. Multiple strings are all executed
+	// in the context of a single shell.
+	Inline []string
 
-  // An inline script to execute. Multiple strings are all executed
-  // in the context of a single shell.
-  Inline []string
+	// The shebang value used when running inline scripts.
+	InlineShebang string `mapstructure:"inline_shebang"`
 
-  // The shebang value used when running inline scripts.
-  InlineShebang string `mapstructure:"inline_shebang"`
-
-  tpl *packer.ConfigTemplate
+	tpl *packer.ConfigTemplate
 }
 
 type Provisioner struct {
-  config config
+	config config
 }
 
 type ExecuteCommandTemplate struct {
-  Vars string
-  Path string
+	Vars string
+	Path string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-  md, err := common.DecodeConfig(&p.config, raws...)
-  if err != nil {
-    return err
-  }
+	md, err := common.DecodeConfig(&p.config, raws...)
+	if err != nil {
+		return err
+	}
 
-  p.config.tpl, err = packer.NewConfigTemplate()
-  if err != nil {
-    return err
-  }
-  p.config.tpl.UserVars = p.config.PackerUserVars
+	p.config.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return err
+	}
+	p.config.tpl.UserVars = p.config.PackerUserVars
 
-  // Accumulate any errors
-  errs := common.CheckUnusedConfig(md)
+	// Accumulate any errors
+	errs := common.CheckUnusedConfig(md)
 
-  if p.config.Inline != nil && len(p.config.Inline) == 0 {
-    p.config.Inline = nil
-  }
+	if p.config.Inline != nil && len(p.config.Inline) == 0 {
+		p.config.Inline = nil
+	}
 
-  if p.config.InlineShebang == "" {
-    p.config.InlineShebang = DefaultSheBang
-  }
+	if p.config.InlineShebang == "" {
+		p.config.InlineShebang = DefaultSheBang
+	}
 
-  templates := map[string]*string{
-    "inline_shebang": &p.config.InlineShebang,
-  }
+	templates := map[string]*string{
+		"inline_shebang": &p.config.InlineShebang,
+	}
 
-  for n, ptr := range templates {
-    var err error
-    *ptr, err = p.config.tpl.Process(*ptr, nil)
-    if err != nil {
-      errs = packer.MultiErrorAppend(
-        errs, fmt.Errorf("Error processing %s: %s", n, err))
-    }
-  }
+	for n, ptr := range templates {
+		var err error
+		*ptr, err = p.config.tpl.Process(*ptr, nil)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error processing %s: %s", n, err))
+		}
+	}
 
-  sliceTemplates := map[string][]string{
-    "inline": p.config.Inline,
-  }
+	sliceTemplates := map[string][]string{
+		"inline": p.config.Inline,
+	}
 
-  for n, slice := range sliceTemplates {
-    for i, elem := range slice {
-      var err error
-      slice[i], err = p.config.tpl.Process(elem, nil)
-      if err != nil {
-        errs = packer.MultiErrorAppend(
-          errs, fmt.Errorf("Error processing %s[%d]: %s", n, i, err))
-      }
-    }
-  }
+	for n, slice := range sliceTemplates {
+		for i, elem := range slice {
+			var err error
+			slice[i], err = p.config.tpl.Process(elem, nil)
+			if err != nil {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Error processing %s[%d]: %s", n, i, err))
+			}
+		}
+	}
 
-  if p.config.Inline == nil {
-    errs = packer.MultiErrorAppend(errs,
-      errors.New("inline script must be specified."))
-  }
+	if p.config.Inline == nil {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("inline script must be specified."))
+	}
 
-  if errs != nil && len(errs.Errors) > 0 {
-    return errs
-  }
+	if errs != nil && len(errs.Errors) > 0 {
+		return errs
+	}
 
-  return nil
+	return nil
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
-  scripts := make([]string, 0)
+	scripts := make([]string, 0)
 
-  if p.config.Inline != nil {
-    tf, err := ioutil.TempFile("", "packer-shell-local")
-    if err != nil {
-      return fmt.Errorf("Error preparing shell script: %s", err)
-    }
-    defer os.Remove(tf.Name())
+	if p.config.Inline != nil {
+		tf, err := ioutil.TempFile("", "packer-shell-local")
+		if err != nil {
+			return fmt.Errorf("Error preparing shell script: %s", err)
+		}
+		defer os.Remove(tf.Name())
 
-    // Set the path to the temporary file
-    scripts = append(scripts, tf.Name())
+		// Set the path to the temporary file
+		scripts = append(scripts, tf.Name())
 
-    // Write our contents to it
-    writer := bufio.NewWriter(tf)
-    writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
-    for _, command := range p.config.Inline {
-      if _, err := writer.WriteString(command + "\n"); err != nil {
-        return fmt.Errorf("Error preparing shell script: %s", err)
-      }
-    }
+		// Write our contents to it
+		writer := bufio.NewWriter(tf)
+		writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
+		for _, command := range p.config.Inline {
+			if _, err := writer.WriteString(command + "\n"); err != nil {
+				return fmt.Errorf("Error preparing shell script: %s", err)
+			}
+		}
 
-    if err := writer.Flush(); err != nil {
-      return fmt.Errorf("Error preparing shell script: %s", err)
-    }
-    tf.Close()
+		if err := writer.Flush(); err != nil {
+			return fmt.Errorf("Error preparing shell script: %s", err)
+		}
+		tf.Close()
 
-  } else {
-      return fmt.Errorf("Inline must be defined")
-  }
+	} else {
+		return fmt.Errorf("Inline must be defined")
+	}
 
-  for _, path := range scripts {
-    ui.Say(fmt.Sprintf("Provisioning with local shell script: %s", path))
+	for _, path := range scripts {
+		ui.Say(fmt.Sprintf("Provisioning with local shell script: %s", path))
 
-    log.Printf("Executing local script %s", path)
+		log.Printf("Executing local script %s", path)
 
-    err := os.Chmod(path, 0770)
-    if err != nil {
-      return fmt.Errorf(
-        "Error chmodding script file to 0777 "+
-          "machine: %s", err)
-    }
+		err := os.Chmod(path, 0770)
+		if err != nil {
+			return fmt.Errorf(
+				"Error chmodding script file to 0777 "+
+					"machine: %s", err)
+		}
 
-    out, err := exec.Command(path).Output()
-    if err != nil {
-      return fmt.Errorf("Error executeing script machine: %s", err)
-    }
-  	ui.Say(fmt.Sprintf("%s", out))
-  }
+		out, err := exec.Command(path).Output()
+		if err != nil {
+			return fmt.Errorf("Error executeing script machine: %s", err)
+		}
+		ui.Say(fmt.Sprintf("%s", out))
+	}
 
-  return nil
+	return nil
 }
 
 func (p *Provisioner) Cancel() {
-  // Just hard quit. It isn't a big deal if what we're doing keeps
-  // running on the other side.
-  os.Exit(0)
+	// Just hard quit. It isn't a big deal if what we're doing keeps
+	// running on the other side.
+	os.Exit(0)
 }

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -1,0 +1,174 @@
+// This package implements a provisioner for Packer that executes
+// shell scripts within the remote machine.
+package shelllocal
+
+import (
+  "bufio"
+  "errors"
+  "fmt"
+  "github.com/mitchellh/packer/common"
+  "github.com/mitchellh/packer/packer"
+  // "io"
+  "io/ioutil"
+  "log"
+  "os"
+  "os/exec"
+)
+
+const DefaultRemotePath = "/tmp/script.sh"
+const DefaultSheBang = "/bin/sh"
+
+type config struct {
+  common.PackerConfig `mapstructure:",squash"`
+
+
+  // An inline script to execute. Multiple strings are all executed
+  // in the context of a single shell.
+  Inline []string
+
+  // The shebang value used when running inline scripts.
+  InlineShebang string `mapstructure:"inline_shebang"`
+
+  // The command used to execute the script. The '{{ .Path }}' variable
+  // should be used to specify where the script goes, {{ .Vars }}
+  // can be used to inject the environment_vars into the environment.
+  ExecuteCommand string `mapstructure:"execute_command"`
+
+  tpl *packer.ConfigTemplate
+}
+
+type Provisioner struct {
+  config config
+}
+
+type ExecuteCommandTemplate struct {
+  Vars string
+  Path string
+}
+
+func (p *Provisioner) Prepare(raws ...interface{}) error {
+  md, err := common.DecodeConfig(&p.config, raws...)
+  if err != nil {
+    return err
+  }
+
+  p.config.tpl, err = packer.NewConfigTemplate()
+  if err != nil {
+    return err
+  }
+  p.config.tpl.UserVars = p.config.PackerUserVars
+
+  // Accumulate any errors
+  errs := common.CheckUnusedConfig(md)
+
+  if p.config.ExecuteCommand == "" {
+    p.config.ExecuteCommand = "chmod +x {{.Path}}; {{.Vars}} {{.Path}}"
+  }
+
+  if p.config.Inline != nil && len(p.config.Inline) == 0 {
+    p.config.Inline = nil
+  }
+
+  if p.config.InlineShebang == "" {
+    p.config.InlineShebang = DefaultSheBang
+  }
+
+  templates := map[string]*string{
+    "inline_shebang": &p.config.InlineShebang,
+  }
+
+  for n, ptr := range templates {
+    var err error
+    *ptr, err = p.config.tpl.Process(*ptr, nil)
+    if err != nil {
+      errs = packer.MultiErrorAppend(
+        errs, fmt.Errorf("Error processing %s: %s", n, err))
+    }
+  }
+
+  sliceTemplates := map[string][]string{
+    "inline": p.config.Inline,
+  }
+
+  for n, slice := range sliceTemplates {
+    for i, elem := range slice {
+      var err error
+      slice[i], err = p.config.tpl.Process(elem, nil)
+      if err != nil {
+        errs = packer.MultiErrorAppend(
+          errs, fmt.Errorf("Error processing %s[%d]: %s", n, i, err))
+      }
+    }
+  }
+
+  if p.config.Inline == nil {
+    errs = packer.MultiErrorAppend(errs,
+      errors.New("inline script must be specified."))
+  }
+
+  if errs != nil && len(errs.Errors) > 0 {
+    return errs
+  }
+
+  return nil
+}
+
+func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+
+  scripts := make([]string, 0)
+
+  if p.config.Inline != nil {
+    tf, err := ioutil.TempFile("", "packer-shell-local")
+    if err != nil {
+      return fmt.Errorf("Error preparing shell script: %s", err)
+    }
+    defer os.Remove(tf.Name())
+
+    // Set the path to the temporary file
+    scripts = append(scripts, tf.Name())
+
+    // Write our contents to it
+    writer := bufio.NewWriter(tf)
+    writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
+    for _, command := range p.config.Inline {
+      if _, err := writer.WriteString(command + "\n"); err != nil {
+        return fmt.Errorf("Error preparing shell script: %s", err)
+      }
+    }
+
+    if err := writer.Flush(); err != nil {
+      return fmt.Errorf("Error preparing shell script: %s", err)
+    }
+    tf.Close()
+
+  } else {
+      return fmt.Errorf("Inline must be defined")
+  }
+
+  for _, path := range scripts {
+    ui.Say(fmt.Sprintf("Provisioning with local shell script: %s", path))
+
+    log.Printf("Executing local script %s", path)
+
+    err := os.Chmod(path, 0770)
+    if err != nil {
+      return fmt.Errorf(
+        "Error chmodding script file to 0777 "+
+          "machine: %s", err)
+    }
+
+    out, err := exec.Command(path).Output()
+    if err != nil {
+      return fmt.Errorf("Error executeing script machine: %s", err)
+    }
+  	ui.Say(fmt.Sprintf("%s", out))
+  }
+
+  return nil
+}
+
+func (p *Provisioner) Cancel() {
+  // Just hard quit. It isn't a big deal if what we're doing keeps
+  // running on the other side.
+  os.Exit(0)
+}

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -15,7 +15,6 @@ import (
   "os/exec"
 )
 
-const DefaultRemotePath = "/tmp/script.sh"
 const DefaultSheBang = "/bin/sh"
 
 type config struct {
@@ -28,11 +27,6 @@ type config struct {
 
   // The shebang value used when running inline scripts.
   InlineShebang string `mapstructure:"inline_shebang"`
-
-  // The command used to execute the script. The '{{ .Path }}' variable
-  // should be used to specify where the script goes, {{ .Vars }}
-  // can be used to inject the environment_vars into the environment.
-  ExecuteCommand string `mapstructure:"execute_command"`
 
   tpl *packer.ConfigTemplate
 }
@@ -60,10 +54,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
   // Accumulate any errors
   errs := common.CheckUnusedConfig(md)
-
-  if p.config.ExecuteCommand == "" {
-    p.config.ExecuteCommand = "chmod +x {{.Path}}; {{.Vars}} {{.Path}}"
-  }
 
   if p.config.Inline != nil && len(p.config.Inline) == 0 {
     p.config.Inline = nil

--- a/provisioner/shell-local/provisioner_test.go
+++ b/provisioner/shell-local/provisioner_test.go
@@ -125,7 +125,7 @@ func TestProvisionerProvision_Inline(t *testing.T) {
   }
 
   if runtime.GOOS == "windows" {
-    //this test only runs on windows
+    //the rest of this test only runs on non-windows systems
     return
   }
 

--- a/provisioner/shell-local/provisioner_test.go
+++ b/provisioner/shell-local/provisioner_test.go
@@ -1,104 +1,103 @@
-
 package shelllocal
 
 import (
-  "github.com/mitchellh/packer/packer"
-  "runtime"
-  "strings"
-  "testing"
+	"github.com/mitchellh/packer/packer"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 func testConfig() map[string]interface{} {
-  return map[string]interface{}{
-    "inline": []interface{}{"foo", "bar"},
-  }
+	return map[string]interface{}{
+		"inline": []interface{}{"foo", "bar"},
+	}
 }
 
 func TestProvisioner_Impl(t *testing.T) {
-  var raw interface{}
-  raw = &Provisioner{}
-  if _, ok := raw.(packer.Provisioner); !ok {
-    t.Fatalf("must be a Provisioner")
-  }
+	var raw interface{}
+	raw = &Provisioner{}
+	if _, ok := raw.(packer.Provisioner); !ok {
+		t.Fatalf("must be a Provisioner")
+	}
 }
 
 func TestProvisionerPrepare_InvalidKey(t *testing.T) {
-  var p Provisioner
-  config := testConfig()
+	var p Provisioner
+	config := testConfig()
 
-  // Add a random key
-  config["i_should_not_be_valid"] = true
-  err := p.Prepare(config)
-  if err == nil {
-    t.Fatal("should have error")
-  }
+	// Add a random key
+	config["i_should_not_be_valid"] = true
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
 }
 
 func TestProvisionerPrepare_Defaults(t *testing.T) {
-  var p Provisioner
-  config := testConfig()
+	var p Provisioner
+	config := testConfig()
 
-  err := p.Prepare(config)
-  if err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  if p.config.InlineShebang != DefaultSheBang {
-    t.Errorf("unexpected inline shebang: %s", p.config.InlineShebang)
-  }
+	if p.config.InlineShebang != DefaultSheBang {
+		t.Errorf("unexpected inline shebang: %s", p.config.InlineShebang)
+	}
 }
 
 func TestProvisionerPrepare_InlineShebang(t *testing.T) {
-  config := testConfig()
+	config := testConfig()
 
-  delete(config, "inline_shebang")
-  p := new(Provisioner)
-  err := p.Prepare(config)
-  if err != nil {
-    t.Fatalf("should not have error: %s", err)
-  }
+	delete(config, "inline_shebang")
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
 
-  if p.config.InlineShebang != "/bin/sh" {
-    t.Fatalf("bad value: %s", p.config.InlineShebang)
-  }
+	if p.config.InlineShebang != "/bin/sh" {
+		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	}
 
-  // Test with a good one
-  config["inline_shebang"] = "foo"
-  p = new(Provisioner)
-  err = p.Prepare(config)
-  if err != nil {
-    t.Fatalf("should not have error: %s", err)
-  }
+	// Test with a good one
+	config["inline_shebang"] = "foo"
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
 
-  if p.config.InlineShebang != "foo" {
-    t.Fatalf("bad value: %s", p.config.InlineShebang)
-  }
+	if p.config.InlineShebang != "foo" {
+		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	}
 }
 
 func TestProvisionerPrepare_Inline(t *testing.T) {
-  var p Provisioner
-  config := testConfig()
+	var p Provisioner
+	config := testConfig()
 
-  delete(config, "inline")
-  err := p.Prepare(config)
-  if err == nil {
-    t.Fatal("should have error")
-  }
+	delete(config, "inline")
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
 
-  // Test with a good one
-  config["inline"] = []interface{}{"foo"}
-  err = p.Prepare(config)
-  if err != nil {
-    t.Fatal("should not have error %s", err)
-  }
+	// Test with a good one
+	config["inline"] = []interface{}{"foo"}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatal("should not have error %s", err)
+	}
 }
 
 type stubUi struct {
-  sayMessages string
+	sayMessages string
 }
 
 func (su *stubUi) Ask(string) (string, error) {
-  return "", nil
+	return "", nil
 }
 
 func (su *stubUi) Error(string) {
@@ -111,37 +110,37 @@ func (su *stubUi) Message(string) {
 }
 
 func (su *stubUi) Say(msg string) {
-  su.sayMessages += msg
+	su.sayMessages += msg
 }
 
 func TestProvisionerProvision_Inline(t *testing.T) {
-  var p Provisioner
-  config := testConfig()
+	var p Provisioner
+	config := testConfig()
 
-  config["inline"] = []interface{}{"echo \"Hello World\""}
-  err := p.Prepare(config)
-  if err != nil {
-    t.Fatal("should not have error %s", err)
-  }
+	config["inline"] = []interface{}{"echo \"Hello World\""}
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatal("should not have error %s", err)
+	}
 
-  if runtime.GOOS == "windows" {
-    //the rest of this test only runs on non-windows systems
-    return
-  }
+	if runtime.GOOS == "windows" {
+		//the rest of this test only runs on non-windows systems
+		return
+	}
 
-  ui := &stubUi{}
-  comm := &packer.MockCommunicator{}
-  err = p.Provision(ui, comm)
-  if err != nil {
-    t.Fatalf("should successfully provision: %s", err)
-  }
+	ui := &stubUi{}
+	comm := &packer.MockCommunicator{}
+	err = p.Provision(ui, comm)
+	if err != nil {
+		t.Fatalf("should successfully provision: %s", err)
+	}
 
-  if !strings.Contains(ui.sayMessages, "Provisioning with local shell script:") {
-    t.Fatalf("should print Provisioning with local shell script")
-  }
+	if !strings.Contains(ui.sayMessages, "Provisioning with local shell script:") {
+		t.Fatalf("should print Provisioning with local shell script")
+	}
 
-  if !strings.Contains(ui.sayMessages, "Hello World") {
-    t.Fatalf("should print Hello")
-  }
+	if !strings.Contains(ui.sayMessages, "Hello World") {
+		t.Fatalf("should print Hello")
+	}
 
 }

--- a/provisioner/shell-local/provisioner_test.go
+++ b/provisioner/shell-local/provisioner_test.go
@@ -1,0 +1,147 @@
+
+package shelllocal
+
+import (
+  "github.com/mitchellh/packer/packer"
+  "runtime"
+  "strings"
+  "testing"
+)
+
+func testConfig() map[string]interface{} {
+  return map[string]interface{}{
+    "inline": []interface{}{"foo", "bar"},
+  }
+}
+
+func TestProvisioner_Impl(t *testing.T) {
+  var raw interface{}
+  raw = &Provisioner{}
+  if _, ok := raw.(packer.Provisioner); !ok {
+    t.Fatalf("must be a Provisioner")
+  }
+}
+
+func TestProvisionerPrepare_InvalidKey(t *testing.T) {
+  var p Provisioner
+  config := testConfig()
+
+  // Add a random key
+  config["i_should_not_be_valid"] = true
+  err := p.Prepare(config)
+  if err == nil {
+    t.Fatal("should have error")
+  }
+}
+
+func TestProvisionerPrepare_Defaults(t *testing.T) {
+  var p Provisioner
+  config := testConfig()
+
+  err := p.Prepare(config)
+  if err != nil {
+    t.Fatalf("err: %s", err)
+  }
+
+  if p.config.InlineShebang != DefaultSheBang {
+    t.Errorf("unexpected inline shebang: %s", p.config.InlineShebang)
+  }
+}
+
+func TestProvisionerPrepare_InlineShebang(t *testing.T) {
+  config := testConfig()
+
+  delete(config, "inline_shebang")
+  p := new(Provisioner)
+  err := p.Prepare(config)
+  if err != nil {
+    t.Fatalf("should not have error: %s", err)
+  }
+
+  if p.config.InlineShebang != "/bin/sh" {
+    t.Fatalf("bad value: %s", p.config.InlineShebang)
+  }
+
+  // Test with a good one
+  config["inline_shebang"] = "foo"
+  p = new(Provisioner)
+  err = p.Prepare(config)
+  if err != nil {
+    t.Fatalf("should not have error: %s", err)
+  }
+
+  if p.config.InlineShebang != "foo" {
+    t.Fatalf("bad value: %s", p.config.InlineShebang)
+  }
+}
+
+func TestProvisionerPrepare_Inline(t *testing.T) {
+  var p Provisioner
+  config := testConfig()
+
+  delete(config, "inline")
+  err := p.Prepare(config)
+  if err == nil {
+    t.Fatal("should have error")
+  }
+
+  // Test with a good one
+  config["inline"] = []interface{}{"foo"}
+  err = p.Prepare(config)
+  if err != nil {
+    t.Fatal("should not have error %s", err)
+  }
+}
+
+type stubUi struct {
+  sayMessages string
+}
+
+func (su *stubUi) Ask(string) (string, error) {
+  return "", nil
+}
+
+func (su *stubUi) Error(string) {
+}
+
+func (su *stubUi) Machine(string, ...string) {
+}
+
+func (su *stubUi) Message(string) {
+}
+
+func (su *stubUi) Say(msg string) {
+  su.sayMessages += msg
+}
+
+func TestProvisionerProvision_Inline(t *testing.T) {
+  var p Provisioner
+  config := testConfig()
+
+  config["inline"] = []interface{}{"echo \"Hello World\""}
+  err := p.Prepare(config)
+  if err != nil {
+    t.Fatal("should not have error %s", err)
+  }
+
+  if runtime.GOOS == "windows" {
+    //this test only runs on windows
+    return
+  }
+
+  ui := &stubUi{}
+  comm := &packer.MockCommunicator{}
+  err = p.Provision(ui, comm)
+  if err != nil {
+    t.Fatalf("should successfully provision: %s", err)
+  }
+
+  if !strings.Contains(ui.sayMessages, "Provisioning with local shell script:") {
+    t.Fatalf("should print Provisioning with local shell script")
+  }
+
+  if !strings.Contains(ui.sayMessages, "Hello World") {
+    t.Fatalf("should print Hello")
+  }
+
+}

--- a/website/source/docs/provisioners/shell-local.html.markdown
+++ b/website/source/docs/provisioners/shell-local.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "docs"
+page_title: "Shell Local Provisioner"
+description: |-
+  The shell-local Packer provisioner allows shell scripts to be run on machine running packer
+---
+
+# Shell Local Provisioner
+
+Type: `shell-local`
+
+The shell-local Packer provisioner allows shell scripts to be run on machine running packer.
+The primary use case for the shell-local provisioner is to allow for running an image verification process such as [serverspec](http://serverspec.org/) prior to creating an image without the need to run this from the machine you are building. Generally it is used as the last provisioner for a giving machine.
+
+## Basic Example
+
+The example below is fully functional.
+
+```javascript
+{
+  "type": "shell-local",
+  "inline": ["echo foo"]
+}
+```
+
+## Configuration Reference
+
+The reference of available configuration options is listed below. The only
+required element is either "inline" or "script". Every other option is optional.
+
+Required parameter:
+
+* `inline` (array of strings) - This is an array of commands to execute.
+  The commands are concatenated by newlines and turned into a single file,
+  so they are all executed within the same context. This allows you to
+  change directories in one command and use something in the directory in
+  the next and so on.
+
+Optional parameters:
+
+* `inline_shebang` (string) - The
+  [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) value to use when
+  running commands specified by `inline`. By default, this is `/bin/sh`.
+  If you're not using `inline`, then this configuration has no effect.

--- a/website/source/docs/provisioners/shell-local.html.markdown
+++ b/website/source/docs/provisioners/shell-local.html.markdown
@@ -2,15 +2,23 @@
 layout: "docs"
 page_title: "Shell Local Provisioner"
 description: |-
-  The shell-local Packer provisioner allows shell scripts to be run on machine running packer
+  The shell-local Packer provisioner allows shell scripts to be run on machine
+  running packer
 ---
 
 # Shell Local Provisioner
 
 Type: `shell-local`
 
-The shell-local Packer provisioner allows shell scripts to be run on machine running packer.
-The primary use case for the shell-local provisioner is to allow for running an image verification process such as [serverspec](http://serverspec.org/) prior to creating an image without the need to run this from the machine you are building. Generally it is used as the last provisioner for a giving machine.
+The shell-local Packer provisioner allows shell scripts to be run on machine
+running packer.
+
+The primary use case for the shell-local provisioner is to allow for running an
+image verification process such as [serverspec](http://serverspec.org/) prior to
+creating an image without the need to run this from the machine you are
+building.
+
+Generally it is used as the last provisioner for a giving machine.
 
 ## Basic Example
 


### PR DESCRIPTION
This provisioner makes it possible to execute a shell script from the machine running the packer build to allow for executing tools like serverspec prior to taking an image.  Currently the only way was to use the shell provisioner and run them on the remote server meaning you need to have all of the dependencies installed on the server image even if they weren't part of the image itself.