### PR TITLE
Corrected invalid boot command section for Parallels, Virtualbox, and VMware ISO builders

### DIFF
--- a/website/source/docs/builders/parallels-iso.html.markdown
+++ b/website/source/docs/builders/parallels-iso.html.markdown
@@ -267,7 +267,7 @@ an Ubuntu 12.04 installer:
   "fb=false debconf/frontend=noninteractive ",
   "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
   "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-  "initrd=/install/initrd.gz -- &lt;enter&gt;"
+  "initrd=/install/initrd.gz -- <enter>;"
 ]
 ```
 

--- a/website/source/docs/builders/parallels-iso.html.markdown
+++ b/website/source/docs/builders/parallels-iso.html.markdown
@@ -257,9 +257,9 @@ The available variables are:
 Example boot command. This is actually a working boot command used to start
 an Ubuntu 12.04 installer:
 
-```javascript
+```text
 [
-  "&lt;esc&gt;&lt;esc&gt;&lt;enter&gt;&lt;wait&gt;",
+  "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",
   "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
   "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",

--- a/website/source/docs/builders/virtualbox-iso.html.markdown
+++ b/website/source/docs/builders/virtualbox-iso.html.markdown
@@ -283,7 +283,7 @@ The available variables are:
 Example boot command. This is actually a working boot command used to start
 an Ubuntu 12.04 installer:
 
-```
+```text
 [
   "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",

--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -311,7 +311,7 @@ The available variables are:
 Example boot command. This is actually a working boot command used to start
 an Ubuntu 12.04 installer:
 
-```
+```text
 [
   "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",


### PR DESCRIPTION
Trying to parse as text, previously was javascript, something in the markdown to HTML for the site may still be affecting this.