### PR TITLE
Adds a -artifact-output-file option to save the ami_id (ref #1701)

### DIFF
--- a/common/command/build_flags.go
+++ b/common/command/build_flags.go
@@ -13,6 +13,7 @@ func BuildOptionFlags(fs *flag.FlagSet, f *BuildOptions) {
 	fs.Var((*SliceValue)(&f.Only), "only", "only build the given builds by name")
 	fs.Var((*userVarValue)(&f.UserVars), "var", "specify a user variable")
 	fs.Var((*AppendSliceValue)(&f.UserVarFiles), "var-file", "file with user variables")
+	fs.StringVar(&f.ArtifactOutputFile, "artifact-output-file", "", "Filename where to store the created instance id")
 }
 
 // userVarValue is a flag.Value that parses out user variables in

--- a/common/command/build_flags_test.go
+++ b/common/command/build_flags_test.go
@@ -19,6 +19,7 @@ func TestBuildOptionFlags(t *testing.T) {
 		"-var=foo=bang",
 		"-var-file=foo",
 		"-var-file=bar",
+		"-artifact-output-file=ami_id",
 	}
 
 	err := fs.Parse(args)
@@ -51,6 +52,10 @@ func TestBuildOptionFlags(t *testing.T) {
 	expected = []string{"foo", "bar"}
 	if !reflect.DeepEqual(opts.UserVarFiles, expected) {
 		t.Fatalf("bad: %#v", opts.UserVarFiles)
+	}
+
+	if opts.ArtifactOutputFile != "ami_id" {
+		t.Fatalf("bad: %#v", opts.ArtifactOutputFile)
 	}
 }
 

--- a/common/command/template.go
+++ b/common/command/template.go
@@ -17,6 +17,7 @@ type BuildOptions struct {
 	UserVars     map[string]string
 	Except       []string
 	Only         []string
+	ArtifactOutputFile string
 }
 
 // Validate validates the options


### PR DESCRIPTION
As seen in #1701 or [parse AMI id from packer output](https://groups.google.com/forum/#!topic/packer-tool/FjwlZU2lo3g), a decent amount of people need to easily get the ami_id after generation.
Right now it's not very convenient to get (need to parse the output).
This pull request adds a -artifact-output-file parameter to the build command.
Now a call to `packer build -artifact-output-file=ami_id packer.json` will generate the ami and save the ami's id in the file ami_id.
