### PR TITLE
Windows AWS instances

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/helper/communicator"
@@ -27,6 +28,7 @@ type RunConfig struct {
 	TemporaryKeyPairName     string            `mapstructure:"temporary_key_pair_name"`
 	UserData                 string            `mapstructure:"user_data"`
 	UserDataFile             string            `mapstructure:"user_data_file"`
+	WindowsPasswordTimeout   time.Duration     `mapstructure:"windows_password_timeout"`
 	VpcId                    string            `mapstructure:"vpc_id"`
 
 	// Communicator settings
@@ -38,6 +40,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.TemporaryKeyPairName == "" {
 		c.TemporaryKeyPairName = fmt.Sprintf(
 			"packer %s", uuid.TimeOrderedUUID())
+	}
+
+	if c.WindowsPasswordTimeout == 0 {
+		c.WindowsPasswordTimeout = 10 * time.Minute
 	}
 
 	// Validation

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -48,9 +48,7 @@ func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
 		ui.Say("Waiting for auto-generated password for instance...")
 		ui.Message(
 			"It is normal for this process to take up to 15 minutes,\n" +
-				"but it usually takes around 5. Please wait. After the\n" +
-				"password is read, it will printed out below. Since it should\n" +
-				"be a temporary password, this should be a minimal security risk.")
+				"but it usually takes around 5. Please wait.")
 		password, err = s.waitForPassword(state, cancel)
 		waitDone <- true
 	}()
@@ -68,7 +66,7 @@ WaitLoop:
 				return multistep.ActionHalt
 			}
 
-			ui.Message(fmt.Sprintf(" \nPassword retrieved: %s", password))
+			ui.Message(fmt.Sprintf(" \nPassword retrieved!"))
 			s.Comm.WinRMPassword = password
 			break WaitLoop
 		case <-timeout:

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -46,6 +46,9 @@ func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
 	waitDone := make(chan bool, 1)
 	go func() {
 		ui.Say("Waiting for auto-generated password for instance...")
+		ui.Message(
+			"It is normal for this process to take up to 15 minutes,\n" +
+				"but it usually takes around 5. Please wait.")
 		password, err = s.waitForPassword(state, cancel)
 		waitDone <- true
 	}()

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -1,0 +1,155 @@
+package common
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/helper/communicator"
+	"github.com/mitchellh/packer/packer"
+)
+
+// StepGetPassword reads the password from a Windows server and sets it
+// on the WinRM config.
+type StepGetPassword struct {
+	Comm    *communicator.Config
+	Timeout time.Duration
+}
+
+func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	image := state.Get("source_image").(*ec2.Image)
+
+	// Skip if we're not Windows...
+	if *image.Platform != "windows" {
+		log.Printf("[INFO] Not Windows, skipping get password...")
+		return multistep.ActionContinue
+	}
+
+	// If we already have a password, skip it
+	if s.Comm.WinRMPassword != "" {
+		ui.Say("Skipping waiting for password since WinRM password set...")
+		return multistep.ActionContinue
+	}
+
+	// Get the password
+	var password string
+	var err error
+	cancel := make(chan struct{})
+	waitDone := make(chan bool, 1)
+	go func() {
+		ui.Say("Waiting for auto-generated password for instance...")
+		password, err = s.waitForPassword(state, cancel)
+		waitDone <- true
+	}()
+
+	timeout := time.After(s.Timeout)
+WaitLoop:
+	for {
+		// Wait for either SSH to become available, a timeout to occur,
+		// or an interrupt to come through.
+		select {
+		case <-waitDone:
+			if err != nil {
+				ui.Error(fmt.Sprintf("Error waiting for password: %s", err))
+				state.Put("error", err)
+				return multistep.ActionHalt
+			}
+
+			ui.Message("Password retrieved!")
+			s.Comm.WinRMPassword = password
+			break WaitLoop
+		case <-timeout:
+			err := fmt.Errorf("Timeout waiting for password.")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			close(cancel)
+			return multistep.ActionHalt
+		case <-time.After(1 * time.Second):
+			if _, ok := state.GetOk(multistep.StateCancelled); ok {
+				// The step sequence was cancelled, so cancel waiting for password
+				// and just start the halting process.
+				close(cancel)
+				log.Println("[WARN] Interrupt detected, quitting waiting for password.")
+				return multistep.ActionHalt
+			}
+		}
+	}
+	return multistep.ActionContinue
+}
+
+func (s *StepGetPassword) Cleanup(multistep.StateBag) {}
+
+func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-chan struct{}) (string, error) {
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	instance := state.Get("instance").(*ec2.Instance)
+	privateKey := state.Get("privateKey").(string)
+
+	for {
+		select {
+		case <-cancel:
+			log.Println("[INFO] Retrieve password wait cancelled. Exiting loop.")
+			return "", errors.New("Retrieve password wait cancelled")
+		case <-time.After(5 * time.Second):
+		}
+
+		resp, err := ec2conn.GetPasswordData(&ec2.GetPasswordDataInput{
+			InstanceID: instance.InstanceID,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error retrieving auto-generated instance password: %s", err)
+			return "", err
+		}
+
+		if resp.PasswordData != nil && *resp.PasswordData != "" {
+			decryptedPassword, err := decryptPasswordDataWithPrivateKey(
+				*resp.PasswordData, []byte(privateKey))
+			if err != nil {
+				err := fmt.Errorf("Error decrypting auto-generated instance password: %s", err)
+				return "", err
+			}
+
+			return decryptedPassword, nil
+		}
+	}
+}
+
+func decryptPasswordDataWithPrivateKey(passwordData string, pemBytes []byte) (string, error) {
+	encryptedPasswd, err := base64.StdEncoding.DecodeString(passwordData)
+	if err != nil {
+		return "", err
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	var asn1Bytes []byte
+	if _, ok := block.Headers["DEK-Info"]; ok {
+		return "", errors.New("encrypted private key isn't yet supported")
+		/*
+			asn1Bytes, err = x509.DecryptPEMBlock(block, password)
+			if err != nil {
+				return "", err
+			}
+		*/
+	} else {
+		asn1Bytes = block.Bytes
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(asn1Bytes)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := rsa.DecryptPKCS1v15(nil, key, encryptedPasswd)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -28,7 +28,7 @@ func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
 	image := state.Get("source_image").(*ec2.Image)
 
 	// Skip if we're not Windows...
-	if *image.Platform != "windows" {
+	if image.Platform == nil || *image.Platform != "windows" {
 		log.Printf("[INFO] Not Windows, skipping get password...")
 		return multistep.ActionContinue
 	}

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -48,7 +48,9 @@ func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
 		ui.Say("Waiting for auto-generated password for instance...")
 		ui.Message(
 			"It is normal for this process to take up to 15 minutes,\n" +
-				"but it usually takes around 5. Please wait.")
+				"but it usually takes around 5. Please wait. After the\n" +
+				"password is read, it will printed out below. Since it should\n" +
+				"be a temporary password, this should be a minimal security risk.")
 		password, err = s.waitForPassword(state, cancel)
 		waitDone <- true
 	}()
@@ -66,7 +68,7 @@ WaitLoop:
 				return multistep.ActionHalt
 			}
 
-			ui.Message("Password retrieved!")
+			ui.Message(fmt.Sprintf(" \nPassword retrieved: %s", password))
 			s.Comm.WinRMPassword = password
 			break WaitLoop
 		case <-timeout:
@@ -121,6 +123,8 @@ func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-cha
 
 			return decryptedPassword, nil
 		}
+
+		log.Printf("[DEBUG] Password is blank, will retry...")
 	}
 }
 

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -53,7 +54,14 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 			return multistep.ActionHalt
 		}
 
+		// Test if it is encoded already, and if not, encode it
+		if _, err := base64.StdEncoding.DecodeString(string(contents)); err != nil {
+			log.Printf("[DEBUG] base64 encoding user data...")
+			contents = []byte(base64.StdEncoding.EncodeToString(contents))
+		}
+
 		userData = string(contents)
+
 	}
 
 	ui.Say("Launching a source AWS instance...")

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -94,7 +94,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupIds: b.config.SecurityGroupIds,
-			SSHPort:          b.config.RunConfig.Comm.SSHPort,
+			CommConfig:       &b.config.RunConfig.Comm,
 			VpcId:            b.config.VpcId,
 		},
 		&awscommon.StepRunSourceInstance{

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -113,6 +113,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
 		},
+		&awscommon.StepGetPassword{
+			Comm:    &b.config.RunConfig.Comm,
+			Timeout: b.config.WindowsPasswordTimeout,
+		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -198,6 +198,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
 		},
+		&awscommon.StepGetPassword{
+			Comm:    &b.config.RunConfig.Comm,
+			Timeout: b.config.WindowsPasswordTimeout,
+		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -179,8 +179,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			PrivateKeyFile: b.config.RunConfig.Comm.SSHPrivateKey,
 		},
 		&awscommon.StepSecurityGroup{
+			CommConfig:       &b.config.RunConfig.Comm,
 			SecurityGroupIds: b.config.SecurityGroupIds,
-			SSHPort:          b.config.RunConfig.Comm.SSHPort,
 			VpcId:            b.config.VpcId,
 		},
 		&awscommon.StepRunSourceInstance{

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -31,6 +31,18 @@ type Config struct {
 	WinRMTimeout  time.Duration `mapstructure:"winrm_timeout"`
 }
 
+// Port returns the port that will be used for access based on config.
+func (c *Config) Port() int {
+	switch c.Type {
+	case "ssh":
+		return c.SSHPort
+	case "winrm":
+		return c.WinRMPort
+	default:
+		return 0
+	}
+}
+
 func (c *Config) Prepare(ctx *interpolate.Context) []error {
 	if c.Type == "" {
 		c.Type = "ssh"

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -42,6 +42,7 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		if config.InterpolateContext == nil {
 			config.InterpolateContext = ctx
 		} else {
+			config.InterpolateContext.TemplatePath = ctx.TemplatePath
 			config.InterpolateContext.UserVariables = ctx.UserVariables
 		}
 		ctx = config.InterpolateContext

--- a/template/parse.go
+++ b/template/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
@@ -315,6 +316,13 @@ func ParseFile(path string) (*Template, error) {
 	tpl, err := Parse(f)
 	if err != nil {
 		return nil, err
+	}
+
+	if !filepath.IsAbs(path) {
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	tpl.Path = path

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -306,7 +307,7 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		path := fixtureDir(tc.File)
+		path, _ := filepath.Abs(fixtureDir(tc.File))
 		tpl, err := ParseFile(fixtureDir(tc.File))
 		if (err != nil) != tc.Err {
 			t.Fatalf("err: %s", err)

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -168,6 +168,10 @@ each category, the available configuration keys are alphabetized.
 * `vpc_id` (string) - If launching into a VPC subnet, Packer needs the
   VPC ID in order to create a temporary security group within the VPC.
 
+* `windows_password_timeout` (string) - The timeout for waiting for
+  a Windows password for Windows instances. Defaults to 20 minutes.
+  Example value: "10m"
+
 ## Basic Example
 
 Here is a basic example. It is completely valid except for the access keys:

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -209,6 +209,10 @@ each category, the available configuration keys are alphabetized.
   it is perfectly okay to create this directory as part of the provisioning
   process.
 
+* `windows_password_timeout` (string) - The timeout for waiting for
+  a Windows password for Windows instances. Defaults to 20 minutes.
+  Example value: "10m"
+
 ## Basic Example
 
 Here is a basic example. It is completely valid except for the access keys:


### PR DESCRIPTION
Fixes #697 

This adds support for Windows AWS instances. We automatically detect Windows AMIs and call the `GetPasswordData` API to get the admin password, decrypt it with our private key, and use that to configure WinRM. 

There is also a pretty important `template_dir` bug fix that slipped in here that I found while working on this.

HUGE props to the Packer community for pointing me in the right direction to get this done, there is almost zero personal creativity here and 100% community creativity.