### PR TITLE
vmware/iso: support hierarchical output directories

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -311,8 +311,8 @@ func (d *ESX5Driver) String() string {
 }
 
 func (d *ESX5Driver) datastorePath(path string) string {
-	baseDir := filepath.Base(filepath.Dir(path))
-	return filepath.ToSlash(filepath.Join("/vmfs/volumes", d.Datastore, baseDir, filepath.Base(path)))
+	dirPath := filepath.Dir(path)
+	return filepath.ToSlash(filepath.Join("/vmfs/volumes", d.Datastore, dirPath, filepath.Base(path)))
 }
 
 func (d *ESX5Driver) cachePath(path string) string {


### PR DESCRIPTION
When providing a hierarchical output_directory value like
'transient/jenkins-slave', the VM would fail to build in the CreateDisk
step.  The properly created output directory would not match the location
provided to CreateDisk, since datastorePath() did not properly split such
paths.  Now this case works; tested hierarchical and singular
output_directory values.