### PR TITLE
Add support for UserDataFile in OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -94,6 +94,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SourceImage:    b.config.SourceImage,
 			SecurityGroups: b.config.SecurityGroups,
 			Networks:       b.config.Networks,
+			UserDataFile:   b.config.UserDataFile,
 		},
 		&StepWaitForRackConnect{
 			Wait:           b.config.RackconnectWait,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -87,6 +87,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 		"openstack_provider": &c.OpenstackProvider,
 		"floating_ip_pool":   &c.FloatingIpPool,
 		"floating_ip":        &c.FloatingIp,
+		"user_data_file":     &c.UserDataFile,
 	}
 
 	for n, ptr := range templates {

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mitchellh/packer/packer"
+	"os"
 	"time"
 )
 
@@ -23,6 +24,7 @@ type RunConfig struct {
 	FloatingIp        string   `mapstructure:"floating_ip"`
 	SecurityGroups    []string `mapstructure:"security_groups"`
 	Networks          []string `mapstructure:"networks"`
+	UserDataFile      string   `mapstructure:"user_data_file"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration
@@ -67,6 +69,13 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 
 	if c.SSHUsername == "" {
 		errs = append(errs, errors.New("An ssh_username must be specified"))
+	}
+
+	if c.UserDataFile != "" {
+		if _, err := os.Stat(c.UserDataFile); err != nil {
+			errs = append(errs,
+				fmt.Errorf("user_data_file not found: %s", c.UserDataFile))
+		}
 	}
 
 	templates := map[string]*string{

--- a/builder/openstack/run_config_test.go
+++ b/builder/openstack/run_config_test.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -82,6 +83,25 @@ func TestRunConfigPrepare_SSHTimeout(t *testing.T) {
 func TestRunConfigPrepare_SSHUsername(t *testing.T) {
 	c := testRunConfig()
 	c.SSHUsername = ""
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestRunConfigPrepare_UserDataFile(t *testing.T) {
+	c := testRunConfig()
+	c.UserDataFile = "badfile"
+	if err := c.Prepare(nil); len(err) != 1 {
+		t.Fatalf("err: %s", err)
+	}
+
+	tf, err := ioutil.TempFile("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer tf.Close()
+
+	c.UserDataFile = tf.Name()
 	if err := c.Prepare(nil); len(err) != 0 {
 		t.Fatalf("err: %s", err)
 	}

--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -110,7 +110,10 @@ each category, the available configuration keys are alphabetized.
   installation requires this.
 
 * `use_floating_ip` (boolean) - Whether or not to use a floating IP for
-  the instance. Defaults to false.
+the instance. Defaults to false.
+
+* `user_data_file` (string) - The path to a file that will be used for the
+  user data when launching the instance. 
 
 * `rackconnect_wait` (boolean) - For rackspace, whether or not to wait for
   Rackconnect to assign the machine an IP address before connecting via SSH.


### PR DESCRIPTION
This adds the ability to supply `user_data` when an OpenStack instance is booted for the first time. `user_data` is often used by the cloudinit package in ubuntu.

The data is base64 encoded when sent over the wire, but the user should be able to specify a file containing the unencoded data, just like they would when using the python-novaclient.