### PR TITLE
Fix config interpolation for some builders

### DIFF
--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -42,10 +42,10 @@ type Config struct {
 }
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
-	var c Config
+	c := new(Config)
 
 	var md mapstructure.Metadata
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Metadata:    &md,
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
@@ -142,5 +142,5 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 
 	common.ScrubConfig(c, c.APIToken)
-	return &c, nil, nil
+	return c, nil, nil
 }

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -31,10 +31,10 @@ type Config struct {
 }
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
-	var c Config
+	c := new(Config)
 
 	var md mapstructure.Metadata
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Metadata:    &md,
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
@@ -91,5 +91,5 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		return nil, nil, errs
 	}
 
-	return &c, nil, nil
+	return c, nil, nil
 }

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -47,7 +47,7 @@ type Config struct {
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{

--- a/builder/null/config.go
+++ b/builder/null/config.go
@@ -21,7 +21,7 @@ type Config struct {
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
 
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{

--- a/builder/parallels/pvm/config.go
+++ b/builder/parallels/pvm/config.go
@@ -33,7 +33,7 @@ type Config struct {
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -40,8 +40,8 @@ type Config struct {
 }
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
-	var c Config
-	err := config.Decode(&c, &config.DecodeOpts{
+	c := new(Config)
+	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate: true,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
@@ -132,5 +132,5 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.ImportFlags = append(c.ImportFlags, "--options", c.ImportOpts)
 	}
 
-	return &c, warnings, nil
+	return c, warnings, nil
 }


### PR DESCRIPTION
Fix some of the builders (googlecompute, null, parallels/pvm) that were not working after the config interpolation changes (example below). Also, make the config usage more consistent in some of the other builders (digitalocean, docker, virtualbox/ovf).

```
$ cat nulltest.json
{
  "builders": [
    {
        "type": "null",
        "host": "test.example.com",
        "ssh_username": "test",
        "ssh_password": "password"
    }
  ]
}
$ packer validate nulltest.json
Template validation failed. Errors are shown below.

Errors validating build 'null'. 3 error(s) occurred:

* host must be specified
* ssh_username must be specified
* one of ssh_password and ssh_private_key_file must be specified
```