### PR TITLE
Changes date example in isotime

### DIFF
--- a/website/source/docs/templates/configuration-templates.html.markdown
+++ b/website/source/docs/templates/configuration-templates.html.markdown
@@ -116,7 +116,7 @@ Formatting for the function `isotime` uses the magic reference date
 isotime = June 7, 7:22:43pm 2014
 
 {{isotime "2006-01-02"}} = 2014-06-07
-{{isotime "Mon 1506"}} = Sat 1914
+{{isotime "Mon 1504"}} = Sat 1922
 {{isotime "01-Jan-06 03\_04\_05"}} = 07-Jun-2014 07\_22\_43
 {{isotime "Hour15Year200603"}} = Hour19Year201407
 ```


### PR DESCRIPTION
The example of using 1506 doesn't make much sense since 15 is the hour and 06 is the year. 
Using HHMM is a more intuitive example