### PR TITLE
Better error reporting when a config key in template is Unknown

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -33,7 +33,7 @@ func CheckUnusedConfig(md *mapstructure.Metadata) *packer.MultiError {
 		for _, unused := range md.Unused {
 			if unused != "type" && !strings.HasPrefix(unused, "packer_") {
 				errs = append(
-					errs, fmt.Errorf("Unknown configuration key: %s", unused))
+					errs, fmt.Errorf("Unknown configuration key: %q", unused))
 			}
 		}
 	}


### PR DESCRIPTION
This patch will allow to fix the following bug much faster:

```
1 error(s) occurred:

* Unknown configuration key: output_directory
```

Related configuration:

```
"output_directory ": "build/sl_base/",
```

After the patch, the error reporting will be:

```
1 error(s) occurred:

* Unknown configuration key: "output_directory "
```