### PR TITLE
Fix tutorial source ID

### DIFF
--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -54,7 +54,7 @@ briefly. Create a file `example.json` and fill it with the following contents:
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-3d50120d",
+    "source_ami": "ami-9eaa1cf6",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"


### PR DESCRIPTION
`ami-9eaa1cf6` is the correct Ubuntu 14.04 AMI for the us-east-1 region. These screenshots from AWS's AMI search shows that the two are exactly the same:

Current (us-west-2) AMI:
![screen shot 2015-01-21 at 4 32 44 pm](https://cloud.githubusercontent.com/assets/2530982/5845580/29ae2d06-a18b-11e4-8942-7791ec274bd4.png)

Corrected (us-east-1) AMI:
![screen shot 2015-01-21 at 4 32 37 pm](https://cloud.githubusercontent.com/assets/2530982/5845581/29b3b6f4-a18b-11e4-8e37-ef162b3c48c6.png)


Fixes #1841