### PR TITLE
use docker 'exec' instead of 'attach' for remote execution

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -41,7 +41,7 @@ func (c *Communicator) Start(remote *packer.RemoteCmd) error {
 	// This file will store the exit code of the command once it is complete.
 	exitCodePath := outputFile.Name() + "-exit"
 
-	cmd := exec.Command("docker", "attach", c.ContainerId)
+	cmd := exec.Command("docker", "exec", "-i", c.ContainerId, "/bin/sh")
 	stdin_w, err := cmd.StdinPipe()
 	if err != nil {
 		// We have to do some cleanup since run was never called


### PR DESCRIPTION
Points to discuss for the core team:

  * Is it ok to break backwards compatibility, or should we implement a version check plus fallback to old implementation
  * is /bin/sh the right shell? afaik the old implementation was using bash
  * do we need to cleanup other parts of the code when `attach` is not used anymore