### PR TITLE
Remove --version from readme and fix cli test

### DIFF
--- a/test/cli.bats
+++ b/test/cli.bats
@@ -15,14 +15,6 @@ load test_helper
     run packer version
     [ "$status" -eq 0 ]
     [[ "$output" == *"Packer v"* ]]
-
-    run packer -v
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ ([0-9]+\.[0-9]+) ]]
-
-    run packer --version
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ ([0-9]+\.[0-9]+) ]]
 }
 
 @test "cli: packer version show help" {

--- a/website/source/docs/installation.html.markdown
+++ b/website/source/docs/installation.html.markdown
@@ -40,7 +40,7 @@ a new command prompt or console, and checking that `packer` is available:
 
 ```text
 $ packer
-usage: packer [--version] [--help] <command> [<args>]
+usage: packer [--help] <command> [<args>]
 
 Available commands are:
     build        build image(s) from template

--- a/website/source/intro/getting-started/setup.html.markdown
+++ b/website/source/intro/getting-started/setup.html.markdown
@@ -43,7 +43,7 @@ a new command prompt or console, and checking that `packer` is available:
 
 ```text
 $ packer
-usage: packer [--version] [--help] <command> [<args>]
+usage: packer [--help] <command> [<args>]
 
 Available commands are:
     build       build image(s) from template


### PR DESCRIPTION
`packer --version` does not work. Looks like it has been replaced with `packer version`. This updates the readmes to reflect and fixes failing `cli.bats` tests.

Before:
```
$ bats test/cli.bats
 ✓ cli: packer should show help
 ✗ cli: packer version
   (in test file test/cli.bats, line 24)
     `[ "$status" -eq 1 ]' failed
   Executing:  packer version
   Packer v0.7.5
   Executing:  packer -v
   usage: packer [--version] [--help] <command> [<args>]
   Available commands are:
       build       build image(s) from template
       fix         fixes templates from old versions of packer
       inspect     see components of a template
       push        push template files to a Packer build service
       validate    check that a template is valid
       version     Prints the Packer version
   Executing:  packer --version
   usage: packer [--version] [--help] <command> [<args>]
   Available commands are:
       build       build image(s) from template
       fix         fixes templates from old versions of packer
       inspect     see components of a template
       push        push template files to a Packer build service
       validate    check that a template is valid
       version     Prints the Packer version
 ✓ cli: packer version show help

3 tests, 1 failure
```

After:

```
$ bats test/cli.bats
 ✓ cli: packer should show help
 ✓ cli: packer version
 ✓ cli: packer version show help

3 tests, 0 failures
```