### PR TITLE
Revert "Changing --region to --location"

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -80,7 +80,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			"-s {{.SecretKey}} " +
 			"-d {{.BundleDirectory}} " +
 			"--batch " +
-			"--location {{.Region}} " +
+			"--region {{.Region}} " +
 			"--retry"
 	}
 


### PR DESCRIPTION
This reverts commit f40fd36c3150440de0ad939e2e8c46782d709a59.

According to the documentation below, `--region` is the current flag. If you're
using an older version of the tools that use `--location`, you can customize the
commands in your Packer config with `bundle_vol_command` and `bundle_upload_command`

- http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-upload-bundle.html
- https://www.packer.io/docs/builders/amazon-instance.html

Closes/refs:
- #1931
- #2142