### PR TITLE
Force qemu to use a VNC port by setting vnc_min_port == vnc_max_port

### DIFF
--- a/builder/qemu/step_configure_vnc.go
+++ b/builder/qemu/step_configure_vnc.go
@@ -32,7 +32,12 @@ func (stepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
 	var vncPort uint
 	portRange := int(config.VNCPortMax - config.VNCPortMin)
 	for {
-		vncPort = uint(rand.Intn(portRange)) + config.VNCPortMin
+		if portRange > 0 {
+		    vncPort = uint(rand.Intn(portRange)) + config.VNCPortMin
+		} else {
+			vncPort = config.VNCPortMin
+		}
+ 
 		log.Printf("Trying port: %d", vncPort)
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", vncPort))
 		if err == nil {


### PR DESCRIPTION
Similar to Issue #1288, this prevents a crash when we set the VNC
minimum port equivalent to the VNC maximum port

Ran `go test` and `make dev` and tested it with a file that has the same VNC min and max port.