### PR TITLE
Fixes #2080 Add prlctl_post in builder Parallels

### DIFF
--- a/builder/parallels/common/prlctl_post_config.go
+++ b/builder/parallels/common/prlctl_post_config.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+)
+
+type PrlctlPostConfig struct {
+	PrlctlPost [][]string `mapstructure:"prlctl_post"`
+}
+
+func (c *PrlctlPostConfig) Prepare(t *packer.ConfigTemplate) []error {
+	if c.PrlctlPost == nil {
+		c.PrlctlPost = make([][]string, 0)
+	}
+
+	errs := make([]error, 0)
+	for i, args := range c.PrlctlPost {
+		for j, arg := range args {
+			if err := t.Validate(arg); err != nil {
+				errs = append(errs,
+					fmt.Errorf("Error processing prlctl_post[%d][%d]: %s", i, j, err))
+			}
+		}
+	}
+
+	return errs
+}

--- a/builder/parallels/common/prlctl_post_config_test.go
+++ b/builder/parallels/common/prlctl_post_config_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrlctlPostConfigPrepare_PrlctlPost(t *testing.T) {
+	// Test with empty
+	c := new(PrlctlPostConfig)
+	errs := c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	if !reflect.DeepEqual(c.PrlctlPost, [][]string{}) {
+		t.Fatalf("bad: %#v", c.PrlctlPost)
+	}
+
+	// Test with a good one
+	c = new(PrlctlPostConfig)
+	c.PrlctlPost = [][]string{
+		{"foo", "bar", "baz"},
+	}
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	expected := [][]string{
+		[]string{"foo", "bar", "baz"},
+	}
+
+	if !reflect.DeepEqual(c.PrlctlPost, expected) {
+		t.Fatalf("bad: %#v", c.PrlctlPost)
+	}
+}

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -23,6 +23,7 @@ type config struct {
 	parallelscommon.FloppyConfig        `mapstructure:",squash"`
 	parallelscommon.OutputConfig        `mapstructure:",squash"`
 	parallelscommon.PrlctlConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlPostConfig    `mapstructure:",squash"`
 	parallelscommon.PrlctlVersionConfig `mapstructure:",squash"`
 	parallelscommon.RunConfig           `mapstructure:",squash"`
 	parallelscommon.ShutdownConfig      `mapstructure:",squash"`
@@ -71,6 +72,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		errs, b.config.OutputConfig.Prepare(b.config.tpl, &b.config.PackerConfig)...)
 	errs = packer.MultiErrorAppend(errs, b.config.RunConfig.Prepare(b.config.tpl)...)
 	errs = packer.MultiErrorAppend(errs, b.config.PrlctlConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.PrlctlPostConfig.Prepare(b.config.tpl)...)
 	errs = packer.MultiErrorAppend(errs, b.config.PrlctlVersionConfig.Prepare(b.config.tpl)...)
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(b.config.tpl)...)
 	errs = packer.MultiErrorAppend(errs, b.config.SSHConfig.Prepare(b.config.tpl)...)
@@ -294,6 +296,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&parallelscommon.StepShutdown{
 			Command: b.config.ShutdownCommand,
 			Timeout: b.config.ShutdownTimeout,
+		},
+		&parallelscommon.StepPrlctl{
+			Commands: b.config.PrlctlPost,
+			Tpl:      b.config.tpl,
 		},
 	}
 

--- a/builder/parallels/pvm/builder.go
+++ b/builder/parallels/pvm/builder.go
@@ -99,6 +99,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Command: b.config.ShutdownCommand,
 			Timeout: b.config.ShutdownTimeout,
 		},
+		&parallelscommon.StepPrlctl{
+			Commands: b.config.PrlctlPost,
+			Tpl:      b.config.tpl,
+		},
 	}
 
 	// Run the steps.

--- a/builder/parallels/pvm/config.go
+++ b/builder/parallels/pvm/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	parallelscommon.FloppyConfig        `mapstructure:",squash"`
 	parallelscommon.OutputConfig        `mapstructure:",squash"`
 	parallelscommon.PrlctlConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlPostConfig    `mapstructure:",squash"`
 	parallelscommon.PrlctlVersionConfig `mapstructure:",squash"`
 	parallelscommon.RunConfig           `mapstructure:",squash"`
 	parallelscommon.SSHConfig           `mapstructure:",squash"`
@@ -51,6 +52,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.FloppyConfig.Prepare(c.tpl)...)
 	errs = packer.MultiErrorAppend(errs, c.OutputConfig.Prepare(c.tpl, &c.PackerConfig)...)
 	errs = packer.MultiErrorAppend(errs, c.PrlctlConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.PrlctlPostConfig.Prepare(c.tpl)...)
 	errs = packer.MultiErrorAppend(errs, c.PrlctlVersionConfig.Prepare(c.tpl)...)
 	errs = packer.MultiErrorAppend(errs, c.RunConfig.Prepare(c.tpl)...)
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare(c.tpl)...)

--- a/website/source/docs/builders/parallels-iso.html.markdown
+++ b/website/source/docs/builders/parallels-iso.html.markdown
@@ -170,6 +170,10 @@ each category, the available options are alphabetized and described.
   where the `Name` variable is replaced with the VM name. More details on how
   to use `prlctl` are below.
 
+* `prlctl_post` (array of array of strings) - Identical to `prlctl`,
+  except that it is run after the virtual machine is shutdown, and before the
+  virtual machine is exported.
+
 * `prlctl_version_file` (string) - The path within the virtual machine to upload
   a file that contains the `prlctl` version that was used to create the machine.
   This information can be useful for provisioning. By default this is

--- a/website/source/docs/builders/parallels-pvm.html.markdown
+++ b/website/source/docs/builders/parallels-pvm.html.markdown
@@ -113,6 +113,10 @@ each category, the available options are alphabetized and described.
   where the `Name` variable is replaced with the VM name. More details on how
   to use `prlctl` are below.
 
+* `prlctl_post` (array of array of strings) - Identical to `prlctl`,
+  except that it is run after the virtual machine is shutdown, and before the
+  virtual machine is exported.
+
 * `prlctl_version_file` (string) - The path within the virtual machine to upload
   a file that contains the `prlctl` version that was used to create the machine.
   This information can be useful for provisioning. By default this is


### PR DESCRIPTION
This adds config option prlctl_post for builder parallels-iso/pvm. It
allows additional prlctl commands to run after the VM has been shutdown
just before being exported.