### PR TITLE
Patch for #2087

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -96,14 +96,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Networks:       b.config.Networks,
 		},
 		&StepWaitForRackConnect{
-			Wait:           b.config.RackconnectWait,
+			Wait: b.config.RackconnectWait,
 		},
 		&StepAllocateIp{
 			FloatingIpPool: b.config.FloatingIpPool,
 			FloatingIp:     b.config.FloatingIp,
 		},
 		&common.StepConnectSSH{
-			SSHAddress:     SSHAddress(csp, b.config.SSHInterface, b.config.SSHPort),
+			SSHAddress:     SSHAddress(csp, b.config.SSHInterface, b.config.SSHPort, b.config.SSHPrivateIp),
 			SSHConfig:      SSHConfig(b.config.SSHUsername),
 			SSHWaitTimeout: b.config.SSHTimeout(),
 		},

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -16,6 +16,7 @@ type RunConfig struct {
 	SSHUsername       string   `mapstructure:"ssh_username"`
 	SSHPort           int      `mapstructure:"ssh_port"`
 	SSHInterface      string   `mapstructure:"ssh_interface"`
+	SSHPrivateIp      bool     `mapstructure:"ssh_private_ip"`
 	OpenstackProvider string   `mapstructure:"openstack_provider"`
 	UseFloatingIp     bool     `mapstructure:"use_floating_ip"`
 	RackconnectWait   bool     `mapstructure:"rackconnect_wait"`


### PR DESCRIPTION
openstack output will be in this color.
 
```
==> openstack: Creating temporary keypair for this instance...
==> openstack: Waiting for server (f8fc5320-019b-44f7-91da-98104571fc60) to become ready...
==> openstack: Waiting for SSH to become available...
==> openstack: Connected to SSH!
==> openstack: Provisioning with Ansible...
    openstack: Creating Ansible staging directory...
    openstack: Creating directory: /tmp/packer-provisioner-ansible-local
    openstack:
    openstack:
    openstack: Uploading main Playbook file...
    openstack: Uploading inventory file...
    openstack: Uploading role directories...
    openstack: Creating directory: /tmp/packer-provisioner-ansible-local/roles/roles
```