### PR TITLE
Fix a problem preventing `tag` or `save` from docker-tag artifacts

### DIFF
--- a/post-processor/docker-save/post-processor.go
+++ b/post-processor/docker-save/post-processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mitchellh/packer/helper/config"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/post-processor/docker-import"
+	"github.com/mitchellh/packer/post-processor/docker-tag"
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
@@ -44,7 +45,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-	if artifact.BuilderId() != dockerimport.BuilderId {
+	if artifact.BuilderId() != dockerimport.BuilderId &&
+		artifact.BuilderId() != dockertag.BuilderId {
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only save Docker builder artifacts.",
 			artifact.BuilderId())

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -45,7 +45,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-	if artifact.BuilderId() != dockerimport.BuilderId {
+	if artifact.BuilderId() != BuilderId &&
+		artifact.BuilderId() != dockerimport.BuilderId {
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only tag from Docker builder artifacts.",
 			artifact.BuilderId())


### PR DESCRIPTION
Currently, consecutive `docker-tag`s or `docker-save` after `docker-tag` in a sequence definition raises errors.

````json
{
  "post-processors": [
    [{
      "type": "docker-tag",
      "repository": "username/repository",
      "tag": "foo"
    }, {
      "type": "docker-tag",
      "repository": "username/repository",
      "tag": "bar"
    }]
  ]
}
````

The above configuration emits the following error.

````
==> docker: Running post-processor: docker-tag
Build 'docker' errored: 1 error(s) occurred:

* Post-processor failed: Unknown artifact type: packer.post-processor.docker-tag
Can only tag from Docker builder artifacts.
````