### PR TITLE
Update AWS EBS builder to fix invalid params

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -29,13 +29,23 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 
 	for _, blockDevice := range b {
 		ebsBlockDevice := &ec2.EBSBlockDevice{
-			SnapshotID:          &blockDevice.SnapshotId,
-			Encrypted:           &blockDevice.Encrypted,
-			IOPS:                &blockDevice.IOPS,
 			VolumeType:          &blockDevice.VolumeType,
 			VolumeSize:          &blockDevice.VolumeSize,
 			DeleteOnTermination: &blockDevice.DeleteOnTermination,
 		}
+
+		// IOPS is only valid for SSD Volumes
+		if blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
+			ebsBlockDevice.IOPS = &blockDevice.IOPS
+		}
+
+		// You cannot specify Encrypted if you specify a Snapshot ID
+		if blockDevice.SnapshotId != "" {
+			ebsBlockDevice.SnapshotID = &blockDevice.SnapshotId
+		} else {
+			ebsBlockDevice.Encrypted = &blockDevice.Encrypted
+		}
+
 		mapping := &ec2.BlockDeviceMapping{
 			EBS:         ebsBlockDevice,
 			DeviceName:  &blockDevice.DeviceName,


### PR DESCRIPTION
- `IOPS` is not a valid Block Device parameter if you're using `standard` or `gp2`
- `encrypted` is not valid if you're specifying a `snapshot_id`

Fixes #2195 