### PR TITLE
Fixes #2128 Retry the AWS API when looking for a newly created instance

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -195,7 +195,16 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 		instanceId = spotResp.SpotRequestResults[0].InstanceId
 	}
 
-	instanceResp, err := ec2conn.Instances([]string{instanceId}, nil)
+	var instanceResp, instanceErr = ec2conn.Instances([]string{instanceId}, nil)
+	for i := 0; i < 10; i++ {
+		if instanceErr == nil {
+			err = instanceErr
+			break
+		}
+		time.Sleep(time.Duration(3))
+		instanceResp, err = ec2conn.Instances([]string{instanceId}, nil)
+	}
+
 	if err != nil {
 		err := fmt.Errorf("Error finding source instance (%s): %s", instanceId, err)
 		state.Put("error", err)


### PR DESCRIPTION
Sometimes the AWS API responds that it can't find a newly created instance if you poll it too soon after creation.  Retry a few times to be sure it really hasn't been created.

(In our environment, over the past 28 days packer failed to find 204 instances that were successfully created meaning we had to clean up those instances, security groups and keys manually)