### PR TITLE
Fix statement in machine-readable 'ui' type docs.

### DIFF
--- a/website/source/docs/machine-readable/general.html.markdown
+++ b/website/source/docs/machine-readable/general.html.markdown
@@ -15,7 +15,7 @@ machine-readable output and are provided by Packer core itself.
 	<dd>
 		<p>
 		Specifies the output and type of output that would've normally
-		gone to the console if Packer wasn't running in human-readable
+		gone to the console if Packer were running in human-readable
 		mode.
 		</p>
 


### PR DESCRIPTION
The text previously stated that "ui"-type messages represent messages that would be shown if Packer is *not* running in human-readable mode.

This is rather talking about what would happen when Packer *is* using human-readable mode.