### PR TITLE
builder/vmware-esxi: Add step_export

### DIFF
--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -54,6 +54,7 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 
 		vmxData[ide+"devicetype"] = "cdrom-raw"
 		vmxData[ide+"filename"] = "auto detect"
+		vmxData[ide+"clientdevice"] = "TRUE"
 	}
 
 	ui.Message("Disabling VNC server...")

--- a/builder/vmware/common/step_output_dir.go
+++ b/builder/vmware/common/step_output_dir.go
@@ -60,15 +60,18 @@ func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 		dir := state.Get("dir").(OutputDir)
 		ui := state.Get("ui").(packer.Ui)
 
-		ui.Say("Deleting output directory...")
-		for i := 0; i < 5; i++ {
-			err := dir.RemoveAll()
-			if err == nil {
-				break
-			}
+		exists, _ := dir.DirExists()
+		if exists {
+			ui.Say("Deleting output directory...")
+			for i := 0; i < 5; i++ {
+				err := dir.RemoveAll()
+				if err == nil {
+					break
+				}
 
-			log.Printf("Error removing output dir: %s", err)
-			time.Sleep(2 * time.Second)
+				log.Printf("Error removing output dir: %s", err)
+				time.Sleep(2 * time.Second)
+			}
 		}
 	}
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -40,6 +40,7 @@ type Config struct {
 	DiskSize            uint     `mapstructure:"disk_size"`
 	DiskTypeId          string   `mapstructure:"disk_type_id"`
 	FloppyFiles         []string `mapstructure:"floppy_files"`
+	Format              string   `mapstruture:"format"`
 	GuestOSType         string   `mapstructure:"guest_os_type"`
 	ISOChecksum         string   `mapstructure:"iso_checksum"`
 	ISOChecksumType     string   `mapstructure:"iso_checksum_type"`
@@ -235,6 +236,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	default:
 		dir = new(vmwcommon.LocalOutputDir)
 	}
+	if b.config.RemoteType != "" && b.config.Format != "" {
+		b.config.OutputDir = b.config.VMName
+	}
 	dir.SetOutputDir(b.config.OutputDir)
 
 	// Setup the state bag
@@ -289,7 +293,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			VNCPortMin: b.config.VNCPortMin,
 			VNCPortMax: b.config.VNCPortMax,
 		},
-		&StepRegister{},
+		&StepRegister{
+			Format: b.config.Format,
+		},
 		&vmwcommon.StepRun{
 			BootWait:           b.config.BootWait,
 			DurationBeforeStop: 5 * time.Second,
@@ -328,6 +334,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},
+		&StepExport{
+			Format: b.config.Format,
+		},
 	}
 
 	// Run!
@@ -357,7 +366,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	// Compile the artifact list
-	files, err := state.Get("dir").(OutputDir).ListFiles()
+	var files []string
+	if b.config.RemoteType != "" {
+		dir = new(vmwcommon.LocalOutputDir)
+		dir.SetOutputDir(b.config.OutputDir)
+		files, err = dir.ListFiles()
+	} else {
+		files, err = state.Get("dir").(OutputDir).ListFiles()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -104,6 +104,18 @@ func (d *ESX5Driver) Unregister(vmxPathLocal string) error {
 	return d.sh("vim-cmd", "vmsvc/unregister", d.vmId)
 }
 
+func (d *ESX5Driver) Destroy() error {
+	return d.sh("vim-cmd", "vmsvc/destroy", d.vmId)
+}
+
+func (d *ESX5Driver) IsDestroyed() (bool, error) {
+	err := d.sh("test", "!", "-e", d.outputDir)
+	if err != nil {
+		return false, err
+	}
+	return true, err
+}
+
 func (d *ESX5Driver) UploadISO(localPath string, checksum string, checksumType string) (string, error) {
 	finalPath := d.cachePath(localPath)
 	if err := d.mkdir(filepath.ToSlash(filepath.Dir(finalPath))); err != nil {

--- a/builder/vmware/iso/remote_driver.go
+++ b/builder/vmware/iso/remote_driver.go
@@ -18,6 +18,12 @@ type RemoteDriver interface {
 	// Removes a VM from inventory specified by the path to the VMX given.
 	Unregister(string) error
 
+	// Destroys a VM
+	Destroy() error
+
+	// Checks if the VM is destroyed.
+	IsDestroyed() (bool, error)
+
 	// Uploads a local file to remote side.
 	upload(dst, src string) error
 

--- a/builder/vmware/iso/remote_driver_mock.go
+++ b/builder/vmware/iso/remote_driver_mock.go
@@ -20,6 +20,13 @@ type RemoteDriverMock struct {
 	UnregisterPath   string
 	UnregisterErr    error
 
+	DestroyCalled bool
+	DestroyErr    error
+
+	IsDestroyedCalled bool
+	IsDestroyedResult bool
+	IsDestroyedErr    error
+
 	uploadErr error
 
 	ReloadVMErr error
@@ -41,6 +48,16 @@ func (d *RemoteDriverMock) Unregister(path string) error {
 	d.UnregisterCalled = true
 	d.UnregisterPath = path
 	return d.UnregisterErr
+}
+
+func (d *RemoteDriverMock) Destroy() error {
+	d.DestroyCalled = true
+	return d.DestroyErr
+}
+
+func (d *RemoteDriverMock) IsDestroyed() (bool, error) {
+	d.DestroyCalled = true
+	return d.IsDestroyedResult, d.IsDestroyedErr
 }
 
 func (d *RemoteDriverMock) upload(dst, src string) error {

--- a/builder/vmware/iso/step_export.go
+++ b/builder/vmware/iso/step_export.go
@@ -1,0 +1,74 @@
+package iso
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type StepExport struct {
+	Format string
+}
+
+func (s *StepExport) Run(state multistep.StateBag) multistep.StepAction {
+	c := state.Get("config").(*Config)
+	ui := state.Get("ui").(packer.Ui)
+
+	if c.RemoteType != "esx5" || s.Format == "" {
+		return multistep.ActionContinue
+	}
+
+	ovftool := "ovftool"
+	if runtime.GOOS == "windows" {
+		ovftool = "ovftool.exe"
+	}
+
+	if _, err := exec.LookPath(ovftool); err != nil {
+		err := fmt.Errorf("Error %s not found: %s", ovftool, err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Export the VM
+	outputPath := filepath.Join(c.VMName, c.VMName+"."+s.Format)
+
+	if s.Format == "ova" {
+		os.MkdirAll(outputPath, 0755)
+	}
+
+	args := []string{
+		"--noSSLVerify=true",
+		"--skipManifestCheck",
+		"-tt=" + s.Format,
+		"vi://" + c.RemoteUser + ":" + url.QueryEscape(c.RemotePassword) + "@" + c.RemoteHost + "/" + c.VMName,
+		outputPath,
+	}
+
+	ui.Say("Exporting virtual machine...")
+	ui.Message(fmt.Sprintf("Executing: %s %s", ovftool, strings.Join(args, " ")))
+	var out bytes.Buffer
+	cmd := exec.Command(ovftool, args...)
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		err := fmt.Errorf("Error exporting virtual machine: %s\n%s\n", err, out.String())
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	ui.Message(fmt.Sprintf("%s", out.String()))
+
+	state.Put("exportPath", outputPath)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepExport) Cleanup(state multistep.StateBag) {}

--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -398,6 +398,10 @@ modify as well:
 
 -   `remote_password` - The SSH password for access to the remote machine.
 
+-   `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
+    format of the exported virtual machine. This defaults to "ovf".
+    Before using this option, you need to install `ovftool`.
+
 ### Using a Floppy for Linux kickstart file or preseed
 
 Depending on your network configuration, it may be difficult to use packer's


### PR DESCRIPTION
Add step_export to builder/vmware-esxi.
Packer exports ovf or ova files from ESXi with ovftool, only if `format` option exists in template.json.
This p-r related to #1577, but doesn't change existing behaviors.