### PR TITLE
Interpolate the "push" config

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -28,6 +28,7 @@ func testMeta(t *testing.T) Meta {
 	var out, err bytes.Buffer
 
 	return Meta{
+		CoreConfig: packer.TestCoreConfig(t),
 		Ui: &packer.BasicUi{
 			Writer:      &out,
 			ErrorWriter: &err,

--- a/command/push.go
+++ b/command/push.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/atlas-go/archive"
 	"github.com/hashicorp/atlas-go/v1"
 	"github.com/mitchellh/packer/template"
-	"github.com/mitchellh/packer/template/interpolate"
 )
 
 // archiveTemplateEntry is the name the template always takes within the slug.
@@ -73,13 +72,7 @@ func (c *PushCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-	push := tpl.Push
-	pushRaw, err := interpolate.RenderInterface(&push, core.Context())
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return 1
-	}
-	push = *pushRaw.(*template.Push)
+	push := core.Template.Push
 
 	// If we didn't pass name from the CLI, use the template
 	if name == "" {

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -190,6 +190,35 @@ func TestPush_uploadErrorCh(t *testing.T) {
 	}
 }
 
+func TestPush_vars(t *testing.T) {
+	var actualOpts *uploadOpts
+	uploadFn := func(r io.Reader, opts *uploadOpts) (<-chan struct{}, <-chan error, error) {
+		actualOpts = opts
+
+		doneCh := make(chan struct{})
+		close(doneCh)
+		return doneCh, nil, nil
+	}
+
+	c := &PushCommand{
+		Meta:     testMeta(t),
+		uploadFn: uploadFn,
+	}
+
+	args := []string{
+		"-var", "name=foo/bar",
+		filepath.Join(testFixture("push-vars"), "template.json"),
+	}
+	if code := c.Run(args); code != 0 {
+		fatalCommand(t, c.Meta)
+	}
+
+	expected := "foo/bar"
+	if actualOpts.Slug != expected {
+		t.Fatalf("bad: %#v", actualOpts.Slug)
+	}
+}
+
 func testArchive(t *testing.T, r io.Reader) []string {
 	// Finish the archiving process in-memory
 	var buf bytes.Buffer

--- a/command/test-fixtures/push-vars/template.json
+++ b/command/test-fixtures/push-vars/template.json
@@ -1,0 +1,11 @@
+{
+    "variables": {
+        "name": null
+    },
+
+    "builders": [{"type": "dummy"}],
+
+    "push": {
+        "name": "{{user `name`}}"
+    }
+}

--- a/packer/core.go
+++ b/packer/core.go
@@ -12,8 +12,9 @@ import (
 // Core is the main executor of Packer. If Packer is being used as a
 // library, this is the struct you'll want to instantiate to get anything done.
 type Core struct {
+	Template *template.Template
+
 	components ComponentFinder
-	template   *template.Template
 	variables  map[string]string
 	builds     map[string]*template.Builder
 }
@@ -51,8 +52,8 @@ type ComponentFinder struct {
 // NewCore creates a new Core.
 func NewCore(c *CoreConfig) (*Core, error) {
 	result := &Core{
+		Template:   c.Template,
 		components: c.Components,
-		template:   c.Template,
 		variables:  c.Variables,
 	}
 	if err := result.validate(); err != nil {
@@ -112,8 +113,8 @@ func (c *Core) Build(n string) (Build, error) {
 	rawName := configBuilder.Name
 
 	// Setup the provisioners for this build
-	provisioners := make([]coreBuildProvisioner, 0, len(c.template.Provisioners))
-	for _, rawP := range c.template.Provisioners {
+	provisioners := make([]coreBuildProvisioner, 0, len(c.Template.Provisioners))
+	for _, rawP := range c.Template.Provisioners {
 		// If we're skipping this, then ignore it
 		if rawP.Skip(rawName) {
 			continue
@@ -155,8 +156,8 @@ func (c *Core) Build(n string) (Build, error) {
 	}
 
 	// Setup the post-processors
-	postProcessors := make([][]coreBuildPostProcessor, 0, len(c.template.PostProcessors))
-	for _, rawPs := range c.template.PostProcessors {
+	postProcessors := make([][]coreBuildPostProcessor, 0, len(c.Template.PostProcessors))
+	for _, rawPs := range c.Template.PostProcessors {
 		current := make([]coreBuildPostProcessor, 0, len(rawPs))
 		for _, rawP := range rawPs {
 			// If we skip, ignore
@@ -201,7 +202,7 @@ func (c *Core) Build(n string) (Build, error) {
 		builderType:    configBuilder.Type,
 		postProcessors: postProcessors,
 		provisioners:   provisioners,
-		templatePath:   c.template.Path,
+		templatePath:   c.Template.Path,
 		variables:      c.variables,
 	}, nil
 }
@@ -209,7 +210,7 @@ func (c *Core) Build(n string) (Build, error) {
 // Context returns an interpolation context.
 func (c *Core) Context() *interpolate.Context {
 	return &interpolate.Context{
-		TemplatePath:  c.template.Path,
+		TemplatePath:  c.Template.Path,
 		UserVariables: c.variables,
 	}
 }
@@ -221,13 +222,13 @@ func (c *Core) Context() *interpolate.Context {
 func (c *Core) validate() error {
 	// First validate the template in general, we can't do anything else
 	// unless the template itself is valid.
-	if err := c.template.Validate(); err != nil {
+	if err := c.Template.Validate(); err != nil {
 		return err
 	}
 
 	// Validate variables are set
 	var err error
-	for n, v := range c.template.Variables {
+	for n, v := range c.Template.Variables {
 		if v.Required {
 			if _, ok := c.variables[n]; !ok {
 				err = multierror.Append(err, fmt.Errorf(
@@ -252,7 +253,7 @@ func (c *Core) init() error {
 	ctx := c.Context()
 	ctx.EnableEnv = true
 	ctx.UserVariables = nil
-	for k, v := range c.template.Variables {
+	for k, v := range c.Template.Variables {
 		// Ignore variables that are required
 		if v.Required {
 			continue
@@ -272,6 +273,11 @@ func (c *Core) init() error {
 		}
 
 		c.variables[k] = def
+	}
+
+	// Interpolate the push configuration
+	if _, err := interpolate.RenderInterface(&c.Template.Push, c.Context()); err != nil {
+		return fmt.Errorf("Error interpolating 'push': %s", err)
 	}
 
 	return nil

--- a/packer/core.go
+++ b/packer/core.go
@@ -66,7 +66,7 @@ func NewCore(c *CoreConfig) (*Core, error) {
 	// to do this at this point with the variables.
 	result.builds = make(map[string]*template.Builder)
 	for _, b := range c.Template.Builders {
-		v, err := interpolate.Render(b.Name, result.context())
+		v, err := interpolate.Render(b.Name, result.Context())
 		if err != nil {
 			return nil, fmt.Errorf(
 				"Error interpolating builder '%s': %s",
@@ -206,6 +206,14 @@ func (c *Core) Build(n string) (Build, error) {
 	}, nil
 }
 
+// Context returns an interpolation context.
+func (c *Core) Context() *interpolate.Context {
+	return &interpolate.Context{
+		TemplatePath:  c.template.Path,
+		UserVariables: c.variables,
+	}
+}
+
 // validate does a full validation of the template.
 //
 // This will automatically call template.validate() in addition to doing
@@ -241,7 +249,7 @@ func (c *Core) init() error {
 	}
 
 	// Go through the variables and interpolate the environment variables
-	ctx := c.context()
+	ctx := c.Context()
 	ctx.EnableEnv = true
 	ctx.UserVariables = nil
 	for k, v := range c.template.Variables {
@@ -267,11 +275,4 @@ func (c *Core) init() error {
 	}
 
 	return nil
-}
-
-func (c *Core) context() *interpolate.Context {
-	return &interpolate.Context{
-		TemplatePath:  c.template.Path,
-		UserVariables: c.variables,
-	}
 }

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -368,6 +368,40 @@ func TestCoreBuild_templatePath(t *testing.T) {
 	}
 }
 
+func TestCore_pushInterpolate(t *testing.T) {
+	cases := []struct {
+		File   string
+		Vars   map[string]string
+		Result template.Push
+	}{
+		{
+			"push-vars.json",
+			map[string]string{"foo": "bar"},
+			template.Push{Name: "bar"},
+		},
+	}
+
+	for _, tc := range cases {
+		tpl, err := template.ParseFile(fixtureDir(tc.File))
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", tc.File, err)
+		}
+
+		core, err := NewCore(&CoreConfig{
+			Template:  tpl,
+			Variables: tc.Vars,
+		})
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", tc.File, err)
+		}
+
+		expected := core.Template.Push
+		if !reflect.DeepEqual(expected, tc.Result) {
+			t.Fatalf("err: %s\n\n%#v", tc.File, expected)
+		}
+	}
+}
+
 func TestCoreValidate(t *testing.T) {
 	cases := []struct {
 		File string

--- a/packer/test-fixtures/push-vars.json
+++ b/packer/test-fixtures/push-vars.json
@@ -1,0 +1,11 @@
+{
+    "variables": {
+        "foo": null
+    },
+
+    "builders": [{"type": "test"}],
+
+    "push": {
+        "name": "{{user `foo`}}"
+    }
+}

--- a/template/interpolate/render_test.go
+++ b/template/interpolate/render_test.go
@@ -5,6 +5,47 @@ import (
 	"testing"
 )
 
+func TestRenderInterface(t *testing.T) {
+	type Test struct {
+		Foo string
+	}
+
+	cases := map[string]struct {
+		Input  interface{}
+		Output interface{}
+	}{
+		"basic": {
+			map[string]interface{}{
+				"foo": "{{upper `bar`}}",
+			},
+			map[string]interface{}{
+				"foo": "BAR",
+			},
+		},
+
+		"struct": {
+			&Test{
+				Foo: "{{upper `bar`}}",
+			},
+			&Test{
+				Foo: "BAR",
+			},
+		},
+	}
+
+	ctx := &Context{}
+	for k, tc := range cases {
+		actual, err := RenderInterface(tc.Input, ctx)
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", k, err)
+		}
+
+		if !reflect.DeepEqual(actual, tc.Output) {
+			t.Fatalf("err: %s\n\n%#v\n\n%#v", k, actual, tc.Output)
+		}
+	}
+}
+
 func TestRenderMap(t *testing.T) {
 	cases := map[string]struct {
 		Input  interface{}


### PR DESCRIPTION
The "push" config is now interpolated. This requires that all required variables be set for `push`, but should result in a much better user experience.