### PR TITLE
helper/communicator: configurable handshake attempts [GH-1988]

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -12,14 +12,15 @@ import (
 // Config is the common configuration that communicators allow within
 // a builder.
 type Config struct {
-	Type          string        `mapstructure:"communicator"`
-	SSHHost       string        `mapstructure:"ssh_host"`
-	SSHPort       int           `mapstructure:"ssh_port"`
-	SSHUsername   string        `mapstructure:"ssh_username"`
-	SSHPassword   string        `mapstructure:"ssh_password"`
-	SSHPrivateKey string        `mapstructure:"ssh_private_key_file"`
-	SSHPty        bool          `mapstructure:"ssh_pty"`
-	SSHTimeout    time.Duration `mapstructure:"ssh_timeout"`
+	Type                 string        `mapstructure:"communicator"`
+	SSHHost              string        `mapstructure:"ssh_host"`
+	SSHPort              int           `mapstructure:"ssh_port"`
+	SSHUsername          string        `mapstructure:"ssh_username"`
+	SSHPassword          string        `mapstructure:"ssh_password"`
+	SSHPrivateKey        string        `mapstructure:"ssh_private_key_file"`
+	SSHPty               bool          `mapstructure:"ssh_pty"`
+	SSHTimeout           time.Duration `mapstructure:"ssh_timeout"`
+	SSHHandshakeAttempts int           `mapstructure:"ssh_handshake_attempts"`
 }
 
 func (c *Config) Prepare(ctx *interpolate.Context) []error {
@@ -33,6 +34,10 @@ func (c *Config) Prepare(ctx *interpolate.Context) []error {
 
 	if c.SSHTimeout == 0 {
 		c.SSHTimeout = 5 * time.Minute
+	}
+
+	if c.SSHHandshakeAttempts == 0 {
+		c.SSHHandshakeAttempts = 10
 	}
 
 	// Validation

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -149,8 +149,10 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 				handshakeAttempts += 1
 			}
 
-			if handshakeAttempts < 10 {
-				// Try to connect via SSH a handful of times
+			if handshakeAttempts < s.Config.SSHHandshakeAttempts {
+				// Try to connect via SSH a handful of times. We sleep here
+				// so we don't get a ton of authentication errors back to back.
+				time.Sleep(2 * time.Second)
 				continue
 			}
 


### PR DESCRIPTION
Fixes #1988 

This does two things:

* Add a 2 second sleep between auth errors. This is to allow the machine time to set itself up.
* Add `ssh_handshake_attempts` to be able to configure the number of attempts. Defaults to 10 (the same old value).