### PR TITLE
Skip *.ignore files to improve Chocolatey package for Windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -172,6 +172,11 @@ func (c *config) discoverSingle(glob string, m *map[string]string) error {
 	for _, match := range matches {
 		file := filepath.Base(match)
 
+		// skip *.ignore files from Windows Chocolatey
+		if strings.HasSuffix(file, ".ignore") {
+			continue
+		}
+
 		// If the filename has a ".", trim up to there
 		if idx := strings.Index(file, "."); idx >= 0 {
 			file = file[:idx]


### PR DESCRIPTION
I'm the maintainer of the Chocolatey package of [packer](https://chocolatey.org/packages/packer) for Windows.  Currently I'm working on an improved Chocolatey package for the next release of packer. There is a small issue to get the best exprience for the user.  Chocolatey now has more control to install the packer.zip and uninstall the package in a very clean way.

Chocolatey can redirect exe files to put them easily into the user's PATH. For packer only the `packer.exe` needs this redirect.  All the other exe files are discovered by packer itself.

To suppress the redirects for the many other exe files to keep the user's setup more clean I have to add `*.ignore` files into the Chocolatey package.

With the current packer 0.7.5 the discovery also finds all of these `*.ignore` files and takes them as the file name of the plugin.  Starting that empty file fails and packer aborts:

``` 
2015/06/04 09:52:44 [INFO] Packer version: 0.7.5  9cd66feeacbd9cb318b72eb5ed59428c5b8c37ac+CHANGES
2015/06/04 09:52:44 Packer Target OS/Arch: windows amd64
2015/06/04 09:52:44 Built with Go Version: go1.3.3
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: amazon-chroot = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-amazon-chroot.exe
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: amazon-chroot = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-amazon-chroot.exe.ignore
...
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: virtualbox-iso = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: virtualbox-iso = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe.ignore
...
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: shell = C:\ProgramData\chocolatey\lib\packer\tools\packer-provisioner-shell.exe
2015/06/04 09:52:44 [DEBUG] Discoverd plugin: shell = C:\ProgramData\chocolatey\lib\packer\tools\packer-provisioner-shell.exe.ignore
2015/06/04 09:52:44 Attempting to open config file: C:\Users\vagrant\AppData\Roaming\packer.config
2015/06/04 09:52:44 File doesn't exist, but doesn't need to. Ignoring.
...
2015/06/04 09:52:44 Setting cache directory: C:\Users\vagrant\Documents\ubuntu-vm\packer_cache
2015/06/04 09:52:44 Reading template: ubuntu1204.json
2015/06/04 09:52:44 Skipping build 'vmware-iso' because not specified by -only.
2015/06/04 09:52:44 Creating build: virtualbox-iso
2015/06/04 09:52:44 Loading builder: virtualbox-iso
2015/06/04 09:52:44 Creating plugin client for path: C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe.ignore
2015/06/04 09:52:44 Starting plugin: C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe.ignore []string{"C:\\ProgramData\\chocolatey\\lib\\packer\\tools\\packer-builder-virtualbox-iso.exe.ignore"}
2015/06/04 09:52:44 ui error: Failed to create build 'virtualbox-iso': 

fork/exec C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe.ignore: %1 is not a valid Win32 application.
2015/06/04 09:52:44 waiting for all plugin processes to complete...
```

With this fix packer just skips all `*.ignore` files while discovering packer plugins. With this patch packer works fine:

```
2015/06/04 11:07:31 [INFO] Packer version: 0.7.5  
2015/06/04 11:07:31 Packer Target OS/Arch: windows amd64
2015/06/04 11:07:31 Built with Go Version: go1.4.2
2015/06/04 11:07:31 [DEBUG] Discovered plugin: amazon-chroot = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-amazon-chroot.exe
2015/06/04 11:07:31 [DEBUG] Discovered plugin: amazon-ebs = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-amazon-ebs.exe
...
2015/06/04 11:07:31 [DEBUG] Discovered plugin: virtualbox-iso = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe
2015/06/04 11:07:31 [DEBUG] Discovered plugin: virtualbox-ovf = C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-ovf.exe
...
...
2015/06/04 11:07:31 Setting cache directory: C:\Users\vagrant\Documents\ubuntu-vm\packer_cache
2015/06/04 11:07:31 Loading builder: virtualbox-iso
2015/06/04 11:07:31 Creating plugin client for path: C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe
2015/06/04 11:07:31 Starting plugin: C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe []string{"C:\\ProgramData\\chocolatey\\lib\\packer\\tools\\packer-builder-virtualbox-iso.exe"}
2015/06/04 11:07:31 Waiting for RPC address for: C:\ProgramData\chocolatey\lib\packer\tools\packer-builder-virtualbox-iso.exe
...
```

@mitchellh Looking forward to meet you at enterJS in two weeks!