### PR TITLE
Fix network interface spec when requesting spot.

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -174,11 +174,15 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 				ImageID:            &s.SourceAMI,
 				InstanceType:       &s.InstanceType,
 				UserData:           &userData,
-				SecurityGroupIDs:   securityGroupIds,
 				IAMInstanceProfile: &ec2.IAMInstanceProfileSpecification{Name: &s.IamInstanceProfile},
-				SubnetID:           &s.SubnetId,
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
-					&ec2.InstanceNetworkInterfaceSpecification{AssociatePublicIPAddress: &s.AssociatePublicIpAddress},
+					&ec2.InstanceNetworkInterfaceSpecification{
+						DeviceIndex:              aws.Long(0),
+						AssociatePublicIPAddress: &s.AssociatePublicIpAddress,
+						SubnetID:                 &s.SubnetId,
+						Groups:                   securityGroupIds,
+						DeleteOnTermination:      aws.Boolean(true),
+					},
 				},
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: &availabilityZone,


### PR DESCRIPTION
Fixes the error on creating spot instances:
`InvalidParameterValue: Each network interface requires a device index.`
According to AWS Go SDK, when creating network interface, device index must be specified. 

Moreover, we need to pass Subnet ID and Security Group ID when creating NetworkInterfaceSpecification (instead of passing them as instance-level parameter).