### PR TITLE
Excluding "Windows Disks" directory in Parallels vagrant post-processor (issue #1881)

### DIFF
--- a/post-processor/vagrant/parallels.go
+++ b/post-processor/vagrant/parallels.go
@@ -10,7 +10,7 @@ import (
 
 // These are the extensions of files and directories that are unnecessary for the function
 // of a Parallels virtual machine.
-var UnnecessaryFilesPatterns = []string{"\\.log$", "\\.backup$", "\\.Backup$", "\\.app/"}
+var UnnecessaryFilesPatterns = []string{"\\.log$", "\\.backup$", "\\.Backup$", "\\.app/", "\\Windows Disks/"}
 
 type ParallelsProvider struct{}
 


### PR DESCRIPTION
This PR addresses the small issue in #1881 where the `vagrant` post-processor fails to properly copy the .pvm file:

```
==> parallels-iso: Running post-processor: vagrant
==> parallels-iso (vagrant): Creating Vagrant box for 'parallels' provider
    parallels-iso (vagrant): Copying: output-parallels-iso/packer-parallels-iso.pvm/VmInfo.pvi
    parallels-iso (vagrant): Copying: output-parallels-iso/packer-parallels-iso.pvm/Windows Disks/C
Build 'parallels-iso' errored: 1 error(s) occurred:

* Post-processor failed: open output-parallels-iso/packer-parallels-iso.pvm/Windows Disks/C: no such file or directory

==> Some builds didn't complete successfully and had errors:
--> parallels-iso: 1 error(s) occurred:

* Post-processor failed: open output-parallels-iso/packer-parallels-iso.pvm/Windows Disks/C: no such file or directory

==> Builds finished but no artifacts were created.
```

Excluding the "Windows Disks" directory prevents this issue and is not required in the export.