### PR TITLE
Boot command section in vmware and virtualbox ISO wasn't working

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -228,7 +228,7 @@ each category, the available options are alphabetized and described.
   `tools_upload_flavor`. By default the upload path is set to
   `{{.Flavor}}.iso`.
 
-* `version` (string) - The [vmx hardware version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746) for the new virtual machine.  Only the default value has been tested, any other value is expiermental.  Default value is '9'.
+* `version` (string) - The [vmx hardware version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746) for the new virtual machine.  Only the default value has been tested, any other value is experimental.  Default value is '9'.
 
 * `vm_name` (string) - This is the name of the VMX file for the new virtual
   machine, without the file extension. By default this is "packer-BUILDNAME",


### PR DESCRIPTION
Modified the code block sections to not type to javascript (which was converting < and > to HTML code).