### PR TITLE
Fixes #1881 Don't include Windows Disks when packaging boxes for prl

### DIFF
--- a/post-processor/vagrant/parallels.go
+++ b/post-processor/vagrant/parallels.go
@@ -10,7 +10,7 @@ import (
 
 // These are the extensions of files and directories that are unnecessary for the function
 // of a Parallels virtual machine.
-var UnnecessaryFilesPatterns = []string{"\\.log$", "\\.backup$", "\\.Backup$", "\\.app/"}
+var UnnecessaryFilesPatterns = []string{"\\.log$", "\\.backup$", "\\.Backup$", "\\.app/", "/Windows Disks/"}
 
 type ParallelsProvider struct{}
 


### PR DESCRIPTION
This excludes the directory "Windows Disks" present in the VM data
directory if you hava a Windows VM with Parallels tools installed.