### PR TITLE
builder/openstack: support user data [GH-1867]

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -80,6 +80,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SecurityGroups:   b.config.SecurityGroups,
 			Networks:         b.config.Networks,
 			AvailabilityZone: b.config.AvailabilityZone,
+			UserData:         b.config.UserData,
+			UserDataFile:     b.config.UserDataFile,
 		},
 		&StepWaitForRackConnect{
 			Wait: b.config.RackconnectWait,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -23,6 +23,8 @@ type RunConfig struct {
 	FloatingIp       string   `mapstructure:"floating_ip"`
 	SecurityGroups   []string `mapstructure:"security_groups"`
 	Networks         []string `mapstructure:"networks"`
+	UserData         string   `mapstructure:"user_data"`
+	UserDataFile     string   `mapstructure:"user_data_file"`
 
 	// Not really used, but here for BC
 	OpenstackProvider string `mapstructure:"openstack_provider"`


### PR DESCRIPTION
Fixes #1867 

Adds support for user data to OpenStack. Copies the implementation of Amazon and friends.