### PR TITLE
add discard option to qemu builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -64,6 +64,11 @@ var diskCache = map[string]bool{
 	"directsync":   true,
 }
 
+var diskDiscard = map[string]bool{
+	"unmap":  true,
+	"ignore": true,
+}
+
 type Builder struct {
 	config config
 	runner multistep.Runner
@@ -77,6 +82,7 @@ type config struct {
 	DiskInterface   string     `mapstructure:"disk_interface"`
 	DiskSize        uint       `mapstructure:"disk_size"`
 	DiskCache       string     `mapstructure:"disk_cache"`
+	DiskDiscard     string     `mapstructure:"disk_discard"`
 	FloppyFiles     []string   `mapstructure:"floppy_files"`
 	Format          string     `mapstructure:"format"`
 	Headless        bool       `mapstructure:"headless"`
@@ -139,6 +145,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.DiskCache == "" {
 		b.config.DiskCache = "writeback"
+	}
+
+	if b.config.DiskDiscard == "" {
+		b.config.DiskDiscard = "ignore"
 	}
 
 	if b.config.Accelerator == "" {
@@ -296,6 +306,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if _, ok := diskCache[b.config.DiskCache]; !ok {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("unrecognized disk cache type"))
+	}
+
+	if _, ok := diskDiscard[b.config.DiskDiscard]; !ok {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("unrecognized disk cache type"))
 	}

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -81,7 +81,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	defaultArgs["-machine"] = fmt.Sprintf("type=%s", config.MachineType)
 	defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:22", sshHostPort)
 	defaultArgs["-device"] = fmt.Sprintf("%s,netdev=user.0", config.NetDevice)
-	defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s", imgPath, config.DiskInterface, config.DiskCache)
+	defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard)
 	if !config.DiskImage {
 		defaultArgs["-cdrom"] = isoPath
 	}

--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -115,6 +115,9 @@ each category, the available options are alphabetized and described.
   values include any of "writethrough", "writeback", "none", "unsafe" or
   "directsync".
 
+* `disk_discard` (string) - The discard mode to use for disk. Allowed values
+  include any of "unmap" or "ignore".
+
 * `disk_image` (boolean) - Packer defaults to building from an ISO file,
   this parameter controls whether the ISO URL supplied is actually a bootable
   QEMU image.  When this value is set to true, the machine will clone the


### PR DESCRIPTION
Enabling discards for disk can greatly minimize disk size then user
inside vm use fstrim command or trim/discard unneded blocks.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>