### PR TITLE
builder/digitalocean: fix response decoding after api changes

### DIFF
--- a/builder/digitalocean/api.go
+++ b/builder/digitalocean/api.go
@@ -5,12 +5,16 @@
 package digitalocean
 
 type Region struct {
-	Id        uint     `json:"id,omitempty"`        //only in v1 api
-	Slug      string   `json:"slug"`                //presen in both api
-	Name      string   `json:"name"`                //presen in both api
-	Sizes     []string `json:"sizes,omitempty"`     //only in v2 api
-	Available bool     `json:"available,omitempty"` //only in v2 api
-	Features  []string `json:"features,omitempty"`  //only in v2 api
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+
+	// v1 only
+	Id uint `json:"id,omitempty"`
+
+	// v2 only
+	Sizes     []string `json:"sizes,omitempty"`
+	Available bool     `json:"available,omitempty"`
+	Features  []string `json:"features,omitempty"`
 }
 
 type RegionsResp struct {
@@ -18,16 +22,19 @@ type RegionsResp struct {
 }
 
 type Size struct {
-	Id           uint     `json:"id,omitempty"`            //only in v1 api
-	Name         string   `json:"name,omitempty"`          //only in v1 api
-	Slug         string   `json:"slug"`                    //presen in both api
-	Memory       uint     `json:"memory,omitempty"`        //only in v2 api
-	VCPUS        uint     `json:"vcpus,omitempty"`         //only in v2 api
-	Disk         uint     `json:"disk,omitempty"`          //only in v2 api
-	Transfer     float64  `json:"transfer,omitempty"`      //only in v2 api
-	PriceMonthly float64  `json:"price_monthly,omitempty"` //only in v2 api
-	PriceHourly  float64  `json:"price_hourly,omitempty"`  //only in v2 api
-	Regions      []string `json:"regions,omitempty"`       //only in v2 api
+	Slug string `json:"slug"`
+
+	// v1 only
+	Id   uint   `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+
+	// v2 only
+	Memory       uint    `json:"memory,omitempty"`
+	VCPUS        uint    `json:"vcpus,omitempty"`
+	Disk         uint    `json:"disk,omitempty"`
+	Transfer     float64 `json:"transfer,omitempty"`
+	PriceMonthly float64 `json:"price_monthly,omitempty"`
+	PriceHourly  float64 `json:"price_hourly,omitempty"`
 }
 
 type SizesResp struct {
@@ -35,14 +42,15 @@ type SizesResp struct {
 }
 
 type Image struct {
-	Id           uint     `json:"id"`                   //presen in both api
-	Name         string   `json:"name"`                 //presen in both api
-	Slug         string   `json:"slug"`                 //presen in both api
-	Distribution string   `json:"distribution"`         //presen in both api
-	Public       bool     `json:"public,omitempty"`     //only in v2 api
-	Regions      []string `json:"regions,omitempty"`    //only in v2 api
-	ActionIds    []string `json:"action_ids,omitempty"` //only in v2 api
-	CreatedAt    string   `json:"created_at,omitempty"` //only in v2 api
+	Id           uint   `json:"id"`
+	Name         string `json:"name"`
+	Slug         string `json:"slug"`
+	Distribution string `json:"distribution"`
+
+	// v2 only
+	Public    bool     `json:"public,omitempty"`
+	ActionIds []string `json:"action_ids,omitempty"`
+	CreatedAt string   `json:"created_at,omitempty"`
 }
 
 type ImagesResp struct {


### PR DESCRIPTION
Since the API data structures seem to keep changing from underneath us, this PR removes the `Regions` struct field from both the Size and Image structs. We aren't using them anywhere currently.

Side note, I've opened [an issue](https://www.digitalocean.com/community/questions/api-data-structure-changes-break-clients) on the community page for DO about these kinds of changes, so we'll see if anyone replies there.