### PR TITLE
post-processor/atlas: fix index out of range panic

### DIFF
--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -178,7 +178,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 			// Modify the archive options to only include the files
 			// that are in our file list.
-			include := make([]string, 0, len(fs))
+			include := make([]string, len(fs))
 			for i, f := range fs {
 				include[i] = strings.Replace(f, path, "", 1)
 			}


### PR DESCRIPTION
Fixes a panic in the atlas post-processor when a build contains artifacts. The trace is available here:
https://gist.github.com/ryanuber/1bb37c5bb34ef9c32ade