### PR TITLE
Added support to allow either manifest_dir or manifest_file with puppet

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -172,15 +172,20 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		}
 	}
 
-	if p.config.ManifestFile == "" {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("A manifest_file must be specified."))
-	} else {
-		_, err := os.Stat(p.config.ManifestFile)
+	if p.config.ManifestFile != "" {
+		info, err := os.Stat(p.config.ManifestFile)
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("manifest_file is invalid: %s", err))
+		} else if info.IsDir() {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("manifest_file must point to a regular file"))			
 		}
+	}
+
+	if p.config.ManifestFile == "" && p.config.ManifestDir == "" {
+		errs = packer.MultiErrorAppend(errs,
+			fmt.Errorf("one of manifest_file or manifest_dir must be specified"))
 	}
 
 	for i, path := range p.config.ModulePaths {
@@ -242,10 +247,16 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		modulePaths = append(modulePaths, targetPath)
 	}
 
-	// Upload manifests
-	remoteManifestFile, err := p.uploadManifests(ui, comm)
-	if err != nil {
-		return fmt.Errorf("Error uploading manifests: %s", err)
+	// Upload manifest file if set
+	remoteManifestFile := ""
+	var err error
+	if p.config.ManifestFile != "" {
+		remoteManifestFile, err = p.uploadManifests(ui, comm)
+		if err != nil {
+			return fmt.Errorf("Error uploading manifests: %s", err)
+		}
+	} else {
+		remoteManifestFile = remoteManifestDir
 	}
 
 	// Compile the facter variables
@@ -313,7 +324,6 @@ func (p *Provisioner) uploadManifests(ui packer.Ui, comm packer.Communicator) (s
 		return "", fmt.Errorf("Error creating manifests directory: %s", err)
 	}
 
-	// Upload the main manifest
 	f, err := os.Open(p.config.ManifestFile)
 	if err != nil {
 		return "", err
@@ -321,6 +331,7 @@ func (p *Provisioner) uploadManifests(ui packer.Ui, comm packer.Communicator) (s
 	defer f.Close()
 
 	manifestFilename := filepath.Base(p.config.ManifestFile)
+
 	remoteManifestFile := fmt.Sprintf("%s/%s", remoteManifestsPath, manifestFilename)
 	if err := comm.Upload(remoteManifestFile, f, nil); err != nil {
 		return "", err

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -40,9 +40,19 @@ The reference of available configuration options is listed below.
 
 Required parameters:
 
+At least one of manifest_file or manifest_dir must be specified, but both are
+not required.
+
 * `manifest_file` (string) - The manifest file for Puppet to use in order
   to compile and run a catalog. This file must exist on your local system
   and will be uploaded to the remote machine.
+
+* `manifest_dir` (string) - The path to a local directory with manifests
+  to be uploaded to the remote machine. This is useful if your main
+  manifest file uses imports. This directory doesn't necessarily contain
+  the `manifest_file`. It is a separate directory that will be set as
+  the "manifestdir" setting on Puppet. If you do not specify a `manifest_file`
+  puppet will apply the entire contents of `manifest_dir`.
 
 Optional parameters:
 
@@ -57,12 +67,6 @@ Optional parameters:
 * `hiera_config_path` (string) - The path to a local file with hiera
   configuration to be uploaded to the remote machine. Hiera data directories
   must be uploaded using the file provisioner separately.
-
-* `manifest_dir` (string) - The path to a local directory with manifests
-  to be uploaded to the remote machine. This is useful if your main
-  manifest file uses imports. This directory doesn't necessarily contain
-  the `manifest_file`. It is a separate directory that will be set as
-  the "manifestdir" setting on Puppet.
 
 * `module_paths` (array of strings) - This is an array of paths to module
   directories on your local filesystem. These will be uploaded to the remote


### PR DESCRIPTION
My proposed patch will accept either manifest_file or manifest_dir, and do the right thing depending on which one you use. It reinstates the requirement that manifest_file actually be a file, and that you use manifest_dir when applying an entire directory. If manifest_dir and manifest_file are set, it will apply manifest_file.

Updated provisioner parameters:

    {
      "type": "puppet-masterless",
      "manifest_dir": "nubis-puppet/manifests",
      "module_paths": ["nubis-puppet/modules"]
    }

Resulting packer build output:

    amazon-us-west-2: Running Puppet:   sudo -E puppet apply --verbose --modulepath='/tmp/packer-puppet-masterless/module-0' --manifestdir='/tmp/packer-puppet-masterless/manifests' --detailed-exitcodes /tmp/packer-puppet-masterless/manifests

Fixes #1933 