### PR TITLE
config file doesn't need to exist if set [GH-2225]

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,12 +217,10 @@ func loadConfig() (*config, error) {
 		return nil, err
 	}
 
-	mustExist := true
 	configFilePath := os.Getenv("PACKER_CONFIG")
 	if configFilePath == "" {
 		var err error
 		configFilePath, err = configFile()
-		mustExist = false
 
 		if err != nil {
 			log.Printf("Error detecting default config file path: %s", err)
@@ -240,11 +238,7 @@ func loadConfig() (*config, error) {
 			return nil, err
 		}
 
-		if mustExist {
-			return nil, err
-		}
-
-		log.Println("File doesn't exist, but doesn't need to. Ignoring.")
+		log.Println("[WARN] Config file doesn't exist: %s", configFilePath)
 		return &config, nil
 	}
 	defer f.Close()

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func loadConfig() (*config, error) {
 			return nil, err
 		}
 
-		log.Println("[WARN] Config file doesn't exist: %s", configFilePath)
+		log.Printf("[WARN] Config file doesn't exist: %s", configFilePath)
 		return &config, nil
 	}
 	defer f.Close()


### PR DESCRIPTION
Fixes #2225 

The config file doesn't need to exist if set, and log a warning if it doesn't. This makes it so that Packer continues working even if its not set.