### PR TITLE
Clarify error message in case of an atlas client connection failure

### DIFF
--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -115,7 +115,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		p.client, err = atlas.NewClient(p.config.ServerAddr)
 		if err != nil {
 			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Error initializing client: %s", err))
+				errs, fmt.Errorf("Error initializing atlas client: %s", err))
 			return errs
 		}
 	}
@@ -126,8 +126,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	if !p.config.Test {
 		// Verify the client
 		if err := p.client.Verify(); err != nil {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Error initializing client: %s", err))
+			if err == atlas.ErrAuth {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Error connecting to atlas server, please check your ATLAS_TOKEN env: %s", err))
+			} else {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Error initializing atlas client: %s", err))
+			}
 			return errs
 		}
 	}


### PR DESCRIPTION
When a packer json contains an atlas postprocessor, and `packer validate` runned locally
in case of the missing ATLAS_TOKEN env var, the following error message is displayed:
    
    * Error initializing client: authentication failed
    
It wasn't clear which plugin produced this message, so the amazon-ebs builder was the suspect

## Proposed error message

With the proposed change the following error message is displayed:

    * Error connecting to atlas server, please check your ATLAS_TOKEN env: authentication failed
