### PR TITLE
virtualbox/common: remove devices should delete floppy controller

### DIFF
--- a/builder/virtualbox/common/step_remove_devices.go
+++ b/builder/virtualbox/common/step_remove_devices.go
@@ -38,6 +38,19 @@ func (s *StepRemoveDevices) Run(state multistep.StateBag) multistep.StepAction {
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
+
+		// Don't forget to remove the floppy controller as well
+		command = []string{
+			"storagectl", vmName,
+			"--name", "Floppy Controller",
+			"--remove",
+		}
+		if err := driver.VBoxManage(command...); err != nil {
+			err := fmt.Errorf("Error removing floppy controller: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	}
 
 	if _, ok := state.GetOk("attachedIso"); ok {

--- a/builder/virtualbox/common/step_remove_devices_test.go
+++ b/builder/virtualbox/common/step_remove_devices_test.go
@@ -102,10 +102,13 @@ func TestStepRemoveDevices_floppyPath(t *testing.T) {
 	}
 
 	// Test that both were removed
-	if len(driver.VBoxManageCalls) != 1 {
+	if len(driver.VBoxManageCalls) != 2 {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
 	if driver.VBoxManageCalls[0][3] != "Floppy Controller" {
+		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
+	}
+	if driver.VBoxManageCalls[1][3] != "Floppy Controller" {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
 }


### PR DESCRIPTION
Fixes #1879

In addition to simply removing the floppy disk, we should remove the floppy controller to allow future runs to potentially add the floppy controller back.

A more robust way to do this would be to verify that the floppy controller is actually empty to remove it, and checking if it already exists when we mount the floppy drive and simply not adding it. But this is probably strictly better than nothing else.