### PR TITLE
Make PackerBuildName and PackerBuilderType available as Facts during a m...

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -147,6 +147,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		newFacts[k] = v
 	}
 
+	newFacts["packer_build_name"] = p.config.PackerBuildName
+	newFacts["packer_builder_type"] = p.config.PackerBuilderType
 	p.config.Facter = newFacts
 
 	// Validation

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -159,9 +159,9 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 	}
 	defer os.RemoveAll(td)
 
-  facts := make(map[string]string)
+	facts := make(map[string]string)
 	facts["fact_name"] = "fact_value"
-  config["facter"] = facts
+	config["facter"] = facts
 
 	p = new(Provisioner)
 	err = p.Prepare(config)
@@ -169,7 +169,7 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-  // Make sure the default facts are present
+	// Make sure the default facts are present
 	delete(config, "facter")
 	p = new(Provisioner)
 	err = p.Prepare(config)

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -133,3 +133,47 @@ func TestProvisionerPrepare_modulePaths(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestProvisionerPrepare_facterFacts(t *testing.T) {
+	config := testConfig()
+
+	delete(config, "facter")
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Test with malformed fact
+	config["facter"] = "fact=stringified"
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should be an error")
+	}
+
+	// Test with a good one
+	td, err := ioutil.TempDir("", "packer")
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	defer os.RemoveAll(td)
+
+  facts := make(map[string]string)
+	facts["fact_name"] = "fact_value"
+  config["facter"] = facts
+
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+  // Make sure the default facts are present
+	delete(config, "facter")
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if p.config.Facter == nil {
+		t.Fatalf("err: Default facts are not set in the Puppet provisioner!")
+	}
+}

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -106,3 +106,17 @@ can contain various template variables, defined below:
 * `ModulePath` - The paths to the module directories.
 * `Sudo` - A boolean of whether to `sudo` the command or not, depending on
   the value of the `prevent_sudo` configuration.
+
+## Default Facts
+
+In addition to being able to specify custom Facter facts using the `facter`
+configuration, the provisioner automatically defines certain commonly useful
+facts:
+
+* `packer_build_name` is set to the name of the build that Packer is running.
+  This is most useful when Packer is making multiple builds and you want to
+  distinguish them in your Hiera hierarchy.
+
+* `packer_builder_type` is the type of the builder that was used to create the
+  machine that Puppet is running on. This is useful if you want to run only
+  certain parts of your Puppet code on systems built with certain builders.


### PR DESCRIPTION
...asterless run similar to the way we do with the Shell provisioner.