### PR TITLE
provisioner/puppet-masterless: only base if manifest is a file [GH-1933]

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -264,6 +264,8 @@ func (p *Provisioner) uploadManifests(ui packer.Ui, comm packer.Communicator) (s
 		return "", fmt.Errorf("Error inspecting manifest file: %s", err)
 	} else if !fi.IsDir() {
 		manifestFilename = filepath.Base(manifestFilename)
+	} else {
+		ui.Say("WARNING: manifest_file should be a file. Use manifest_dir for directories")
 	}
 
 	remoteManifestFile := fmt.Sprintf("%s/%s", remoteManifestsPath, manifestFilename)

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -259,7 +259,13 @@ func (p *Provisioner) uploadManifests(ui packer.Ui, comm packer.Communicator) (s
 	}
 	defer f.Close()
 
-	manifestFilename := filepath.Base(p.config.ManifestFile)
+	manifestFilename := p.config.ManifestFile
+	if fi, err := os.Stat(p.config.ManifestFile); err != nil {
+		return "", fmt.Errorf("Error inspecting manifest file: %s", err)
+	} else if !fi.IsDir() {
+		manifestFilename = filepath.Base(manifestFilename)
+	}
+
 	remoteManifestFile := fmt.Sprintf("%s/%s", remoteManifestsPath, manifestFilename)
 	if err := comm.Upload(remoteManifestFile, f, nil); err != nil {
 		return "", err


### PR DESCRIPTION
Fixes #1933 

We only want the directory of the manifest file if its a file.