### PR TITLE
Updates to Into: Build An Image docs

### DIFF
--- a/website/Vagrantfile
+++ b/website/Vagrantfile
@@ -6,6 +6,8 @@ sudo apt-get -y update
 
 # RVM/Ruby
 sudo apt-get -y install curl
+sudo apt-get -y install git
+gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable
 . ~/.bashrc
 . ~/.bash_profile

--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -54,8 +54,8 @@ briefly. Create a file `example.json` and fill it with the following contents:
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-9eaa1cf6",
-    "instance_type": "t2.micro",
+    "source_ami": "ami-c65be9ae",
+    "instance_type": "t1.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   }]


### PR DESCRIPTION
I was working through [the Intro][1] and got hung up on the example json file. 
This PR fixes these:

- the listed AMI isn't found
- t2.micros can only be in a VPC(? so said an error), and the docs say
  we're using a t1.micro anyway
- Updates to the vagrant file to get the website to build

[1]: https://packer.io/intro/getting-started/build-image.html