### PR TITLE
remove image format from image name in qemu builder

### DIFF
--- a/builder/qemu/step_copy_disk.go
+++ b/builder/qemu/step_copy_disk.go
@@ -3,7 +3,6 @@ package qemu
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
@@ -18,13 +17,13 @@ func (s *stepCopyDisk) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	isoPath := state.Get("iso_path").(string)
 	ui := state.Get("ui").(packer.Ui)
-	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName,
-		strings.ToLower(config.Format)))
-	name := config.VMName + "." + strings.ToLower(config.Format)
+	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s", config.VMName))
+	name := config.VMName
 
 	command := []string{
 		"convert",
 		"-f", config.Format,
+		"-O", config.Format,
 		isoPath,
 		path,
 	}

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -2,10 +2,10 @@ package qemu
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"path/filepath"
-	"strings"
 )
 
 // This step creates the virtual disk that will be used as the
@@ -16,7 +16,7 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*config)
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	name := config.VMName + "." + strings.ToLower(config.Format)
+	name := config.VMName
 	path := filepath.Join(config.OutputDir, name)
 
 	command := []string{

--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -2,10 +2,10 @@ package qemu
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"path/filepath"
-	"strings"
 )
 
 // This step resizes the virtual disk that will be used as the
@@ -16,8 +16,7 @@ func (s *stepResizeDisk) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*config)
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName,
-		strings.ToLower(config.Format)))
+	path := filepath.Join(config.OutputDir, config.VMName)
 
 	command := []string{
 		"resize",

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -64,8 +64,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 
 	vnc := fmt.Sprintf("0.0.0.0:%d", vncPort-5900)
 	vmName := config.VMName
-	imgPath := filepath.Join(config.OutputDir,
-		fmt.Sprintf("%s.%s", vmName, strings.ToLower(config.Format)))
+	imgPath := filepath.Join(config.OutputDir, vmName)
 
 	defaultArgs := make(map[string]string)
 


### PR DESCRIPTION
I think that specify image format in image file name not flexible.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>