### PR TITLE
Fixes 'unknown configuration key' errors for 'only' and 'except'

### DIFF
--- a/template/parse.go
+++ b/template/parse.go
@@ -134,6 +134,8 @@ func (r *rawTemplate) Template() (*Template, error) {
 			}
 
 			// Set the configuration
+			delete(c, "except")
+			delete(c, "only")
 			delete(c, "keep_input_artifact")
 			delete(c, "type")
 			if len(c) > 0 {


### PR DESCRIPTION
If you use `only` or `except` configuration keys in `post-processors`, packer raises `unknown configuration key` errors.