### PR TITLE
builder/google: don't hardcode SSH timeout [GH-1781]

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -4,11 +4,11 @@ package googlecompute
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
-	"log"
-	"time"
 )
 
 // The unique ID for this builder.
@@ -63,7 +63,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&common.StepConnectSSH{
 			SSHAddress:     sshAddress,
 			SSHConfig:      sshConfig,
-			SSHWaitTimeout: 5 * time.Minute,
+			SSHWaitTimeout: b.config.sshTimeout,
 		},
 		new(common.StepProvision),
 		new(StepTeardownInstance),


### PR DESCRIPTION
Fixes #1781 

Simple oversight: we already parsed the SSH timeout from the config but still hardcoded it in the step. Use the config value. It defaults to 5m so nothing changed here.