### PR TITLE
Add auto discovery of AZ based on the subnet

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -165,6 +165,17 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	ec2conn := ec2.New(auth, region)
 
+	// If the subnet is specified but not the AZ, try to determine the AZ automatically
+	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
+		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+		resp, err := ec2conn.DescribeSubnets([]string{b.config.SubnetId}, nil)
+		if err != nil {
+			return nil, err
+		}
+		b.config.AvailabilityZone = resp.Subnets[0].AvailabilityZone
+		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+	}
+
 	wrappedCommand := func(command string) (string, error) {
 		return b.config.tpl.Process(
 			b.config.CommandWrapper, &wrappedCommandTemplate{

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -75,6 +75,17 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	ec2conn := ec2.New(auth, region)
 
+	// If the subnet is specified but not the AZ, try to determine the AZ automatically
+	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
+		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+		resp, err := ec2conn.DescribeSubnets([]string{b.config.SubnetId}, nil)
+		if err != nil {
+			return nil, err
+		}
+		b.config.AvailabilityZone = resp.Subnets[0].AvailabilityZone
+		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+	}
+
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", b.config)

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -180,6 +180,17 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	ec2conn := ec2.New(auth, region)
 
+	// If the subnet is specified but not the AZ, try to determine the AZ automatically
+	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
+		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+		resp, err := ec2conn.DescribeSubnets([]string{b.config.SubnetId}, nil)
+		if err != nil {
+			return nil, err
+		}
+		b.config.AvailabilityZone = resp.Subnets[0].AvailabilityZone
+		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+	}
+
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)


### PR DESCRIPTION
Automatically set the AZ, for features such as spot auto pricing, when the subnet has been specified.

Fixes #1956