### PR TITLE
include mention of security group id. Otherwise, this option isn't cl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ own.
     "instance_type": "t1.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
+    "security_group_id" : "OPTIONAL SECURITY GROUP ID"
   }]
 }
 ```


### PR DESCRIPTION
…ear from the docs.

I only found out about this option through an issue https://github.com/mitchellh/packer/issues/350, I couldn't see it mentioned in the docs anywhere. It would be worth mentioning somewhere in the docs if not the quickstart.