### PR TITLE
make it clear that "tools_upload_folder" is not used for esxi

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -226,7 +226,7 @@ each category, the available options are alphabetized and described.
   This is a [configuration template](/docs/templates/configuration-templates.html)
   that has a single valid variable: `Flavor`, which will be the value of
   `tools_upload_flavor`. By default the upload path is set to
-  `{{.Flavor}}.iso`.
+  `{{.Flavor}}.iso`. This setting is not used when `remote_type` is "esx5".
 
 * `version` (string) - The [vmx hardware version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746) for the new virtual machine.  Only the default value has been tested, any other value is experimental.  Default value is '9'.
 


### PR DESCRIPTION
Signed-off-by: gnawhleinad <danielleehwang@gmail.com>

From [`builder/vmware/common/step_prepare_tools.go`](https://github.com/mitchellh/packer/blob/master/builder/vmware/common/step_prepare_tools.go) and [`builder/vmware/iso/driver_esx5.go`](https://github.com/mitchellh/packer/blob/master/builder/vmware/iso/driver_esx5.go), it seems like `tools_upload_flavor` is not used for `esxi`. Assuming I'm correct, I've made changes to the documentation to make it more clear.

I haven't thoroughly investigated this yet, but this could be a different bug if `vmsvc/tools.install` doesn't actually install VMWare Tools. If it doesn't, then I think `tools_upload_flavor` should be handled differently.