### PR TITLE
Add template_dir for path to template [GH-54]

### DIFF
--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -104,7 +104,8 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 // detecting things like user variables from the raw configuration params.
 func DetectContext(raws ...interface{}) (*interpolate.Context, error) {
 	var s struct {
-		Vars map[string]string `mapstructure:"packer_user_variables"`
+		TemplatePath string            `mapstructure:"packer_template_path"`
+		Vars         map[string]string `mapstructure:"packer_user_variables"`
 	}
 
 	for _, r := range raws {
@@ -114,6 +115,7 @@ func DetectContext(raws ...interface{}) (*interpolate.Context, error) {
 	}
 
 	return &interpolate.Context{
+		TemplatePath:  s.TemplatePath,
 		UserVariables: s.Vars,
 	}, nil
 }

--- a/packer/build.go
+++ b/packer/build.go
@@ -24,6 +24,9 @@ const (
 	// force build is enabled.
 	ForceConfigKey = "packer_force"
 
+	// TemplatePathKey is the path to the template that configured this build
+	TemplatePathKey = "packer_template_path"
+
 	// This key contains a map[string]string of the user variables for
 	// template processing.
 	UserVariablesConfigKey = "packer_user_variables"
@@ -78,6 +81,7 @@ type coreBuild struct {
 	hooks          map[string][]Hook
 	postProcessors [][]coreBuildPostProcessor
 	provisioners   []coreBuildProvisioner
+	templatePath   string
 	variables      map[string]string
 
 	debug         bool
@@ -125,6 +129,7 @@ func (b *coreBuild) Prepare() (warn []string, err error) {
 		BuilderTypeConfigKey:   b.builderType,
 		DebugConfigKey:         b.debug,
 		ForceConfigKey:         b.force,
+		TemplatePathKey:        b.templatePath,
 		UserVariablesConfigKey: b.variables,
 	}
 

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -32,6 +32,7 @@ func testDefaultPackerConfig() map[string]interface{} {
 		BuilderTypeConfigKey:   "foo",
 		DebugConfigKey:         false,
 		ForceConfigKey:         false,
+		TemplatePathKey:        "",
 		UserVariablesConfigKey: make(map[string]string),
 	}
 }

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -2,6 +2,7 @@ package packer
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -335,6 +336,35 @@ func TestCoreBuild_postProcess(t *testing.T) {
 	}
 	if p.PostProcessArtifact.Id() != b.ArtifactId {
 		t.Fatalf("bad: %s", p.PostProcessArtifact.Id())
+	}
+}
+
+func TestCoreBuild_templatePath(t *testing.T) {
+	config := TestCoreConfig(t)
+	testCoreTemplate(t, config, fixtureDir("build-template-path.json"))
+	b := TestBuilder(t, config, "test")
+	core := TestCore(t, config)
+
+	expected, _ := filepath.Abs("./test-fixtures")
+
+	build, err := core.Build("test")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := build.Prepare(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Interpolate the config
+	var result map[string]interface{}
+	err = configHelper.Decode(&result, nil, b.PrepareConfig...)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if result["value"] != expected {
+		t.Fatalf("bad: %#v", result)
 	}
 }
 

--- a/packer/test-fixtures/build-template-path.json
+++ b/packer/test-fixtures/build-template-path.json
@@ -1,0 +1,6 @@
+{
+    "builders": [{
+        "type": "test",
+        "value": "{{template_dir}}"
+    }]
+}

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -99,7 +100,7 @@ func funcGenTemplatePath(ctx *Context) interface{} {
 			return "", errors.New("template path not available")
 		}
 
-		return ctx.TemplatePath, nil
+		return filepath.Dir(ctx.TemplatePath), nil
 	}
 }
 

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -24,13 +24,13 @@ func init() {
 
 // Funcs are the interpolation funcs that are available within interpolations.
 var FuncGens = map[string]FuncGenerator{
-	"env":           funcGenEnv,
-	"isotime":       funcGenIsotime,
-	"pwd":           funcGenPwd,
-	"template_path": funcGenTemplatePath,
-	"timestamp":     funcGenTimestamp,
-	"uuid":          funcGenUuid,
-	"user":          funcGenUser,
+	"env":          funcGenEnv,
+	"isotime":      funcGenIsotime,
+	"pwd":          funcGenPwd,
+	"template_dir": funcGenTemplateDir,
+	"timestamp":    funcGenTimestamp,
+	"uuid":         funcGenUuid,
+	"user":         funcGenUser,
 
 	"upper": funcGenPrimitive(strings.ToUpper),
 	"lower": funcGenPrimitive(strings.ToLower),
@@ -94,13 +94,18 @@ func funcGenPwd(ctx *Context) interface{} {
 	}
 }
 
-func funcGenTemplatePath(ctx *Context) interface{} {
+func funcGenTemplateDir(ctx *Context) interface{} {
 	return func() (string, error) {
 		if ctx == nil || ctx.TemplatePath == "" {
 			return "", errors.New("template path not available")
 		}
 
-		return filepath.Dir(ctx.TemplatePath), nil
+		path, err := filepath.Abs(filepath.Dir(ctx.TemplatePath))
+		if err != nil {
+			return "", err
+		}
+
+		return path, nil
 	}
 }
 

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -23,12 +23,13 @@ func init() {
 
 // Funcs are the interpolation funcs that are available within interpolations.
 var FuncGens = map[string]FuncGenerator{
-	"env":       funcGenEnv,
-	"isotime":   funcGenIsotime,
-	"pwd":       funcGenPwd,
-	"timestamp": funcGenTimestamp,
-	"uuid":      funcGenUuid,
-	"user":      funcGenUser,
+	"env":           funcGenEnv,
+	"isotime":       funcGenIsotime,
+	"pwd":           funcGenPwd,
+	"template_path": funcGenTemplatePath,
+	"timestamp":     funcGenTimestamp,
+	"uuid":          funcGenUuid,
+	"user":          funcGenUser,
 
 	"upper": funcGenPrimitive(strings.ToUpper),
 	"lower": funcGenPrimitive(strings.ToLower),
@@ -89,6 +90,16 @@ func funcGenPrimitive(value interface{}) FuncGenerator {
 func funcGenPwd(ctx *Context) interface{} {
 	return func() (string, error) {
 		return os.Getwd()
+	}
+}
+
+func funcGenTemplatePath(ctx *Context) interface{} {
+	return func() (string, error) {
+		if ctx == nil || ctx.TemplatePath == "" {
+			return "", errors.New("template path not available")
+		}
+
+		return ctx.TemplatePath, nil
 	}
 }
 

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -128,7 +128,7 @@ func TestFuncTemplatePath(t *testing.T) {
 	}
 
 	ctx := &Context{
-		TemplatePath: "foo",
+		TemplatePath: "foo/bar",
 	}
 	for _, tc := range cases {
 		i := &I{Value: tc.Input}

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -2,6 +2,7 @@ package interpolate
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -117,18 +118,21 @@ func TestFuncPwd(t *testing.T) {
 }
 
 func TestFuncTemplatePath(t *testing.T) {
+	path := "foo/bar"
+	expected, _ := filepath.Abs(filepath.Dir(path))
+
 	cases := []struct {
 		Input  string
 		Output string
 	}{
 		{
-			`{{template_path}}`,
-			`foo`,
+			`{{template_dir}}`,
+			expected,
 		},
 	}
 
 	ctx := &Context{
-		TemplatePath: "foo/bar",
+		TemplatePath: path,
 	}
 	for _, tc := range cases {
 		i := &I{Value: tc.Input}

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -116,6 +116,33 @@ func TestFuncPwd(t *testing.T) {
 	}
 }
 
+func TestFuncTemplatePath(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			`{{template_path}}`,
+			`foo`,
+		},
+	}
+
+	ctx := &Context{
+		TemplatePath: "foo",
+	}
+	for _, tc := range cases {
+		i := &I{Value: tc.Input}
+		result, err := i.Render(ctx)
+		if err != nil {
+			t.Fatalf("Input: %s\n\nerr: %s", tc.Input, err)
+		}
+
+		if result != tc.Output {
+			t.Fatalf("Input: %s\n\nGot: %s", tc.Input, result)
+		}
+	}
+}
+
 func TestFuncTimestamp(t *testing.T) {
 	expected := strconv.FormatInt(InitTime.Unix(), 10)
 

--- a/template/interpolate/i.go
+++ b/template/interpolate/i.go
@@ -14,6 +14,10 @@ type Context struct {
 	// Funcs are extra functions available in the template
 	Funcs map[string]interface{}
 
+	// TemplatePath is the path to the template that this is being
+	// rendered within.
+	TemplatePath string
+
 	// UserVariables is the mapping of user variables that the
 	// "user" function reads from.
 	UserVariables map[string]string

--- a/template/parse.go
+++ b/template/parse.go
@@ -310,5 +310,11 @@ func ParseFile(path string) (*Template, error) {
 	}
 	defer f.Close()
 
-	return Parse(f)
+	tpl, err := Parse(f)
+	if err != nil {
+		return nil, err
+	}
+
+	tpl.Path = path
+	return tpl, nil
 }

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -272,11 +272,15 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		path := fixtureDir(tc.File)
 		tpl, err := ParseFile(fixtureDir(tc.File))
 		if (err != nil) != tc.Err {
 			t.Fatalf("err: %s", err)
 		}
 
+		if tc.Result != nil {
+			tc.Result.Path = path
+		}
 		if tpl != nil {
 			tpl.RawContents = nil
 		}

--- a/template/template.go
+++ b/template/template.go
@@ -11,6 +11,10 @@ import (
 // Template represents the parsed template that is used to configure
 // Packer builds.
 type Template struct {
+	// Path is the path to the template. This will be blank if Parse is
+	// used, but will be automatically populated by ParseFile.
+	Path string
+
 	Description string
 	MinVersion  string
 

--- a/website/source/docs/templates/configuration-templates.html.markdown
+++ b/website/source/docs/templates/configuration-templates.html.markdown
@@ -55,10 +55,11 @@ While some configuration settings have local variables specific to only that
 configuration, a set of functions are available globally for use in _any string_
 in Packer templates. These are listed below for reference.
 
-* `lower` - Lowercases the string.
-* `pwd` - The working directory while executing Packer.
 * `isotime [FORMAT]` - UTC time, which can be [formatted](http://golang.org/pkg/time/#example_Time_Format).
    See more examples below.
+* `lower` - Lowercases the string.
+* `pwd` - The working directory while executing Packer.
+* `template_dir` - The directory to the template for the build.
 * `timestamp` - The current Unix timestamp in UTC.
 * `uuid` - Returns a random UUID.
 * `upper` - Uppercases the string.


### PR DESCRIPTION
Fixes #54 

This adds a new function `template_dir` to reference the directory where the template is. This allows paths relative to the template. We did this instead of what #54 originally said to preserve backwards compatibility. We also already have `pwd` there so the goal is to eventual get everyone to use these functions.