### PR TITLE
Add support for custom working directory for puppet

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -92,7 +92,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.WorkingDir == "" {
-		p.config.StagingDir = p.config.StagingDir
+		p.config.WorkingDir = p.config.StagingDir
 	}
 
 	// Templates

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -79,12 +79,18 @@ Optional parameters:
   this folder. If the permissions are not correct, use a shell provisioner
   prior to this to configure it properly.
 
+* `working_directory` (string) - This is the directory from which the puppet command
+  will be run. When using hiera with a relative path, this option allows to ensure
+  that he paths are working properly. If not specified, defaults to the value of
+  specified `staging_directory` (or its default value if not specified either).
+
 ## Execute Command
 
 By default, Packer uses the following command (broken across multiple lines
 for readability) to execute Puppet:
 
 ```liquid
+cd {{.WorkingDir}} && \
 {{.FacterVars}}{{if .Sudo}} sudo -E {{end}}puppet apply \
   --verbose \
   --modulepath='{{.ModulePath}}' \
@@ -98,6 +104,7 @@ This command can be customized using the `execute_command` configuration.
 As you can see from the default value above, the value of this configuration
 can contain various template variables, defined below:
 
+* `WorkingDir` - The path from which Puppet will be executed.
 * `FacterVars` - Shell-friendly string of environmental variables used
   to set custom facts configured for this provisioner.
 * `HieraConfigPath` - The path to a hiera configuration file.

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -81,7 +81,7 @@ Optional parameters:
 
 * `working_directory` (string) - This is the directory from which the puppet command
   will be run. When using hiera with a relative path, this option allows to ensure
-  that he paths are working properly. If not specified, defaults to the value of
+  that the paths are working properly. If not specified, defaults to the value of
   specified `staging_directory` (or its default value if not specified either).
 
 ## Execute Command


### PR DESCRIPTION
Similar behaviour to Vagrant's support of masterless puppet (see `Configuring Hiera` section):

https://docs.vagrantup.com/v2/provisioning/puppet_apply.html