### PR TITLE
provisioner/shell: set -e for inline [GH-2069]

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -94,7 +94,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.InlineShebang == "" {
-		p.config.InlineShebang = "/bin/sh"
+		p.config.InlineShebang = "/bin/sh -e"
 	}
 
 	if p.config.RawStartRetryTimeout == "" {
@@ -184,7 +184,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		// Write our contents to it
 		writer := bufio.NewWriter(tf)
 		writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
-		writer.WriteString("set -e\n")
 		for _, command := range p.config.Inline {
 			if _, err := writer.WriteString(command + "\n"); err != nil {
 				return fmt.Errorf("Error preparing shell script: %s", err)

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -184,6 +184,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		// Write our contents to it
 		writer := bufio.NewWriter(tf)
 		writer.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang))
+		writer.WriteString("set -e\n")
 		for _, command := range p.config.Inline {
 			if _, err := writer.WriteString(command + "\n"); err != nil {
 				return fmt.Errorf("Error preparing shell script: %s", err)

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -66,8 +66,10 @@ Optional parameters:
 
 * `inline_shebang` (string) - The
   [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) value to use when
-  running commands specified by `inline`. By default, this is `/bin/sh`.
+  running commands specified by `inline`. By default, this is `/bin/sh -e`.
   If you're not using `inline`, then this configuration has no effect.
+  **Important:** If you customize this, be sure to include something like
+  the `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
 * `remote_path` (string) - The path where the script will be uploaded to
   in the machine. This defaults to "/tmp/script.sh". This value must be


### PR DESCRIPTION
Fixes #2069 

Adds `set -e` to all inline scripts to force exit on error.

One question: is this POSIX compliant? I had a hard time finding that info anywhere. If not, any ideas to do it that way?