### PR TITLE
Enable ssh agent forwarding #1066

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ FEATURES:
       being built. This should be used for template-relative paths. [GH-54]
   * **Disable SSH:** Set `communicator` to "none" in any builder to disable SSH
       connections. Note that provisioners won't work if this is done. [GH-1591]
+  * **SSH Agent Forwarding:** SSH Agent Forwarding will now be enabled
+      to allow access to remote servers such as private git repos. [GH-1066]
 
 IMPROVEMENTS:
 

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -146,6 +146,33 @@ on reboot or in your shell script. For example, on Gentoo:
 /etc/init.d/net.eth0 stop
 ```
 
+## SSH Agent Forwarding
+
+Some provisioning requires connecting to remote SSH servers from within the
+packer instance. The below example is for pulling code from a private git
+repository utilizing openssh on the client. Make sure you are running
+`ssh-agent` and add your git repo ssh keys into it using `ssh-add /path/to/key`.
+When the packer instance needs access to the ssh keys the agent will forward
+the request back to your `ssh-agent`.
+
+Note: when provisioning via git you should add the git server keys into
+the `~/.ssh/known_hosts` file otherwise the git command could hang awaiting
+input. This can be done by copying the file in via the
+[file provisioner](/docs/provisioners/file.html) (more secure)
+or using `ssh-keyscan` to populate the file (less secure). An example of the
+latter accessing github would be:
+
+```
+{
+  "type": "shell",
+  "inline": [
+    "sudo apt-get install -y git",
+    "ssh-keyscan github.com >> ~/.ssh/known_hosts",
+    "git clone git@github.com:exampleorg/myprivaterepo.git"
+  ]
+}
+```
+
 ## Troubleshooting
 
 *My shell script doesn't work correctly on Ubuntu*


### PR DESCRIPTION
I've been debating whether this should be enabled by default for ease of use or make it an ssh configuration bool (which is much more straightforward with the recent ssh changes). Thoughts?