### PR TITLE
command/push: allow specifying a -name param for push target

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -34,6 +34,7 @@ type pushUploadFn func(
 func (c *PushCommand) Run(args []string) int {
 	var token string
 	var message string
+	var name string
 	var create bool
 
 	f := flag.NewFlagSet("push", flag.ContinueOnError)
@@ -41,6 +42,7 @@ func (c *PushCommand) Run(args []string) int {
 	f.StringVar(&token, "token", "", "token")
 	f.StringVar(&message, "m", "", "message")
 	f.StringVar(&message, "message", "", "message")
+	f.StringVar(&name, "name", "", "name")
 	f.BoolVar(&create, "create", false, "create (deprecated)")
 	if err := f.Parse(args); err != nil {
 		return 1
@@ -65,11 +67,17 @@ func (c *PushCommand) Run(args []string) int {
 		return 1
 	}
 
+	// If we didn't pass name from the CLI, use the template
+	if name == "" {
+		name = tpl.Push.Name
+	}
+
 	// Validate some things
-	if tpl.Push.Name == "" {
+	if name == "" {
 		c.Ui.Error(fmt.Sprintf(
 			"The 'push' section must be specified in the template with\n" +
-				"at least the 'name' option set."))
+			"at least the 'name' option set. Alternatively, you can pass the\n" +
+			"name parameter from the CLI."))
 		return 1
 	}
 
@@ -244,6 +252,9 @@ Options:
 
   -m, -message=<detail>    A message to identify the purpose or changes in this
                            Packer template much like a VCS commit message
+
+  -name=<name>             The destination build in Atlas. This is in a format
+                           "username/name".
 
   -token=<token>           The access token to use to when uploading
 `

--- a/website/source/docs/command-line/push.html.markdown
+++ b/website/source/docs/command-line/push.html.markdown
@@ -33,6 +33,9 @@ must be completed within the template.
   service such as Atlas. This can also be specified within the push
   configuration in the template.
 
+* `-name` - The name of the build in the service. This typically
+  looks like `hashicorp/precise64`.
+
 ## Examples
 
 Push a Packer template:


### PR DESCRIPTION
This allows you to Packer push with a `-name` specified from the CLI, falling back to the push block.