### PR TITLE
provisioner/shell: uploaded script should be 0755 [GH-1708]

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -247,11 +247,11 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			}
 
 			cmd = &packer.RemoteCmd{
-				Command: fmt.Sprintf("chmod 0777 %s", p.config.RemotePath),
+				Command: fmt.Sprintf("chmod 0755 %s", p.config.RemotePath),
 			}
 			if err := comm.Start(cmd); err != nil {
 				return fmt.Errorf(
-					"Error chmodding script file to 0777 in remote "+
+					"Error chmodding script file to 0755 in remote "+
 						"machine: %s", err)
 			}
 			cmd.Wait()


### PR DESCRIPTION
Fixes #1708 

Not sure why I ever chmod to 0777 for these... as pointed out in the issue it should very obviously be 0755.