### PR TITLE
code.google.com/p/go.crypto/ssh -> golang.org/x/crypto/ssh

### DIFF
--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"errors"
 	"fmt"
 	"github.com/mitchellh/goamz/ec2"

--- a/builder/digitalocean/ssh.go
+++ b/builder/digitalocean/ssh.go
@@ -1,7 +1,7 @@
 package digitalocean
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"fmt"
 	"github.com/mitchellh/multistep"
 )

--- a/builder/googlecompute/ssh.go
+++ b/builder/googlecompute/ssh.go
@@ -1,7 +1,7 @@
 package googlecompute
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"fmt"
 	"github.com/mitchellh/multistep"
 )

--- a/builder/null/ssh.go
+++ b/builder/null/ssh.go
@@ -1,7 +1,7 @@
 package null
 
 import (
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/communicator/ssh"

--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -1,7 +1,7 @@
 package openstack
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"errors"
 	"fmt"
 	"github.com/mitchellh/multistep"

--- a/builder/parallels/common/ssh.go
+++ b/builder/parallels/common/ssh.go
@@ -3,7 +3,7 @@ package common
 import (
 	"fmt"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"github.com/mitchellh/multistep"
 	commonssh "github.com/mitchellh/packer/common/ssh"
 	packerssh "github.com/mitchellh/packer/communicator/ssh"

--- a/builder/qemu/ssh.go
+++ b/builder/qemu/ssh.go
@@ -3,7 +3,7 @@ package qemu
 import (
 	"fmt"
 
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"github.com/mitchellh/multistep"
 	commonssh "github.com/mitchellh/packer/common/ssh"
 	"github.com/mitchellh/packer/communicator/ssh"

--- a/builder/virtualbox/common/ssh.go
+++ b/builder/virtualbox/common/ssh.go
@@ -3,7 +3,7 @@ package common
 import (
 	"fmt"
 
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"github.com/mitchellh/multistep"
 	commonssh "github.com/mitchellh/packer/common/ssh"
 	"github.com/mitchellh/packer/communicator/ssh"

--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"github.com/mitchellh/multistep"
 	commonssh "github.com/mitchellh/packer/common/ssh"
 	"github.com/mitchellh/packer/communicator/ssh"

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -3,7 +3,7 @@ package iso
 import (
 	"bufio"
 	"bytes"
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"encoding/csv"
 	"errors"
 	"fmt"

--- a/common/ssh/key.go
+++ b/common/ssh/key.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 )
 
 // FileSigner returns an ssh.Signer for a key file.

--- a/common/step_connect_ssh.go
+++ b/common/step_connect_ssh.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	gossh "code.google.com/p/go.crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
 	"errors"
 	"fmt"
 	"github.com/mitchellh/multistep"

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -3,7 +3,7 @@ package ssh
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"errors"
 	"fmt"
 	"github.com/mitchellh/packer/packer"

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -4,7 +4,7 @@ package ssh
 
 import (
 	"bytes"
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"fmt"
 	"github.com/mitchellh/packer/packer"
 	"net"

--- a/communicator/ssh/password.go
+++ b/communicator/ssh/password.go
@@ -1,7 +1,7 @@
 package ssh
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"log"
 )
 

--- a/communicator/ssh/password_test.go
+++ b/communicator/ssh/password_test.go
@@ -1,7 +1,7 @@
 package ssh
 
 import (
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
code.google.com/p/go.crypto/ssh is now at golang.org/x/crypto/ssh as of
https://code.google.com/p/go/source/detail?spec=svn.crypto.69e2a90ed92d03812364aeb947b7068dc42e561e&repo=crypto&r=8fec09c61d5d66f460d227fd1df3473d7e015bc6

Using the code.google.com import redirects properly, but runs into
issues if you try to use a subpackage of `ssh`, e.g. `agent` which
refers to golang.org/x/crypto/ssh causing conflicts if your types expect
code.google.com/p/go.crypto/ssh types.

This is a precursor to a PR for #1066.