### PR TITLE
Handle SIGTERM in addition to SIGINT

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -4,14 +4,16 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	cmdcommon "github.com/mitchellh/packer/common/command"
-	"github.com/mitchellh/packer/packer"
 	"log"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
+
+	cmdcommon "github.com/mitchellh/packer/common/command"
+	"github.com/mitchellh/packer/packer"
 )
 
 type BuildCommand struct {
@@ -149,7 +151,9 @@ func (c BuildCommand) Run(args []string) int {
 
 		// Handle interrupts for this build
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt)
+		for _, sigtype := range []os.Signal{syscall.SIGTERM, os.Interrupt} {
+			signal.Notify(sigCh, sigtype)
+		}
 		defer signal.Stop(sigCh)
 		go func(b packer.Build) {
 			<-sigCh


### PR DESCRIPTION
Catch SIGTERM in addition to SIGINT; this allows for better integration with various tools expecting standard Unix semantics (for instance Jenkins, where cancelling a job will cause SIGTERM to be sent to the process).