### PR TITLE
Fixed #1635

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -48,13 +48,18 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.RawSSHTimeout = "5m"
 	}
 
-	if c.TemporaryKeyPairName == "" {
-		c.TemporaryKeyPairName = fmt.Sprintf(
-			"packer %s", uuid.TimeOrderedUUID())
-	}
-
 	// Validation
 	var errs []error
+
+	if c.TemporaryKeyPairName == "" {
+		if c.SSHPrivateKeyFile != "" {
+			errs = append(errs, errors.New("A temporary_key_pair_name must be specified when ssh_private_key_file is specified"))
+		} else {
+			c.TemporaryKeyPairName = fmt.Sprintf(
+				"packer %s", uuid.TimeOrderedUUID())
+		}
+	}
+
 	if c.SourceAmi == "" {
 		errs = append(errs, errors.New("A source_ami must be specified"))
 	}

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -151,3 +151,12 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 		t.Fatal("keypair empty")
 	}
 }
+
+func TestRunConfigPrepare_TemporaryKeyPairName_SSHPrivateKeyFile(t *testing.T) {
+	c := testConfig()
+	c.TemporaryKeyPairName = ""
+	c.SSHPrivateKeyFile = "test"
+	if err := c.Prepare(nil); len(err) != 1 {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -30,7 +30,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
-		state.Put("keyPair", "")
+		state.Put("keyPair", s.KeyPairName)
 		state.Put("privateKey", string(privateKeyBytes))
 
 		return multistep.ActionContinue


### PR DESCRIPTION
Fixed #1635 
I extended "temporary_key_pair_name" usage for the case when ssh_private_key_file is in place to set the key pair name.
I confirmed this modification worked successfully.
I'd be glad if this PR would be merged and released promptly because I need this feature for my project.