### PR TITLE
Fix type conversion in post processor config parsing [GH-1913]

### DIFF
--- a/packer/template.go
+++ b/packer/template.go
@@ -263,7 +263,18 @@ func ParseTemplate(data []byte, vars map[string]string) (t *Template, err error)
 		configs := make([]RawPostProcessorConfig, 0, len(rawPP))
 		for j, pp := range rawPP {
 			var config RawPostProcessorConfig
-			if err := mapstructure.Decode(pp, &config); err != nil {
+
+			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				Result:           &config,
+				WeaklyTypedInput: true,
+			})
+			if err != nil {
+				// This should never happen.
+				panic(err)
+			}
+
+			err = decoder.Decode(pp)
+			if err != nil {
 				if merr, ok := err.(*mapstructure.Error); ok {
 					for _, err := range merr.Errors {
 						errors = append(errors,


### PR DESCRIPTION
Fixed this in the same way user variable substitution for non-string types was fixed before (in #418)... not sure if that is the right way to go about it.