### PR TITLE
Add step in qemu builder to convert volume to sparse image

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -464,6 +464,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		new(common.StepProvision),
 		new(stepShutdown),
+		new(stepPackDisk),
 	}
 
 	// Setup the state bag

--- a/builder/qemu/step_pack_disk.go
+++ b/builder/qemu/step_pack_disk.go
@@ -1,0 +1,57 @@
+package qemu
+
+import (
+	"os"
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"path/filepath"
+	"strings"
+)
+
+// This step packs the image by removing unallocated disk space
+type stepPackDisk struct{}
+
+func (s *stepPackDisk) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName,
+		strings.ToLower(config.Format)))
+    newpath := fmt.Sprintf("%v.conv", path)
+
+	command := []string{
+		"convert",
+        "-c",
+		"-f", config.Format,
+		"-O", config.Format,
+		path,
+		newpath,
+	}
+
+	ui.Say("Packing image")
+	if err := driver.QemuImg(command...); err != nil {
+		err := fmt.Errorf("Error packing image: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if err := os.Remove(path); err != nil {
+		err := fmt.Errorf("Error deleting old image: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if err := os.Rename(newpath, path); err != nil {
+		err := fmt.Errorf("Error renaming image: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepPackDisk) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
The current QEMU builder produces very large images because they're not sparsified. It tends to slow the whole process (for instance, creating and compressing a Vagrant image). This pull request adds a step to call `qemu-img` at the end of the build.

For this to work, you need to zero out free space as the last provisioning step with a script similar to:
``` bash
# Zero out the free space to save space in the final image
dd if=/dev/zero of=/EMPTY bs=1M || :
rm -f /EMPTY
```