### PR TITLE
Fix docker push

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -19,6 +19,9 @@ type Config struct {
 	LoginPassword string `mapstructure:"login_password"`
 	LoginServer   string `mapstructure:"login_server"`
 
+	Repository    string `mapstructure:"repository"`
+	Tag           string `mapstructure:"tag"`
+
 	tpl *packer.ConfigTemplate
 }
 
@@ -104,7 +107,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// Get the name. We strip off any tags from the name because the
 	// push doesn't use those.
-	name := artifact.Id()
+	//name := artifact.Id()
+
+	name := p.config.Repository
+	if p.config.Tag != "" {
+		name += ":" + p.config.Tag
+	}
+
+	ui.Message("name is: " + name)
 
 	if i := strings.Index(name, "/"); i >= 0 {
 		// This should always be true because the / is required. But we have


### PR DESCRIPTION
Hi,

I encountered issues for Docker push. Because it tries to push an image ID instead of the image name with tag name. I tried this simple configuration:
```
{
    "variables": {
        "debian_release_name": "jessie",
        "ansible_inventory_file": "packer_hosts",
        "ansible_environment": "dev",
        "role_name": "undef",
        "image_version": "undef",
        "debug_level": ""
    },
  "builders": [
    {
      "type": "docker",
      "image": "debian:{{user `debian_release_name`}}",
      "commit": true
    }
  ],
  "post-processors": [
    {
      "type": "docker-tag",
      "repository": "registry.fqdn.lan/nm",
      "tag": "dj-{{user `role_name`}}-{{user `ansible_environment`}}-{{user `image_version`}}"
    },
    {
      "type": "docker-push",
      "login": true,
      "login_email": "jenkins@fqdn.com",
      "login_username": "jenkins",
      "login_password": "jenkins",
      "login_server": "registry.fqdn.lan"
    }
  ]
}
```
But when I run it, I got this issue:
```
docker output will be in this color.

==> docker: Creating a temporary directory for sharing data...
==> docker: Pulling Docker image: debian:jessie
    docker: Pulling repository debian
    docker: Status: Image is up to date for debian:jessie
==> docker: Starting docker container...
    docker: Run command: docker run -v /tmp/packer-docker929050171:/packer-files -d -i -t debian:jessie /bin/bash
    docker: Container ID: cd41609ea83135b114cf25e5e845e8911ce48a9f49ca1fbe26ca8323a767e22c
==> docker: Committing the container
    docker: Image ID: 7bf7989e82fcc526a4c1ee53fa4613c815b3ce83fac105229624896b33d400b9
==> docker: Killing the container: cd41609ea83135b114cf25e5e845e8911ce48a9f49ca1fbe26ca8323a767e22c
==> docker: Running post-processor: docker-tag
    docker (docker-tag): Tagging image: 7bf7989e82fcc526a4c1ee53fa4613c815b3ce83fac105229624896b33d400b9
    docker (docker-tag): Repository: registry.fqdn.lan/nm:dj-common-dev-undef
==> docker: Running post-processor: docker-push
    docker (docker-push): Logging in...
    docker (docker-push): Account created. Please see the documentation of the registry https://registry.fqdn.lan/v1/ for instructions how to activate it.
    docker (docker-push): Pushing: 7bf7989e82fcc526a4c1ee53fa4613c815b3ce83fac105229624896b33d400b9
    docker (docker-push): 2015/02/21 13:41:21 Invalid repository name (7bf7989e82fcc526a4c1ee53fa4613c815b3ce83fac105229624896b33d400b9), cannot specify 64-byte hexadecimal strings
    docker (docker-push): Logging out...
    docker (docker-push): Remove login credentials for registry.fqdn.lan
Build 'docker' errored: 1 error(s) occurred:

* Post-processor failed: Bad exit status: 1

==> Some builds didn't complete successfully and had errors:
--> docker: 1 error(s) occurred:

* Post-processor failed: Bad exit status: 1

==> Builds finished but no artifacts were created.
```

Here is a workaround to get it working. Here is the configuration I used for it:
```
    {
      "type": "docker-push",
      "login": true,
      "login_email": "jenkins@fqdn.com",
      "login_username": "jenkins",
      "login_password": "jenkins",
      "login_server": "registry.fqdn.lan",
      "repository": "registry.fqdn.lan/nm",
      "tag": "dj-{{user `role_name`}}-{{user `ansible_environment`}}-{{user `image_version`}}"
    }
```

Note: it really would be great if you could add more examples in the documentation to avoid parsing the code to find how it really works.

Thanks in advance