### PR TITLE
virtualbox,vmware: http server should listen on IPv4

### DIFF
--- a/builder/virtualbox/common/step_http_server.go
+++ b/builder/virtualbox/common/step_http_server.go
@@ -49,7 +49,7 @@ func (s *StepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
 		}
 
 		httpPort = offset + s.HTTPPortMin
-		httpAddr = fmt.Sprintf(":%d", httpPort)
+		httpAddr = fmt.Sprintf("0.0.0.0:%d", httpPort)
 		log.Printf("Trying port: %d", httpPort)
 		s.l, err = net.Listen("tcp", httpAddr)
 		if err == nil {

--- a/builder/vmware/common/step_http_server.go
+++ b/builder/vmware/common/step_http_server.go
@@ -49,7 +49,7 @@ func (s *StepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
 		}
 
 		httpPort = offset + s.HTTPPortMin
-		httpAddr = fmt.Sprintf(":%d", httpPort)
+		httpAddr = fmt.Sprintf("0.0.0.0:%d", httpPort)
 		log.Printf("Trying port: %d", httpPort)
 		s.l, err = net.Listen("tcp", httpAddr)
 		if err == nil {


### PR DESCRIPTION
Fixes #1709 

This forces the HTTP servers for both VirtualBox and VMware to listen on IPv4. Some hosts have problems if Packer binds to IPv6, the installers can't always connect.

I set the listen bind to `0.0.0.0` since I'm actually not sure if `127.0.0.1` will work, especially with VMware. It might work with VirtualBox... but I didn't want to risk it. We can further restrict this later, since the prior behavior was identical.

