### PR TITLE
builder/amazon: Allow spaces in AMI names

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -20,7 +20,7 @@ func isalphanumeric(b byte) bool {
 
 // Clean up AMI name by replacing invalid characters with "-"
 func templateCleanAMIName(s string) string {
-	allowed := []byte{'(', ')', ',', '/', '-', '_'}
+	allowed := []byte{'(', ')', ',', '/', '-', '_', ' '}
 	b := []byte(s)
 	newb := make([]byte, len(b))
 	for i, c := range b {

--- a/builder/amazon/common/template_funcs_test.go
+++ b/builder/amazon/common/template_funcs_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestAMITemplatePrepare_clean(t *testing.T) {
-	origName := "AMZamz09(),/-_:&^$%"
-	expected := "AMZamz09(),/-_-----"
+	origName := "AMZamz09(),/-_:&^ $%"
+	expected := "AMZamz09(),/-_--- --"
 
 	name := templateCleanAMIName(origName)
 


### PR DESCRIPTION
Fixes #2182 