### PR TITLE
Feature/qemu shrink image

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -465,6 +465,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		new(common.StepProvision),
 		new(stepShutdown),
+		new(stepShrinkDisk),
 	}
 
 	// Setup the state bag

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -92,6 +92,7 @@ type config struct {
 	OutputDir       string     `mapstructure:"output_directory"`
 	QemuArgs        [][]string `mapstructure:"qemuargs"`
 	QemuBinary      string     `mapstructure:"qemu_binary"`
+	ShrinkImage     bool	   `mapstructure:"shrink_image"`
 	ShutdownCommand string     `mapstructure:"shutdown_command"`
 	SSHHostPortMin  uint       `mapstructure:"ssh_host_port_min"`
 	SSHHostPortMax  uint       `mapstructure:"ssh_host_port_max"`

--- a/builder/qemu/step_shrink_disk.go
+++ b/builder/qemu/step_shrink_disk.go
@@ -18,9 +18,10 @@ type stepShrinkDisk struct{}
 func (s *stepShrinkDisk) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*config)
 	driver := state.Get("driver").(Driver)
-	sourcePath := state.Get("disk_filename").(string)
+	diskName := state.Get("disk_filename").(string)
 	ui := state.Get("ui").(packer.Ui)
 	name := config.VMName + ".shrink." + strings.ToLower(config.Format)
+	sourcePath := filepath.Join(config.OutputDir, diskName)
 	targetPath := filepath.Join(config.OutputDir, name)
 
 	command := []string{

--- a/builder/qemu/step_shrink_disk.go
+++ b/builder/qemu/step_shrink_disk.go
@@ -18,7 +18,7 @@ type stepShrinkDisk struct{}
 func (s *stepShrinkDisk) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*config)
 	driver := state.Get("driver").(Driver)
-	sourcePath := state.Get("disk_filename")
+	sourcePath := state.Get("disk_filename").(string)
 	ui := state.Get("ui").(packer.Ui)
 	name := config.VMName + ".shrink." + strings.ToLower(config.Format)
 	targetPath := filepath.Join(config.OutputDir, name)

--- a/builder/qemu/step_shrink_disk.go
+++ b/builder/qemu/step_shrink_disk.go
@@ -1,0 +1,50 @@
+package qemu
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step shrinks the virtual disk that was used as the
+// hard drive for the virtual machine.
+type stepShrinkDisk struct{}
+
+func (s *stepShrinkDisk) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	driver := state.Get("driver").(Driver)
+	sourcePath := state.Get("disk_filename")
+	//isoPath := state.Get("iso_path").(string)
+	ui := state.Get("ui").(packer.Ui)
+	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName,
+		strings.ToLower(config.Format)))
+	name := config.VMName + "." + strings.ToLower(config.Format)
+
+	command := []string{
+		"convert",
+		"-f", config.Format,
+		isoPath,
+		path,
+	}
+
+	if config.ShrinkImage == false {
+		return multistep.ActionContinue
+	}
+
+	ui.Say("Shrinking hard drive...")
+	if err := driver.QemuImg(command...); err != nil {
+		err := fmt.Errorf("Error creating hard drive: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	state.Put("disk_filename", name)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepShrinkDisk) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
Adds support for shrinking qemu (libvirt) images after building the VM.

 - adds new step qemu/stepShrinkDisk
 - adds new configuration option `shrink_image` to qemu builder, if true, runs `qemu-img convert` after provisioning the VM (see http://serverfault.com/a/329671 )

Ie. if provisioning clears the empty space, (`dd if=/dev/zero of=/EMPTY bs=1M && rm -f /EMPTY` before shutting down), and `shrink_image` is true, packer tries to shrink the VM image.

Caveats: building process might require 2*(the disk space of VM being created), because `qemu-img` creates clone of the disk while shrinking.