### PR TITLE
do not request a pty

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -349,7 +349,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHAddress:     driver.SSHAddress,
 			SSHConfig:      vmwcommon.SSHConfigFunc(&b.config.SSHConfig),
 			SSHWaitTimeout: b.config.SSHWaitTimeout,
-			NoPty:          b.config.SSHSkipRequestPty,
+			Pty:            !b.config.SSHSkipRequestPty,
 		},
 		&vmwcommon.StepUploadTools{
 			RemoteType:        b.config.RemoteType,

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -334,7 +334,6 @@ func (d *ESX5Driver) connect() error {
 			User: d.Username,
 			Auth: auth,
 		},
-		NoPty: true,
 	}
 
 	comm, err := ssh.New(address, sshConfig)

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -94,7 +94,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHAddress:     driver.SSHAddress,
 			SSHConfig:      vmwcommon.SSHConfigFunc(&b.config.SSHConfig),
 			SSHWaitTimeout: b.config.SSHWaitTimeout,
-			NoPty:          b.config.SSHSkipRequestPty,
+			Pty:            !b.config.SSHSkipRequestPty,
 		},
 		&vmwcommon.StepUploadTools{
 			RemoteType:        b.config.RemoteType,

--- a/common/step_connect_ssh.go
+++ b/common/step_connect_ssh.go
@@ -34,8 +34,8 @@ type StepConnectSSH struct {
 	// SSHWaitTimeout is the total timeout to wait for SSH to become available.
 	SSHWaitTimeout time.Duration
 
-	// NoPty, if true, will not request a Pty from the remote end.
-	NoPty bool
+	// Pty, if true, will request a Pty from the remote end.
+	Pty bool
 
 	comm packer.Communicator
 }
@@ -138,7 +138,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 		config := &ssh.Config{
 			Connection: connFunc,
 			SSHConfig:  sshConfig,
-			NoPty:      s.NoPty,
+			Pty:        s.Pty,
 		}
 
 		log.Println("Attempting SSH connection...")

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -33,8 +33,8 @@ type Config struct {
 	// case an error occurs.
 	Connection func() (net.Conn, error)
 
-	// NoPty, if true, will not request a pty from the remote end.
-	NoPty bool
+	// Pty, if true, will request a pty from the remote end.
+	Pty bool
 }
 
 // Creates a new packer.Communicator implementation over SSH. This takes
@@ -65,7 +65,7 @@ func (c *comm) Start(cmd *packer.RemoteCmd) (err error) {
 	session.Stdout = cmd.Stdout
 	session.Stderr = cmd.Stderr
 
-	if !c.config.NoPty {
+	if c.config.Pty {
 		// Request a PTY
 		termModes := ssh.TerminalModes{
 			ssh.ECHO:          0,     // do not echo


### PR DESCRIPTION
Change the default behavior from requesting a PTY when executing a
command with the ssh communicator to requesting a PTY only when
configured to do so.

Update the vmware builders to be fully backward compatible with the new
behavior.

This PR replaces #1920, which was closed accidentally when I force pushed onto `bhcleek/packer master`.