### PR TITLE
"Name" parameter required for copying ami across regions [GH-2172]

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -166,7 +166,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepSnapshot{},
 		&StepRegisterAMI{},
 		&awscommon.StepAMIRegionCopy{
-			Regions: b.config.AMIRegions,
+			AccessConfig: &b.config.AccessConfig,
+			Regions:      b.config.AMIRegions,
+			Name:         b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description: b.config.AMIDescription,

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -14,6 +14,7 @@ import (
 type StepAMIRegionCopy struct {
 	AccessConfig *AccessConfig
 	Regions      []string
+	Name         string
 }
 
 func (s *StepAMIRegionCopy) Run(state multistep.StateBag) multistep.StepAction {
@@ -37,7 +38,7 @@ func (s *StepAMIRegionCopy) Run(state multistep.StateBag) multistep.StepAction {
 
 		go func(region string) {
 			defer wg.Done()
-			id, err := amiRegionCopy(state, s.AccessConfig, ami, region, ec2conn.Config.Region)
+			id, err := amiRegionCopy(state, s.AccessConfig, s.Name, ami, region, ec2conn.Config.Region)
 
 			lock.Lock()
 			defer lock.Unlock()
@@ -69,7 +70,7 @@ func (s *StepAMIRegionCopy) Cleanup(state multistep.StateBag) {
 
 // amiRegionCopy does a copy for the given AMI to the target region and
 // returns the resulting ID or error.
-func amiRegionCopy(state multistep.StateBag, config *AccessConfig, imageId string,
+func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, imageId string,
 	target string, source string) (string, error) {
 
 	// Connect to the region where the AMI will be copied to
@@ -83,6 +84,7 @@ func amiRegionCopy(state multistep.StateBag, config *AccessConfig, imageId strin
 	resp, err := regionconn.CopyImage(&ec2.CopyImageInput{
 		SourceRegion:  &source,
 		SourceImageID: &imageId,
+		Name:          &name,
 	})
 
 	if err != nil {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -123,6 +123,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig: &b.config.AccessConfig,
 			Regions:      b.config.AMIRegions,
+			Name:         b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description: b.config.AMIDescription,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -205,6 +205,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig: &b.config.AccessConfig,
 			Regions:      b.config.AMIRegions,
+			Name:         b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:  b.config.AMIDescription,


### PR DESCRIPTION
I have verified this PR in the current packer's unit test and also for EBS AMI Copy in AWS. Please help review it.