### PR TITLE
provisioner/chef-client: chmod the directories

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -310,16 +310,25 @@ func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir stri
 		mkdirCmd = "sudo " + mkdirCmd
 	}
 
-	cmd := &packer.RemoteCmd{
-		Command: mkdirCmd,
-	}
-
+	cmd := &packer.RemoteCmd{Command: mkdirCmd}
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		return err
 	}
-
 	if cmd.ExitStatus != 0 {
-		return fmt.Errorf("Non-zero exit status.")
+		return fmt.Errorf("Non-zero exit status. See output above for more info.")
+	}
+
+	// Chmod the directory to 0777 just so that we can access it as our user
+	mkdirCmd = fmt.Sprintf("chmod 0777 '%s'", dir)
+	if !p.config.PreventSudo {
+		mkdirCmd = "sudo " + mkdirCmd
+	}
+	cmd = &packer.RemoteCmd{Command: mkdirCmd}
+	if err := cmd.StartWithUi(comm, ui); err != nil {
+		return err
+	}
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf("Non-zero exit status. See output above for more info.")
 	}
 
 	return nil

--- a/website/source/docs/provisioners/chef-client.html.markdown
+++ b/website/source/docs/provisioners/chef-client.html.markdown
@@ -161,3 +161,12 @@ curl -L https://www.opscode.com/chef/install.sh | \
 ```
 
 This command can be customized using the `install_command` configuration.
+
+## Folder Permissions
+
+The `chef-client` provisioner will chmod the directory with your Chef
+keys to 777. This is to ensure that Packer can upload and make use of that
+directory. However, once the machine is created, you usually don't
+want to keep these directories with those permissions. To change the
+permissions on the directories, append a shell provisioner after Chef
+to modify them.

--- a/website/source/docs/provisioners/chef-client.html.markdown
+++ b/website/source/docs/provisioners/chef-client.html.markdown
@@ -164,7 +164,7 @@ This command can be customized using the `install_command` configuration.
 
 ## Folder Permissions
 
-The `chef-client` provisioner will chmod the directory with your Chef
+!> The `chef-client` provisioner will chmod the directory with your Chef
 keys to 777. This is to ensure that Packer can upload and make use of that
 directory. However, once the machine is created, you usually don't
 want to keep these directories with those permissions. To change the


### PR DESCRIPTION
Fixes #1054 

This chmods the staging directory to 0777 to avoid any permissions issues. This isn't ideal, so I've added to the docs how to revert permissions using Packer if this isn't okay. 