### PR TITLE
EBS volume creation fails without volume type

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -35,7 +35,7 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 		}
 
 		// IOPS is only valid for SSD Volumes
-		if blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
+		if blockDevice.VolumeType != "" && blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
 			ebsBlockDevice.IOPS = &blockDevice.IOPS
 		}
 

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -39,6 +39,23 @@ func TestBlockDevice(t *testing.T) {
 		{
 			Config: &BlockDevice{
 				DeviceName:          "/dev/sdb",
+				VolumeSize:          8,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/sdb"),
+				VirtualName: aws.String(""),
+				EBS: &ec2.EBSBlockDevice{
+					Encrypted:           aws.Boolean(false),
+					VolumeType:          aws.String(""),
+					VolumeSize:          aws.Long(8),
+					DeleteOnTermination: aws.Boolean(false),
+				},
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName:          "/dev/sdb",
 				VirtualName:         "ephemeral0",
 				VolumeType:          "io1",
 				VolumeSize:          8,


### PR DESCRIPTION
If the volume_type setting in a block device configuration is omitted, an IOPS value of 0 is set, which lets the ami creation fail with:  InvalidParameterCombination: The parameter iops is not supported for standard volumes.