### PR TITLE
documentation: subnet_id is required for non-default VPC

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -79,18 +79,18 @@ GEM
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    middleman (3.3.13)
+    middleman (3.3.12)
       coffee-script (~> 2.2)
       compass (>= 1.0.0, < 2.0.0)
       compass-import-once (= 1.0.5)
       execjs (~> 2.0)
       haml (>= 4.0.5)
       kramdown (~> 1.2)
-      middleman-core (= 3.3.13)
+      middleman-core (= 3.3.12)
       middleman-sprockets (>= 3.1.2)
       sass (>= 3.4.0, < 4.0)
       uglifier (~> 2.5)
-    middleman-core (3.3.13)
+    middleman-core (3.3.12)
       activesupport (~> 4.1.0)
       bundler (~> 1.1)
       erubis
@@ -175,3 +175,6 @@ PLATFORMS
 
 DEPENDENCIES
   middleman-hashicorp!
+
+BUNDLED WITH
+   1.10.2

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -144,7 +144,8 @@ each category, the available configuration keys are alphabetized.
   or "5m". The default SSH timeout is "5m", or five minutes.
 
 * `subnet_id` (string) - If using VPC, the ID of the subnet, such as
-  "subnet-12345def", where Packer will launch the EC2 instance.
+  "subnet-12345def", where Packer will launch the EC2 instance. This field is
+  required if you are using an non-default VPC.
 
 * `tags` (object of key/value strings) - Tags applied to the AMI.
 

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -184,7 +184,8 @@ each category, the available configuration keys are alphabetized.
   or "5m". The default SSH timeout is "5m", or five minutes.
 
 * `subnet_id` (string) - If using VPC, the ID of the subnet, such as
-  "subnet-12345def", where Packer will launch the EC2 instance.
+  "subnet-12345def", where Packer will launch the EC2 instance. This field is
+  required if you are using an non-default VPC.
 
 * `tags` (object of key/value strings) - Tags applied to the AMI.
 


### PR DESCRIPTION
From https://github.com/mitchellh/packer/issues/1935 

If using a non-default VPC, you must specify a `subnet_id` for Packer to launch the instance in.

**ALSO:** Go back to `middleman 3.3.12`; `3.3.13` got yanked 

Relevant docs:

- https://aws.amazon.com/vpc/faqs/
- http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html