### PR TITLE
Use Docker exec for shell provisioner [Backwards compatible]

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -42,6 +42,14 @@ func (c *Communicator) Start(remote *packer.RemoteCmd) error {
 	exitCodePath := outputFile.Name() + "-exit"
 
 	cmd := exec.Command("docker", "exec", "-i", c.ContainerId, "/bin/sh")
+	//Exec only works in 1.3+, attach doesn't work in 1.4. How to make it backwards compatible:
+	//1. Check the version and use one or the other
+	//2. Bash OR (docker exec -i ... || docker attach ....)
+	//3. Somehow check if docker would accept exec and use it if so
+	//Using attach doesn't return an error, it goes silent instead, so we cannot fallback (we could use timeouts or set
+	//a sequence of commands to try when the first one fails)
+
+	//Also. What's the best way of unit testing this? Do we have a mock docker?
 	stdin_w, err := cmd.StdinPipe()
 	if err != nil {
 		// We have to do some cleanup since run was never called

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -142,7 +142,7 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 			return os.MkdirAll(hostpath, info.Mode())
 		}
 
-		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		if info.Mode() & os.ModeSymlink == os.ModeSymlink {
 			dest, err := os.Readlink(path)
 
 			if err != nil {

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -26,7 +26,8 @@ type Communicator struct {
 	lock sync.Mutex
 }
 
-func IsValidDockerCommand(cmd *exec.Cmd) bool {
+//Don't pass any arguments to the docker command
+func IsValidDockerShellCommand(cmd *exec.Cmd) bool {
 	if result := cmd.Run(); result != nil {
 		switch result.(type) {
 		default:
@@ -63,7 +64,7 @@ func (c *Communicator) Start(remote *packer.RemoteCmd) error {
 	cmd := exec.Command("docker", "attach", c.ContainerId)
 
 	//Use exec instead if available
-	if IsValidDockerCommand(exec.Command("docker", "exec")) {
+	if IsValidDockerShellCommand(exec.Command("docker", "exec")) {
 		cmd = exec.Command("docker", "exec", "-i", c.ContainerId, "/bin/sh")
 	}
 

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -60,12 +60,6 @@ func (c *Communicator) Start(remote *packer.RemoteCmd) error {
 	// This file will store the exit code of the command once it is complete.
 	exitCodePath := outputFile.Name() + "-exit"
 
-	//Exec only works in 1.3+, attach doesn't work in 1.4. How to make it backwards compatible:
-	//1. Check the version and use one or the other (Very hard to maintain)
-	//2. Bash OR (docker exec -i ... || docker attach ....) (Ugly)
-	//3. Somehow check if docker would accept exec and use it if so
-	//Using attach doesn't return an error, it goes silent instead, so we cannot fallback (we could use timeouts or set
-	//a sequence of commands to try when the first one fails)
 	cmd := exec.Command("docker", "attach", c.ContainerId)
 
 	//Use exec instead if available

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -14,15 +14,20 @@ func TestIsValidDockerShellCommand(t *testing.T) {
 	if IsValidDockerShellCommand(exec.Command("THIS_COMMAND_WILL_FAIL")) == true {
 		t.Error("THIS_COMMAND_WILL_FAIL should be invalid")
 	}
-	if IsValidDockerShellCommand(exec.Command("docker", "attack")) == true {
-		t.Error("'docker attack' should be invalid")
-	}
-	if IsValidDockerShellCommand(exec.Command("docker", "attach")) != true {
-		t.Error("'docker attach' should be valid")
-	}
 
-	//  This one depends on the version of docker.
-	//	if IsValidDockerShellCommand(exec.Command("docker", "exec")) != true {
-	//		t.Error("'docker exec' should be valid?")
-	//	}
+	//Can only be tested for integration if docker is available
+	//creating a mock feels like simulating failures
+	if exec.Command("docker").Run() == nil {
+		if IsValidDockerShellCommand(exec.Command("docker", "attack")) == true {
+			t.Error("'docker attack' should be invalid")
+		}
+		if IsValidDockerShellCommand(exec.Command("docker", "attach")) != true {
+			t.Error("'docker attach' should be valid")
+		}
+
+		//  This one depends on the version of docker.
+		//	if IsValidDockerShellCommand(exec.Command("docker", "exec")) != true {
+		//		t.Error("'docker exec' should be valid?")
+		//	}
+	}
 }

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -17,5 +17,7 @@ func TestIsValidDockerCommand(t *testing.T) {
 	assert.False(IsValidDockerCommand(exec.Command("THIS_COMMAND_WILL_FAIL")), "THIS_COMMAND_WILL_FAIL")
 	assert.False(IsValidDockerCommand(exec.Command("docker", "attack")), "docker attack")
 	assert.True(IsValidDockerCommand(exec.Command("docker", "attach")), "docker attach")
-	assert.True(IsValidDockerCommand(exec.Command("docker", "exec")), "docker exec")
+
+	//This one depends on the version of docker.
+	//assert.True(IsValidDockerCommand(exec.Command("docker", "exec")), "docker exec")
 }

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -11,13 +11,13 @@ func TestCommunicator_impl(t *testing.T) {
 	var _ packer.Communicator = new(Communicator)
 }
 
-func TestIsValidDockerCommand(t *testing.T) {
+func TestIsValidDockerShellCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.False(IsValidDockerCommand(exec.Command("THIS_COMMAND_WILL_FAIL")), "THIS_COMMAND_WILL_FAIL")
-	assert.False(IsValidDockerCommand(exec.Command("docker", "attack")), "docker attack")
-	assert.True(IsValidDockerCommand(exec.Command("docker", "attach")), "docker attach")
+	assert.False(IsValidDockerShellCommand(exec.Command("THIS_COMMAND_WILL_FAIL")), "THIS_COMMAND_WILL_FAIL")
+	assert.False(IsValidDockerShellCommand(exec.Command("docker", "attack")), "docker attack")
+	assert.True(IsValidDockerShellCommand(exec.Command("docker", "attach")), "docker attach")
 
 	//This one depends on the version of docker.
-	//assert.True(IsValidDockerCommand(exec.Command("docker", "exec")), "docker exec")
+	//assert.True(IsValidDockerShellCommand(exec.Command("docker", "exec")), "docker exec")
 }

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"github.com/mitchellh/packer/packer"
-	"github.com/stretchr/testify/assert"
 	"os/exec"
 	"testing"
 )
@@ -12,12 +11,18 @@ func TestCommunicator_impl(t *testing.T) {
 }
 
 func TestIsValidDockerShellCommand(t *testing.T) {
-	assert := assert.New(t)
+	if IsValidDockerShellCommand(exec.Command("THIS_COMMAND_WILL_FAIL")) == true {
+		t.Error("THIS_COMMAND_WILL_FAIL should be invalid")
+	}
+	if IsValidDockerShellCommand(exec.Command("docker", "attack")) == true {
+		t.Error("'docker attack' should be invalid")
+	}
+	if IsValidDockerShellCommand(exec.Command("docker", "attach")) != true {
+		t.Error("'docker attach' should be valid")
+	}
 
-	assert.False(IsValidDockerShellCommand(exec.Command("THIS_COMMAND_WILL_FAIL")), "THIS_COMMAND_WILL_FAIL")
-	assert.False(IsValidDockerShellCommand(exec.Command("docker", "attack")), "docker attack")
-	assert.True(IsValidDockerShellCommand(exec.Command("docker", "attach")), "docker attach")
-
-	//This one depends on the version of docker.
-	//assert.True(IsValidDockerShellCommand(exec.Command("docker", "exec")), "docker exec")
+	//  This one depends on the version of docker.
+	//	if IsValidDockerShellCommand(exec.Command("docker", "exec")) != true {
+	//		t.Error("'docker exec' should be valid?")
+	//	}
 }

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -2,9 +2,20 @@ package docker
 
 import (
 	"github.com/mitchellh/packer/packer"
+	"github.com/stretchr/testify/assert"
+	"os/exec"
 	"testing"
 )
 
 func TestCommunicator_impl(t *testing.T) {
 	var _ packer.Communicator = new(Communicator)
+}
+
+func TestIsValidDockerCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.False(IsValidDockerCommand(exec.Command("THIS_COMMAND_WILL_FAIL")), "THIS_COMMAND_WILL_FAIL")
+	assert.False(IsValidDockerCommand(exec.Command("docker", "attack")), "docker attack")
+	assert.True(IsValidDockerCommand(exec.Command("docker", "attach")), "docker attach")
+	assert.True(IsValidDockerCommand(exec.Command("docker", "exec")), "docker exec")
 }

--- a/packer.iml
+++ b/packer.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/packer.iml
+++ b/packer.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="RUBY_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
Similar to https://github.com/mitchellh/packer/pull/1825 this pulls @mariussturm's changes (thanks mate) to make packer work with versions of docker > 1.3.5

It also checks that `docker exec` is a valid command prior to using it, else it keeps using the old `docker attach`
Of the multiple ways of making this fix backwards compatible I considered the following:
```
  //1. Check the version and use one or the other (Very hard to maintain)
  //2. Bash OR (docker exec -i ... || docker attach ....) (Ugly)
  //3. Somehow check if docker would accept exec and use it if so
  //Using attach doesn't return an error, it goes silent instead, so we cannot fallback (we could use timeouts or set
  //a sequence of commands to try when the first one fails)
```
