### PR TITLE
Support option for client_key in chef-client provisioner

### DIFF
--- a/website/source/docs/provisioners/chef-client.html.markdown
+++ b/website/source/docs/provisioners/chef-client.html.markdown
@@ -88,6 +88,9 @@ configuration is actually required.
   this folder. If the permissions are not correct, use a shell provisioner
   prior to this to configure it properly.
 
+* `client_key` (string) - Path to client key. If not set, this defaults to a file
+  named client.pem in `staging_directory`.
+
 * `validation_client_name` (string) - Name of the validation client. If
   not set, this won't be set in the configuration and the default that Chef
   uses will be used.


### PR DESCRIPTION
When creating an image based on CentOS 7, which uses the centos user instead of root, I had difficulty using the chef-client provisioner correctly due to permissions issues, and the workarounds in https://github.com/mitchellh/packer/issues/1054 were a bit too hacky.

This PR adds `client_key` to client.rb, and defaults it to be in `staging_directory`.  For my purposes, by setting `"staging_directory": "/tmp"`, I was able to successfully complete a Chef run without permissions issues.  This can, of course, be used for other cases than mine, and allows for the ability to use something other than /etc/chef/client.pem.
