### PR TITLE
communicator/ssh: support for bastion SSH

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -86,6 +86,10 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		if c.SSHBastionPort == 0 {
 			c.SSHBastionPort = 22
 		}
+
+		if c.SSHBastionPrivateKey == "" && c.SSHPrivateKey != "" {
+			c.SSHBastionPrivateKey = c.SSHPrivateKey
+		}
 	}
 
 	// Validation


### PR DESCRIPTION
Fixes #387 

This builds on #1721 and makes an SSH bastion host available to all builders.

For docs I still want to do a bigger communicator section for the docs, so leaving it out for now since I inevitably have to go over every communicator config anyways.