### PR TITLE
Support force option for docker-tag.

### DIFF
--- a/builder/docker/driver.go
+++ b/builder/docker/driver.go
@@ -44,7 +44,7 @@ type Driver interface {
 	StopContainer(id string) error
 
 	// TagImage tags the image with the given ID
-	TagImage(id string, repo string) error
+	TagImage(id string, repo string, force bool) error
 
 	// Verify verifies that the driver can run
 	Verify() error

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -235,9 +235,15 @@ func (d *DockerDriver) StopContainer(id string) error {
 	return exec.Command("docker", "rm", id).Run()
 }
 
-func (d *DockerDriver) TagImage(id string, repo string) error {
+func (d *DockerDriver) TagImage(id string, repo string, force bool) error {
+	args := []string{"tag"}
+	if force {
+		args = append(args, "-f")
+	}
+	args = append(args, id, repo)
+
 	var stderr bytes.Buffer
-	cmd := exec.Command("docker", "tag", id, repo)
+	cmd := exec.Command("docker", args...)
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {

--- a/builder/docker/driver_mock.go
+++ b/builder/docker/driver_mock.go
@@ -44,6 +44,7 @@ type MockDriver struct {
 	TagImageCalled  bool
 	TagImageImageId string
 	TagImageRepo    string
+	TagImageForce   bool
 	TagImageErr     error
 
 	ExportReader io.Reader
@@ -151,10 +152,11 @@ func (d *MockDriver) StopContainer(id string) error {
 	return d.StopError
 }
 
-func (d *MockDriver) TagImage(id string, repo string) error {
+func (d *MockDriver) TagImage(id string, repo string, force bool) error {
 	d.TagImageCalled = true
 	d.TagImageImageId = id
 	d.TagImageRepo = repo
+	d.TagImageForce = force
 	return d.TagImageErr
 }
 

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -15,6 +15,7 @@ type Config struct {
 
 	Repository string `mapstructure:"repository"`
 	Tag        string `mapstructure:"tag"`
+	Force      bool
 
 	tpl *packer.ConfigTemplate
 }
@@ -87,7 +88,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	ui.Message("Tagging image: " + artifact.Id())
 	ui.Message("Repository: " + importRepo)
-	err := driver.TagImage(artifact.Id(), importRepo)
+	err := driver.TagImage(artifact.Id(), importRepo, p.config.Force)
 	if err != nil {
 		return nil, false, err
 	}

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -69,4 +69,47 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 	if driver.TagImageRepo != "foo:bar" {
 		t.Fatal("bad repo")
 	}
+	if driver.TagImageForce {
+		t.Fatal("bad force. force=false in default")
+	}
+}
+
+func TestPostProcessor_PostProcess_Force(t *testing.T) {
+	driver := &docker.MockDriver{}
+	p := &PostProcessor{Driver: driver}
+	config := testConfig()
+	config["force"] = true
+	_, err := common.DecodeConfig(&p.config, config)
+	if err != nil {
+		t.Fatalf("err %s", err)
+	}
+
+	artifact := &packer.MockArtifact{
+		BuilderIdValue: dockerimport.BuilderId,
+		IdValue:        "1234567890abcdef",
+	}
+
+	result, keep, err := p.PostProcess(testUi(), artifact)
+	if _, ok := result.(packer.Artifact); !ok {
+		t.Fatal("should be instance of Artifact")
+	}
+	if !keep {
+		t.Fatal("should keep")
+	}
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !driver.TagImageCalled {
+		t.Fatal("should call TagImage")
+	}
+	if driver.TagImageImageId != "1234567890abcdef" {
+		t.Fatal("bad image id")
+	}
+	if driver.TagImageRepo != "foo:bar" {
+		t.Fatal("bad repo")
+	}
+	if !driver.TagImageForce {
+		t.Fatal("bad force")
+	}
 }


### PR DESCRIPTION
This PR is for https://github.com/mitchellh/packer/issues/1923 .

In Docker v1.4, the bug about force option of `docker tag` command is fixed. Due to this fix, my packer build with already existing tag is failed after I update Docker.
(ref.) https://github.com/docker/docker/pull/8511