### PR TITLE
Report error during Temporary Security Group creation in AWS EBS builder

### DIFF
--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -44,6 +44,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	groupResp, err := ec2conn.CreateSecurityGroup(group)
 	if err != nil {
 		ui.Error(err.Error())
+		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 


### PR DESCRIPTION
Fixes #2021 where an exit code 0 is returned to the user instead of 1 when there is an error during the Temporary Security Group creation.