### PR TITLE
Tests were failing incorrectly when OpenStack environment variables were...

### DIFF
--- a/builder/openstack/access_config_test.go
+++ b/builder/openstack/access_config_test.go
@@ -1,8 +1,16 @@
 package openstack
 
 import (
+	"os"
 	"testing"
 )
+
+func init() {
+	// Clear out the openstack env vars so they don't
+	// affect our tests.
+	os.Setenv("SDK_REGION", "")
+	os.Setenv("OS_REGION_NAME", "")
+}
 
 func testAccessConfig() *AccessConfig {
 	return &AccessConfig{}
@@ -13,6 +21,38 @@ func TestAccessConfigPrepare_NoRegion_Rackspace(t *testing.T) {
 	c.Provider = "rackspace-us"
 	if err := c.Prepare(nil); err == nil {
 		t.Fatalf("shouldn't have err: %s", err)
+	}
+}
+
+func TestAccessConfigRegionWithEmptyEnv(t *testing.T) {
+	c := testAccessConfig()
+	c.Prepare(nil)
+	if c.Region() != "" {
+		t.Fatalf("Region should be empty")
+	}
+}
+
+func TestAccessConfigRegionWithSdkRegionEnv(t *testing.T) {
+	c := testAccessConfig()
+	c.Prepare(nil)
+
+	expectedRegion := "sdk_region"
+	os.Setenv("SDK_REGION", expectedRegion)
+	os.Setenv("OS_REGION_NAME", "")
+	if c.Region() != expectedRegion {
+		t.Fatalf("Region should be: %s", expectedRegion)
+	}
+}
+
+func TestAccessConfigRegionWithOsRegionNameEnv(t *testing.T) {
+	c := testAccessConfig()
+	c.Prepare(nil)
+
+	expectedRegion := "os_region_name"
+	os.Setenv("SDK_REGION", "")
+	os.Setenv("OS_REGION_NAME", expectedRegion)
+	if c.Region() != expectedRegion {
+		t.Fatalf("Region should be: %s", expectedRegion)
 	}
 }
 


### PR DESCRIPTION
... set in the environment running the tests

When an environment has various OpenStack-specific ENV vars defined such as OS_REGION_NAME and/or SDK_REGION the tests will fail inappropriately.
