### PR TITLE
Adding make bin step into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ this exits with exit status 0, then everything is working!
     $ make
     ...
 
+If you want to install the binaries into $GOPATH/bin simply type `make bin`:
+
+    $ make bin
+
 To compile a development version of Packer and the built-in plugins,
 run `make dev`. This will put Packer binaries in the `bin` folder:
 


### PR DESCRIPTION
I had to inspect the Makefile to identify the 'bin' target, maybe this is intuitive to experienced Go users but I'm still green and it took me a moment to figure it out. Hopefully, this can help someone else.