### PR TITLE
builder/qemu: use proper ssh port [GH-2074]

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -80,7 +80,8 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 
 	defaultArgs["-name"] = vmName
 	defaultArgs["-machine"] = fmt.Sprintf("type=%s", config.MachineType)
-	defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:22", sshHostPort)
+	defaultArgs["-netdev"] = fmt.Sprintf(
+		"user,id=user.0,hostfwd=tcp::%v-:%d", sshHostPort, config.SSHPort)
 	defaultArgs["-device"] = fmt.Sprintf("%s,netdev=user.0", config.NetDevice)
 	defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard)
 	if !config.DiskImage {


### PR DESCRIPTION
Fixes #2074 

The guest port configured via `ssh_port` is properly used. This defaults to 22 as well.