### PR TITLE
fixing version numbers: RCs should be labeled x.x.x-rcx

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -34,7 +34,7 @@ func runCheckpoint(c *config) {
 
 	version := Version
 	if VersionPrerelease != "" {
-		version += fmt.Sprintf(".%s", VersionPrerelease)
+		version += fmt.Sprintf("-%s", VersionPrerelease)
 	}
 
 	signaturePath := filepath.Join(configDir, "checkpoint_signature")


### PR DESCRIPTION
see conversation with ryanuber: https://github.com/hashicorp/go-checkpoint/issues/2#issuecomment-73199209