### PR TITLE
file provisioner - downloads

### DIFF
--- a/builder/vmware/common/step_upload_tools.go
+++ b/builder/vmware/common/step_upload_tools.go
@@ -21,14 +21,14 @@ type StepUploadTools struct {
 func (c *StepUploadTools) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 
+	if c.ToolsUploadFlavor == "" {
+		return multistep.ActionContinue
+	}
+
 	if c.RemoteType == "esx5" {
 		if err := driver.ToolsInstall(); err != nil {
 			state.Put("error", fmt.Errorf("Couldn't mount VMware tools ISO. Please check the 'guest_os_type' in your template.json."))
 		}
-		return multistep.ActionContinue
-	}
-
-	if c.ToolsUploadFlavor == "" {
 		return multistep.ActionContinue
 	}
 

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 )
 
@@ -170,8 +171,58 @@ func (c *comm) UploadDir(dst string, src string, excl []string) error {
 	return c.scpSession("scp -rvt "+dst, scpFunc)
 }
 
-func (c *comm) Download(string, io.Writer) error {
-	panic("not implemented yet")
+func (c *comm) Download(path string, output io.Writer) error {
+
+	scpFunc := func(w io.Writer, stdoutR *bufio.Reader) error {
+		fmt.Fprint(w, "\x00")
+
+		// read file info
+		fi, err := stdoutR.ReadString( '\n')
+		if err != nil {
+			return err
+		}
+
+		if len(fi) < 0 {
+			return fmt.Errorf("empty response from server")
+		}
+
+		switch fi[0] {
+		case '\x01', '\x02':
+			return fmt.Errorf("%s", fi[1:len(fi)])
+		case 'C':
+		case 'D':
+			return fmt.Errorf("remote file is directory")
+		default:
+			return fmt.Errorf("unexpected server response (%x)", fi[0])
+		}
+
+		var mode string
+		var size int64
+
+		n, err := fmt.Sscanf(fi, "%6s %d ", &mode, &size)
+		if err != nil || n != 2 {
+			return fmt.Errorf("can't parse server response (%s)", fi)
+		}
+		if size < 0 {
+			return fmt.Errorf("negative file size")
+		}
+
+		fmt.Fprint(w, "\x00")
+
+		if _, err := io.CopyN(output, stdoutR, size); err != nil {
+			return err
+		}
+
+		fmt.Fprint(w, "\x00")
+
+		if err := checkSCPStatus(stdoutR); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return c.scpSession("scp -vf "+strconv.Quote(path), scpFunc)
 }
 
 func (c *comm) newSession() (session *ssh.Session, err error) {


### PR DESCRIPTION
1. communicatior ssh.Download implementation. Only one file without recursion and without preserving file mode.
1. Add "direction" parameter to file provisioner for support file downloading.

no tested very well, but works for me