### PR TITLE
post-processor/atlas: adjust test for cross-platform filepath separator

### DIFF
--- a/post-processor/atlas/util_test.go
+++ b/post-processor/atlas/util_test.go
@@ -1,10 +1,12 @@
 package atlas
 
 import (
+	"path/filepath"
 	"testing"
 )
 
 func TestLongestCommonPrefix(t *testing.T) {
+	sep := string(filepath.Separator)
 	cases := []struct {
 		Input  []string
 		Output string
@@ -18,12 +20,12 @@ func TestLongestCommonPrefix(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"foo/", "foo/bar"},
-			"foo/",
+			[]string{"foo" + sep, "foo" + sep + "bar"},
+			"foo" + sep,
 		},
 		{
-			[]string{"/foo/", "/bar"},
-			"/",
+			[]string{sep + "foo" + sep, sep + "bar"},
+			sep,
 		},
 	}
 


### PR DESCRIPTION
Make TestLongestCommonPrefix cross-platform friendly by defining
the test cases with filepath.Separator.

Fixes test failure on Windows.