### PR TITLE
Use interpolation in version description of Vagrant Cloud post-processor

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -77,6 +77,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	// Template process
+	templates["version_description"] = &p.config.VersionDescription
 	for key, ptr := range templates {
 		*ptr, err = p.config.tpl.Process(*ptr, nil)
 		if err != nil {


### PR DESCRIPTION
Vagrant Cloud post-processor does not interpolate template variables in `version description` options.