### PR TITLE
builder/aws: Add pre validate step, to validate things before building.

### DIFF
--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -35,7 +35,7 @@ func (s *StepPreValidate) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if len(resp.Images) > 0 {
-		err := fmt.Errorf("Error: an AMI with that name already exists")
+		err := fmt.Errorf("Error: name conflicts with an existing AMI: %s", *resp.Images[0].ImageID)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+// StepPreValidate provides an opportunity to pre-validate any configuration for
+// the build before actually doing any time consuming work
+//
+type StepPreValidate struct {
+	DestAmiName string
+}
+
+func (s *StepPreValidate) Run(state multistep.StateBag) multistep.StepAction {
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Prevalidating AMI Name...")
+	resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{&ec2.Filter{
+			Name:   aws.String("name"),
+			Values: []*string{aws.String(s.DestAmiName)},
+		}}})
+
+	if err != nil {
+		err := fmt.Errorf("Error querying AMI: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if len(resp.Images) > 0 {
+		err := fmt.Errorf("Error: an AMI with that name already exists")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepPreValidate) Cleanup(multistep.StateBag) {}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -78,6 +78,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Build the steps
 	steps := []multistep.Step{
+		&awscommon.StepPreValidate{
+			DestAmiName: b.config.AMIName,
+		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:          b.config.SourceAmi,
 			EnhancedNetworking: b.config.AMIEnhancedNetworking,


### PR DESCRIPTION
Taking a stab at fixing fixing #1774, by adding a step in the beginning of the process to validate things like names etc. 

Example output when using an existing name:

```console
$ packer build quickstart.json
amazon-ebs output will be in this color.

==> amazon-ebs: Prevalidating AMI Name...
==> amazon-ebs: Error: name conflicts with an existing AMI: ami-71b05a1a
Build 'amazon-ebs' errored: Error: name conflicts with an existing AMI: ami-71b05a1a

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error: name conflicts with an existing AMI: ami-71b05a1a

==> Builds finished but no artifacts were created.
```

fails in ~1 second :smile: 