### PR TITLE
Permit re-using AWS keypair

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -24,6 +24,7 @@ type RunConfig struct {
 	RawSSHTimeout            string            `mapstructure:"ssh_timeout"`
 	SSHUsername              string            `mapstructure:"ssh_username"`
 	SSHPrivateKeyFile        string            `mapstructure:"ssh_private_key_file"`
+	SSHKeyPairName           string            `mapstructure:"ssh_keypair_name"`
 	SSHPrivateIp             bool              `mapstructure:"ssh_private_ip"`
 	SSHPort                  int               `mapstructure:"ssh_port"`
 	SecurityGroupId          string            `mapstructure:"security_group_id"`
@@ -55,6 +56,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 		"ssh_timeout":             &c.RawSSHTimeout,
 		"ssh_username":            &c.SSHUsername,
 		"ssh_private_key_file":    &c.SSHPrivateKeyFile,
+		"ssh_keypair_name":        &c.SSHKeyPairName,
 		"source_ami":              &c.SourceAmi,
 		"subnet_id":               &c.SubnetId,
 		"temporary_key_pair_name": &c.TemporaryKeyPairName,
@@ -84,8 +86,9 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 		c.RawSSHTimeout = "5m"
 	}
 
-	if c.TemporaryKeyPairName == "" {
-		c.TemporaryKeyPairName = fmt.Sprintf(
+	// if we are not given an explicit keypairname, create a temporary one
+    if c.SSHKeyPairName == "" {
+		c.SSHKeyPairName = fmt.Sprintf(
 			"packer %s", uuid.TimeOrderedUUID())
 	}
 

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -87,7 +87,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	// if we are not given an explicit keypairname, create a temporary one
-    if c.SSHKeyPairName == "" {
+	if c.SSHKeyPairName == "" {
 		c.TemporaryKeyPairName = fmt.Sprintf(
 			"packer %s", uuid.TimeOrderedUUID())
 	}

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -88,7 +88,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 
 	// if we are not given an explicit keypairname, create a temporary one
     if c.SSHKeyPairName == "" {
-		c.SSHKeyPairName = fmt.Sprintf(
+		c.TemporaryKeyPairName = fmt.Sprintf(
 			"packer %s", uuid.TimeOrderedUUID())
 	}
 

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -142,12 +142,12 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 
 func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 	c := testConfig()
-	c.TemporaryKeyPairName = ""
+	c.SSHKeyPairName = ""
 	if err := c.Prepare(nil); len(err) != 0 {
 		t.Fatalf("err: %s", err)
 	}
 
-	if c.TemporaryKeyPairName == "" {
+	if c.SSHKeyPairName == "" {
 		t.Fatal("keypair empty")
 	}
 }

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -142,12 +142,12 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 
 func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 	c := testConfig()
-	c.SSHKeyPairName = ""
+	c.TemporaryKeyPairName = ""
 	if err := c.Prepare(nil); len(err) != 0 {
 		t.Fatalf("err: %s", err)
 	}
 
-	if c.SSHKeyPairName == "" {
+	if c.TemporaryKeyPairName == "" {
 		t.Fatal("keypair empty")
 	}
 }

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -11,20 +11,20 @@ import (
 )
 
 type StepKeyPair struct {
-	Debug          bool
-	DebugKeyPath   string
-	TemporaryKeyPairName    string
-	KeyPairName    string
-	PrivateKeyFile string
+	Debug                bool
+	DebugKeyPath         string
+	TemporaryKeyPairName string
+	KeyPairName          string
+	PrivateKeyFile       string
 
 	keyName string
 }
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	if s.PrivateKeyFile != "" {
-        if s.KeyPairName != "" { 
-            s.keyName = s.KeyPairName // need to get from config
-        }
+		if s.KeyPairName != "" {
+			s.keyName = s.KeyPairName // need to get from config
+		}
 
 		privateKeyBytes, err := ioutil.ReadFile(s.PrivateKeyFile)
 		if err != nil {
@@ -86,8 +86,8 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 
 func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 	// If no key name is set, then we never created it, so just return
-    // If we used an SSH private key file, do not go about deleting 
-    // keypairs
+	// If we used an SSH private key file, do not go about deleting
+	// keypairs
 	if s.PrivateKeyFile != "" {
 		return
 	}
@@ -98,7 +98,7 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 	ui.Say("Deleting temporary keypair...")
 	_, err := ec2conn.DeleteKeyPair(s.keyName)
 	if err != nil {
-	    ui.Error(fmt.Sprintf(
-          "Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
+		ui.Error(fmt.Sprintf(
+			"Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
 	}
 }

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -95,7 +95,7 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("DANGER: Deleting temporary keypair...")
+	ui.Say("Deleting temporary keypair...")
 	_, err := ec2conn.DeleteKeyPair(s.keyName)
 	if err != nil {
 	    ui.Error(fmt.Sprintf(

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -13,6 +13,7 @@ import (
 type StepKeyPair struct {
 	Debug          bool
 	DebugKeyPath   string
+	TemporaryKeyPairName    string
 	KeyPairName    string
 	PrivateKeyFile string
 
@@ -21,7 +22,9 @@ type StepKeyPair struct {
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	if s.PrivateKeyFile != "" {
-		s.keyName = s.KeyPairName // need to get from config
+        if s.KeyPairName != "" { 
+            s.keyName = s.KeyPairName // need to get from config
+        }
 
 		privateKeyBytes, err := ioutil.ReadFile(s.PrivateKeyFile)
 		if err != nil {
@@ -38,15 +41,15 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say(fmt.Sprintf("Creating temporary keypair: %s", s.KeyPairName))
-	keyResp, err := ec2conn.CreateKeyPair(s.KeyPairName)
+	ui.Say(fmt.Sprintf("Creating temporary keypair: %s", s.TemporaryKeyPairName))
+	keyResp, err := ec2conn.CreateKeyPair(s.TemporaryKeyPairName)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Error creating temporary keypair: %s", err))
 		return multistep.ActionHalt
 	}
 
 	// Set the keyname so we know to delete it later
-	s.keyName = s.KeyPairName
+	s.keyName = s.TemporaryKeyPairName
 
 	// Set some state data for use in future steps
 	state.Put("keyPair", s.keyName)
@@ -89,13 +92,13 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	//ec2conn := state.Get("ec2").(*ec2.EC2)
+	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("DANGER: Deleting temporary keypair (not really)...")
-	//_, err := ec2conn.DeleteKeyPair(s.keyName)
-	//if err != nil {
-	//ui.Error(fmt.Sprintf(
-    //"Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
-	//}
+	ui.Say("DANGER: Deleting temporary keypair...")
+	_, err := ec2conn.DeleteKeyPair(s.keyName)
+	if err != nil {
+	    ui.Error(fmt.Sprintf(
+          "Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
+	}
 }

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -21,7 +21,7 @@ type StepKeyPair struct {
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	if s.PrivateKeyFile != "" {
-		s.keyName = ""
+		s.keyName = s.KeyPairName // need to get from config
 
 		privateKeyBytes, err := ioutil.ReadFile(s.PrivateKeyFile)
 		if err != nil {
@@ -29,7 +29,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
-		state.Put("keyPair", "")
+		state.Put("keyPair", s.keyName)
 		state.Put("privateKey", string(privateKeyBytes))
 
 		return multistep.ActionContinue
@@ -83,17 +83,19 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 
 func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 	// If no key name is set, then we never created it, so just return
-	if s.keyName == "" {
+    // If we used an SSH private key file, do not go about deleting 
+    // keypairs
+	if s.PrivateKeyFile != "" {
 		return
 	}
 
-	ec2conn := state.Get("ec2").(*ec2.EC2)
+	//ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("Deleting temporary keypair...")
-	_, err := ec2conn.DeleteKeyPair(s.keyName)
-	if err != nil {
-		ui.Error(fmt.Sprintf(
-			"Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
-	}
+	ui.Say("DANGER: Deleting temporary keypair (not really)...")
+	//_, err := ec2conn.DeleteKeyPair(s.keyName)
+	//if err != nil {
+	//ui.Error(fmt.Sprintf(
+    //"Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
+	//}
 }

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -91,7 +91,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
 			DebugKeyPath:         fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-            TemporaryKeyPairName: b.config.TemporaryKeyPairName,
+			TemporaryKeyPairName: b.config.TemporaryKeyPairName,
 			KeyPairName:          b.config.SSHKeyPairName,
 			PrivateKeyFile:       b.config.SSHPrivateKeyFile,
 		},

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -91,7 +91,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepKeyPair{
 			Debug:          b.config.PackerDebug,
 			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:    b.config.TemporaryKeyPairName,
+			KeyPairName:    b.config.SSHKeyPairName,
 			PrivateKeyFile: b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -89,10 +89,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnhancedNetworking: b.config.AMIEnhancedNetworking,
 		},
 		&awscommon.StepKeyPair{
-			Debug:          b.config.PackerDebug,
-			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:    b.config.SSHKeyPairName,
-			PrivateKeyFile: b.config.SSHPrivateKeyFile,
+			Debug:                b.config.PackerDebug,
+			DebugKeyPath:         fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+            TemporaryKeyPairName: b.config.TemporaryKeyPairName,
+			KeyPairName:          b.config.SSHKeyPairName,
+			PrivateKeyFile:       b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupIds: b.config.SecurityGroupIds,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -194,10 +194,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnhancedNetworking: b.config.AMIEnhancedNetworking,
 		},
 		&awscommon.StepKeyPair{
-			Debug:          b.config.PackerDebug,
-			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:    b.config.SSHKeyPairName,
-			PrivateKeyFile: b.config.SSHPrivateKeyFile,
+			Debug:                b.config.PackerDebug,
+			DebugKeyPath:         fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+            TemporaryKeyPairName: b.config.TemporaryKeyPairName,
+			KeyPairName:          b.config.SSHKeyPairName,
+			PrivateKeyFile:       b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupIds: b.config.SecurityGroupIds,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -196,7 +196,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
 			DebugKeyPath:         fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-            TemporaryKeyPairName: b.config.TemporaryKeyPairName,
+			TemporaryKeyPairName: b.config.TemporaryKeyPairName,
 			KeyPairName:          b.config.SSHKeyPairName,
 			PrivateKeyFile:       b.config.SSHPrivateKeyFile,
 		},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -196,7 +196,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepKeyPair{
 			Debug:          b.config.PackerDebug,
 			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:    b.config.TemporaryKeyPairName,
+			KeyPairName:    b.config.SSHKeyPairName,
 			PrivateKeyFile: b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{


### PR DESCRIPTION
For various reasons not everyone wants to create and delete a keypair each time an AWS provisioner runs. I see an issue here: https://github.com/mitchellh/packer/issues/1635 and a slightly different one here: https://github.com/mitchellh/packer/issues/1697. 

This PR adds a `ssh_keypair_name` option that is used by AWS "instance" and "ebs" builders, the previous `ssh_private_key_file` option remains as-is.

If `ssh_keypair_name` is unset (internally seen as to "") *AND* `ssh_private_key_file` is unset; the AWS builders default to creating and deleting a temporary keypair.

This is my first attempt Go code, so apologies for any amateur mistakes. It took me a while to realize that I needed to clone the main repo and add my fork as a remote, so that the `import ( "github.com/mitchellh/packer/[...]" )` etc. statements worked.