### PR TITLE
post-processor/vagrant: fix test failure on Windows

### DIFF
--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -122,20 +122,25 @@ func TestPostProcessorPrepare_subConfigs(t *testing.T) {
 }
 
 func TestPostProcessorPrepare_vagrantfileTemplateExists(t *testing.T) {
-	var p PostProcessor
-
 	f, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
+	name := f.Name()
 	c := testConfig()
-	c["vagrantfile_template"] = f.Name()
+	c["vagrantfile_template"] = name
 
-	os.Remove(f.Name())
+	if err := f.Close(); err != nil {
+		t.Fatal("err: %s", err)
+	}
 
-	err = p.Configure(c)
-	if err == nil {
+	if err := os.Remove(name); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var p PostProcessor
+	if err := p.Configure(c); err == nil {
 		t.Fatal("expected an error since vagrantfile_template does not exist")
 	}
 }


### PR DESCRIPTION
Close temporary file created in test before trying to remove it.
Fixes test failure on Windows, which cannot remove the file unless
it has been closed.