### PR TITLE
Fixes 'unknown configuration key' errors for 'only' and 'except'

### DIFF
--- a/template/parse.go
+++ b/template/parse.go
@@ -134,6 +134,8 @@ func (r *rawTemplate) Template() (*Template, error) {
 			}
 
 			// Set the configuration
+			delete(c, "except")
+			delete(c, "only")
 			delete(c, "keep_input_artifact")
 			delete(c, "type")
 			if len(c) > 0 {

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -175,6 +175,40 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"parse-pp-only.json",
+			&Template{
+				PostProcessors: [][]*PostProcessor{
+					[]*PostProcessor{
+						&PostProcessor{
+							Type: "foo",
+							OnlyExcept: OnlyExcept{
+								Only: []string{"bar"},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+
+		{
+			"parse-pp-except.json",
+			&Template{
+				PostProcessors: [][]*PostProcessor{
+					[]*PostProcessor{
+						&PostProcessor{
+							Type: "foo",
+							OnlyExcept: OnlyExcept{
+								Except: []string{"bar"},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"parse-pp-string.json",
 			&Template{
 				PostProcessors: [][]*PostProcessor{

--- a/template/test-fixtures/parse-pp-except.json
+++ b/template/test-fixtures/parse-pp-except.json
@@ -1,0 +1,8 @@
+{
+    "post-processors": [
+        {
+            "type": "foo",
+            "except": ["bar"]
+        }
+    ]
+}

--- a/template/test-fixtures/parse-pp-only.json
+++ b/template/test-fixtures/parse-pp-only.json
@@ -1,0 +1,8 @@
+{
+    "post-processors": [
+        {
+            "type": "foo",
+            "only": ["bar"]
+        }
+    ]
+}


### PR DESCRIPTION
If you use only or except configuration keys in post-processors, packer raises unknown configuration key errors.

Sorry for duplication with #2161. The pull request has accidentally been closed while renaming the branch. @sethvargo said "LGTM," and pinged @cbednarski or @mitchellh for a final.