### PR TITLE
command/fix: validate resulting template [GH-2075]

### DIFF
--- a/command/fix_test.go
+++ b/command/fix_test.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFix_noArgs(t *testing.T) {
+	c := &PushCommand{Meta: testMeta(t)}
+	code := c.Run(nil)
+	if code != 1 {
+		t.Fatalf("bad: %#v", code)
+	}
+}
+
+func TestFix_multiArgs(t *testing.T) {
+	c := &PushCommand{Meta: testMeta(t)}
+	code := c.Run([]string{"one", "two"})
+	if code != 1 {
+		t.Fatalf("bad: %#v", code)
+	}
+}
+
+func TestFix(t *testing.T) {
+	c := &FixCommand{
+		Meta: testMeta(t),
+	}
+
+	args := []string{filepath.Join(testFixture("fix"), "template.json")}
+	if code := c.Run(args); code != 0 {
+		fatalCommand(t, c.Meta)
+	}
+}
+
+func TestFix_invalidTemplate(t *testing.T) {
+	c := &FixCommand{
+		Meta: testMeta(t),
+	}
+
+	args := []string{filepath.Join(testFixture("fix-invalid"), "template.json")}
+	if code := c.Run(args); code != 1 {
+		fatalCommand(t, c.Meta)
+	}
+}
+
+func TestFix_invalidTemplateDisableValidation(t *testing.T) {
+	c := &FixCommand{
+		Meta: testMeta(t),
+	}
+
+	args := []string{
+		"-validate=false",
+		filepath.Join(testFixture("fix-invalid"), "template.json"),
+	}
+	if code := c.Run(args); code != 0 {
+		fatalCommand(t, c.Meta)
+	}
+}

--- a/command/test-fixtures/fix-invalid/template.json
+++ b/command/test-fixtures/fix-invalid/template.json
@@ -1,0 +1,3 @@
+{
+    "hello": "world"
+}

--- a/command/test-fixtures/fix/template.json
+++ b/command/test-fixtures/fix/template.json
@@ -1,0 +1,7 @@
+{
+    "builders": [{"type": "dummy"}],
+
+    "push": {
+        "name": "foo/bar"
+    }
+}


### PR DESCRIPTION
Fixes #2075 

This adds a `-validate` flag (defaults to true) to `packer fix` that validates the fixed template. 

Unit tests added.