### PR TITLE
doc update: no need for homebrew/binary anymore

### DIFF
--- a/website/source/docs/installation.html.markdown
+++ b/website/source/docs/installation.html.markdown
@@ -65,12 +65,9 @@ installation managed by the Packer community:
 
 ### Homebrew
 
-If you're using OS X and [Homebrew](http://brew.sh), you can install Packer by
-adding the `binary` tap. Remember that this is updated by a 3rd party, so
-it may not be the latest available version.
+If you're using OS X and [Homebrew](http://brew.sh), you can install Packer:
 
 ```text
-$ brew tap homebrew/binary
 $ brew install packer
 ```
 

--- a/website/source/intro/getting-started/setup.html.markdown
+++ b/website/source/intro/getting-started/setup.html.markdown
@@ -67,10 +67,8 @@ are alternatives available.
 
 ### Homebrew
 
-If you're using OS X and [Homebrew](http://brew.sh), you can install Packer by
-adding the `binary` tap:
+If you're using OS X and [Homebrew](http://brew.sh), you can install Packer:
 
 ```text
-$ brew tap homebrew/binary
 $ brew install packer
 ```


### PR DESCRIPTION
Hi,

`packer` was moved from the `homebrew/binary` tap to the main `homebrew` this afternoon, right at the moment I was trying to install it from `homebrew/binary` :)