### PR TITLE
Try another ssh port if the current one is taken.

### DIFF
--- a/builder/qemu/step_forward_ssh.go
+++ b/builder/qemu/step_forward_ssh.go
@@ -34,12 +34,17 @@ func (s *stepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 
 	for {
 		sshHostPort = offset + config.SSHHostPortMin
+		if sshHostPort >= config.SSHHostPortMax {
+			offset = 0
+			sshHostPort = config.SSHHostPortMin
+		}
 		log.Printf("Trying port: %d", sshHostPort)
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", sshHostPort))
 		if err == nil {
 			defer l.Close()
 			break
 		}
+		offset++
 	}
 	ui.Say(fmt.Sprintf("Found port for SSH: %d.", sshHostPort))
 

--- a/builder/virtualbox/common/step_forward_ssh.go
+++ b/builder/virtualbox/common/step_forward_ssh.go
@@ -42,12 +42,17 @@ func (s *StepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 
 	for {
 		sshHostPort = offset + s.HostPortMin
+		if sshHostPort >= s.HostPortMax {
+			offset = 0
+			sshHostPort = s.HostPortMin
+		}
 		log.Printf("Trying port: %d", sshHostPort)
 		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", sshHostPort))
 		if err == nil {
 			defer l.Close()
 			break
 		}
+		offset++
 	}
 
 	// Create a forwarded port mapping to the VM


### PR DESCRIPTION
This is a simple fix that helps with multiple parallel qemu (or virtualbox) builds. Since the RNG does not seem to be seeded properly, the builder always comes up with the same SSH port number between min_port and max_port, so parallel builds will basically block each other, and only one will be building if they use the same port range.