### PR TITLE
Update Push APIs

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -155,6 +155,8 @@ func (c *PushCommand) Run(args []string) int {
 	if message != "" {
 		metadata["message"] = message
 	}
+	metadata["template"] = tpl.RawContents
+	metadata["template_name"] = filepath.Base(args[0])
 	uploadOpts.Metadata = metadata
 
 	// Warn about builds not having post-processors.

--- a/command/push.go
+++ b/command/push.go
@@ -33,10 +33,12 @@ type pushUploadFn func(
 
 func (c *PushCommand) Run(args []string) int {
 	var token string
+	var message string
 
 	f := flag.NewFlagSet("push", flag.ContinueOnError)
 	f.Usage = func() { c.Ui.Error(c.Help()) }
 	f.StringVar(&token, "token", "", "token")
+	f.StringVar(&message, "message", "", "message")
 	if err := f.Parse(args); err != nil {
 		return 1
 	}
@@ -222,8 +224,10 @@ Usage: packer push [options] TEMPLATE
 
 Options:
 
-  -token=<token>      Access token to use to upload. If blank, the
-                      ATLAS_TOKEN environmental variable will be used.
+  -message=<detail>    A message to identify the purpose or changes in this
+                       Packer template much like a VCS commit message
+
+  -token=<token>       The access token to use to when uploading
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/push.go
+++ b/command/push.go
@@ -34,12 +34,14 @@ type pushUploadFn func(
 func (c *PushCommand) Run(args []string) int {
 	var token string
 	var message string
+	var create bool
 
 	f := flag.NewFlagSet("push", flag.ContinueOnError)
 	f.Usage = func() { c.Ui.Error(c.Help()) }
 	f.StringVar(&token, "token", "", "token")
 	f.StringVar(&message, "m", "", "message")
 	f.StringVar(&message, "message", "", "message")
+	f.BoolVar(&create, "create", false, "create (deprecated)")
 	if err := f.Parse(args); err != nil {
 		return 1
 	}
@@ -48,6 +50,12 @@ func (c *PushCommand) Run(args []string) int {
 	if len(args) != 1 {
 		f.Usage()
 		return 1
+	}
+
+	// Print deprecations
+	if create {
+		c.Ui.Error(fmt.Sprintf("The '-create' option is now the default and is\n" +
+			"longer used. It will be removed in the next version."))
 	}
 
 	// Read the template

--- a/packer/template.go
+++ b/packer/template.go
@@ -3,15 +3,16 @@ package packer
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-version"
-	"github.com/mitchellh/mapstructure"
-	jsonutil "github.com/mitchellh/packer/common/json"
 	"io"
 	"io/ioutil"
 	"os"
 	"sort"
 	"text/template"
 	"time"
+
+	"github.com/hashicorp/go-version"
+	"github.com/mitchellh/mapstructure"
+	jsonutil "github.com/mitchellh/packer/common/json"
 )
 
 // The rawTemplate struct represents the structure of a template read
@@ -33,6 +34,7 @@ type rawTemplate struct {
 // The Template struct represents a parsed template, parsed into the most
 // completed form it can be without additional processing by the caller.
 type Template struct {
+	RawContents    []byte
 	Description    string
 	Variables      map[string]RawVariable
 	Builders       map[string]RawBuilderConfig
@@ -163,6 +165,7 @@ func ParseTemplate(data []byte, vars map[string]string) (t *Template, err error)
 	}
 
 	t = &Template{}
+	t.RawContents = data
 	t.Description = rawTpl.Description
 	t.Variables = make(map[string]RawVariable)
 	t.Builders = make(map[string]RawBuilderConfig)

--- a/packer/template_test.go
+++ b/packer/template_test.go
@@ -58,6 +58,10 @@ func TestParseTemplateFile_basic(t *testing.T) {
 	if len(result.Builders) != 1 {
 		t.Fatalf("bad: %#v", result.Builders)
 	}
+
+	if string(result.RawContents) != data {
+		t.Fatalf("expected %q to be %q", result.RawContents, data)
+	}
 }
 
 func TestParseTemplateFile_minPackerVersionBad(t *testing.T) {

--- a/post-processor/atlas/post-processor_test.go
+++ b/post-processor/atlas/post-processor_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestPostProcessorConfigure(t *testing.T) {
+	currentEnv := os.Getenv("ATLAS_TOKEN")
+	os.Unsetenv("ATLAS_TOKEN")
+	defer os.Setenv("ATLAS_TOKEN", currentEnv)
+
 	var p PostProcessor
 	if err := p.Configure(validDefaults()); err != nil {
 		t.Fatalf("err: %s", err)

--- a/post-processor/atlas/post-processor_test.go
+++ b/post-processor/atlas/post-processor_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPostProcessorConfigure(t *testing.T) {
 	currentEnv := os.Getenv("ATLAS_TOKEN")
-	os.Unsetenv("ATLAS_TOKEN")
+	os.Setenv("ATLAS_TOKEN", "")
 	defer os.Setenv("ATLAS_TOKEN", currentEnv)
 
 	var p PostProcessor

--- a/website/source/docs/command-line/push.html.markdown
+++ b/website/source/docs/command-line/push.html.markdown
@@ -7,27 +7,34 @@ description: |-
 
 # Command-Line: Push
 
-The `packer push` Packer command takes a template and pushes it to a build
-service. The build service will automatically build your Packer template and
-expose the artifacts.
+The `packer push` Packer command takes a template and pushes it to a Packer
+build service such as [HashiCorp's Atlas](https://atlas.hashicorp.com). The
+build service will automatically build your Packer template and expose the
+artifacts.
 
-This command currently only sends templates to
-[Atlas](https://atlas.hashicorp.com) by HashiCorp, but the command will
-be pluggable in the future with alternate implementations.
-
-External build services such as Atlas make it easy to iterate on Packer
-templates, especially when the builder you're running may not be easily
+External build services such as HashiCorp's Atlas make it easy to iterate on
+Packer templates, especially when the builder you are running may not be easily
 accessable (such as developing `qemu` builders on Mac or Windows).
 
-For the `push` command to work, the
-[push configuration](/docs/templates/push.html)
+For the `push` command to work, the [push configuration](/docs/templates/push.html)
 must be completed within the template.
 
 ## Options
 
-* `-create=true` - If the build configuration matching the name of the push
-  doesn't exist, it will be created if this is true. This defaults to true.
+* `-token` - An access token for authenticating the push to the Packer build
+  service such as Atlas. This can also be specified within the push
+  configuration in the template.
 
-* `-token=FOO` - An access token for authenticating the push. This can also
-  be specified within the push configuration in the template. By setting this
-  in the template, you can take advantage of user variables.
+## Examples
+
+Push a Packer template:
+
+```shell
+$ packer push template.json
+```
+
+Push a Packer template with a custom token:
+
+```shell
+$ packer push -token ABCD1234 template.json
+```

--- a/website/source/docs/command-line/push.html.markdown
+++ b/website/source/docs/command-line/push.html.markdown
@@ -25,6 +25,10 @@ must be completed within the template.
 
 ## Options
 
+* `-message` - A message to identify the purpose or changes in this Packer
+  template much like a VCS commit message. This message will be passed to the
+  Packer build service. This option is also available as a short option `-m`.
+
 * `-token` - An access token for authenticating the push to the Packer build
   service such as Atlas. This can also be specified within the push
   configuration in the template.
@@ -34,7 +38,7 @@ must be completed within the template.
 Push a Packer template:
 
 ```shell
-$ packer push template.json
+$ packer push -m "Updating the apache version" template.json
 ```
 
 Push a Packer template with a custom token:

--- a/website/source/docs/command-line/push.html.markdown
+++ b/website/source/docs/command-line/push.html.markdown
@@ -16,6 +16,10 @@ External build services such as HashiCorp's Atlas make it easy to iterate on
 Packer templates, especially when the builder you are running may not be easily
 accessable (such as developing `qemu` builders on Mac or Windows).
 
+!> The Packer build service will receive the raw copy of your Packer template
+when you push. **If you have sensitive data in your Packer template, you should
+move that data into Packer variables or environment variables!**
+
 For the `push` command to work, the [push configuration](/docs/templates/push.html)
 must be completed within the template.
 

--- a/website/source/docs/templates/push.html.markdown
+++ b/website/source/docs/templates/push.html.markdown
@@ -62,4 +62,4 @@ each category, the available configuration keys are alphabetized.
 
 * `vcs` (bool) - If true, Packer will detect your VCS (if there is one)
   and only upload the files that are tracked by the VCS. This is useful
-  for automatically excluding ignored files. This defaults to true.
+  for automatically excluding ignored files. This defaults to false.

--- a/website/source/docs/templates/push.html.markdown
+++ b/website/source/docs/templates/push.html.markdown
@@ -46,8 +46,8 @@ each category, the available configuration keys are alphabetized.
   this is `https://atlas.hashicorp.com`.
 
 * `base_dir` (string) - The base directory of the files to upload. This
-  will be the CWD when the build service executes your template. This
-  path is relative to the template.
+  will be the current working directory when the build service executes your
+  template. This path is relative to the template.
 
 * `include` (array of strings) - Glob patterns to include relative to
   the `base_dir`. If this is specified, only files that match the include
@@ -57,9 +57,35 @@ each category, the available configuration keys are alphabetized.
   the `base_dir`.
 
 * `token` (string) - An access token to use to authenticate to the build
-  service. For Atlas, you can retrieve this access token in your account
-  section by clicking your account name in the upper right corner.
+  service.
 
 * `vcs` (bool) - If true, Packer will detect your VCS (if there is one)
   and only upload the files that are tracked by the VCS. This is useful
   for automatically excluding ignored files. This defaults to false.
+
+## Examples
+
+A push configuration section with minimal options:
+
+```javascript
+{
+  "push": {
+    "name": "hashicorp/precise64"
+  }
+}
+```
+
+A push configuration specifying Packer to inspect the VCS and list individual
+files to include:
+
+```javascript
+{
+  "push": {
+    "name": "hashicorp/precise64",
+    "vcs": true,
+    "include": [
+      "other_file/outside_of.vcs"
+    ]
+  }
+}
+```

--- a/website/source/docs/templates/push.html.markdown
+++ b/website/source/docs/templates/push.html.markdown
@@ -89,3 +89,6 @@ files to include:
   }
 }
 ```
+
+~> **Variable interpolation** is not currently possible in Packer push
+configurations. This will be fixed in an upcoming release.


### PR DESCRIPTION
Major changes:

- Packer saves the raw contents of the file on the `Template` struct when parsing - this allows other functions/plugins to access the raw template contents without re-reading the file.
- Add new `-message` and `-m` for specifying a "commit-like" message when pushing a build configuration.
- Remove the `-create` option and automatically create build configurations if they do not exist. After working with `packer push` on a regular basis, @kfishner and I agreed that the `-create` UX is not desirable and is confusing to new users.
- Upload the raw template contents and filename of the template when pushing as metadata
- Improve documentation and examples on the website.

Questions:

- Should we maintain BC with `-create` as an option? It doesn't need to do anything, but should the command still permit it?

/cc @mitchellh @kfishner