### PR TITLE
Support user variables for missing OpenStack string config options

### DIFF
--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -68,10 +68,13 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	templates := map[string]*string{
-		"flavor":       &c.Flavor,
-		"ssh_timeout":  &c.RawSSHTimeout,
-		"ssh_username": &c.SSHUsername,
-		"source_image": &c.SourceImage,
+		"flavor":             &c.Flavor,
+		"ssh_timeout":        &c.RawSSHTimeout,
+		"ssh_username":       &c.SSHUsername,
+		"source_image":       &c.SourceImage,
+		"openstack_provider": &c.OpenstackProvider,
+		"floating_ip_pool":   &c.FloatingIpPool,
+		"floating_ip":        &c.FloatingIp,
 	}
 
 	for n, ptr := range templates {


### PR DESCRIPTION
Before this change, the "openstack_provider", "floating_ip_pool", and "floating_ip" config options in the OpenStack builder were not processing user variables. This change would fix https://github.com/mitchellh/packer/issues/1506.