### PR TITLE
builder/docker: Run scripts /w `exec` if -v > 1.4

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/ActiveState/tail"
+	"github.com/hashicorp/go-version"
 	"github.com/mitchellh/packer/packer"
 )
 
@@ -24,6 +26,27 @@ type Communicator struct {
 	ContainerDir string
 
 	lock sync.Mutex
+}
+
+var dockerVersion version.Version
+var useDockerExec bool
+
+func init() {
+	execConstraint, _ := version.NewConstraint(">= 1.4.0")
+
+	versionExtractor := regexp.MustCompile(version.VersionRegexpRaw)
+	dockerVersionOutput, _ := exec.Command("docker", "-v").Output()
+	dockerVersionString := string(versionExtractor.FindSubmatch(dockerVersionOutput)[0])
+
+	dockerVersion, err := version.NewVersion(dockerVersionString)
+	if err != nil {
+		log.Printf("Docker returned malformed version string: %e", err)
+		log.Printf("Assuming no `exec` capability, using `attatch`")
+		useDockerExec = false
+	} else {
+		log.Printf("Docker version detected as %s", dockerVersion)
+		useDockerExec = execConstraint.Check(dockerVersion)
+	}
 }
 
 func (c *Communicator) Start(remote *packer.RemoteCmd) error {
@@ -41,7 +64,13 @@ func (c *Communicator) Start(remote *packer.RemoteCmd) error {
 	// This file will store the exit code of the command once it is complete.
 	exitCodePath := outputFile.Name() + "-exit"
 
-	cmd := exec.Command("docker", "attach", c.ContainerId)
+	var cmd *exec.Cmd
+	if useDockerExec {
+		cmd = exec.Command("docker", "exec", "-i", c.ContainerId, "/bin/sh")
+	} else {
+		cmd = exec.Command("docker", "attach", c.ContainerId)
+	}
+
 	stdin_w, err := cmd.StdinPipe()
 	if err != nil {
 		// We have to do some cleanup since run was never called


### PR DESCRIPTION
Per @mariussturm in #1752, using `docker exec` with a new shell works where
`docker attatch` fails in newer versions of Docker.

In principal attatch should work, so that's a seperate bug; but I would argue
the new subshell semantics are more preferable where avaliable anyway.

This commit reworks his patch to only apply to versions with exec, so as to not be
a breaking change. I could also see a case for making it a config; but only once
attatch works again.

Fixes #1752

(Re: #1975, using my explicit shell provisioner that installs chef and then chef-sugar, everything works
fine. In testing without 'skip_install' the contents of /packer-files in the container reflect successful
installation (including 0 in, in my case, `/packer-files/cmd372804478-exit`); there must be something wrong
with the chef-provisioner as well.