### PR TITLE
provisioner/shell: escape single quotes [GH-2067]

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -145,6 +145,9 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("Environment variable not in format 'key=value': %s", kv))
 		} else {
+			// Replace single quotes so they parse
+			vs[1] = strings.Replace(vs[1], "'", `'"'"'`, -1)
+
 			// Single quote env var values
 			p.config.Vars[idx] = fmt.Sprintf("%s='%s'", vs[0], vs[1])
 		}


### PR DESCRIPTION
Fixes #2067 

Escapes single quotes since we wrap everything in single quotes. Hard to unit test, you can verify with the null builder:

```
{
    "builders": [{
        "type": "null",
        "host": "127.0.0.1",
        "ssh_username": "USER",
        "ssh_password": "PASS"
    }],

    "provisioners": [{
        "type": "shell",
        "environment_vars": ["FOO=bar's"],
        "inline": "echo $FOO"
    }]
}

```