### PR TITLE
Add quickfix to restart provisioner as existing one was not working.

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
-var DefaultRestartCommand = "shutdown /r /c \"packer restart\" /t 5 && net stop winrm"
+var DefaultRestartCommand = "powershell \"& {Restart-Computer -force }\""
 var DefaultRestartCheckCommand = winrm.Powershell(`echo "${env:COMPUTERNAME} restarted."`)
 var retryableSleep = 5 * time.Second
 


### PR DESCRIPTION
Change the restart script to use the powershell cmdlet and use -force this makes the server shutdown all services immediately, also remove the command to stop WinRM as this will cause a terminating error as WinRM does not currently handle the termination correctly.

Reference: https://github.com/mitchellh/packer/pull/2243