### PR TITLE
post-processor/vagrant-cloud: retry uploads [GH-2167]

### DIFF
--- a/post-processor/vagrant-cloud/step_upload.go
+++ b/post-processor/vagrant-cloud/step_upload.go
@@ -2,6 +2,8 @@ package vagrantcloud
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
 )
@@ -17,13 +19,38 @@ func (s *stepUpload) Run(state multistep.StateBag) multistep.StepAction {
 	url := upload.UploadPath
 
 	ui.Say(fmt.Sprintf("Uploading box: %s", artifactFilePath))
+	ui.Message(
+		"Depending on your internet connection and the size of the box,\n" +
+			"this may take some time")
 
-	ui.Message("Depending on your internet connection and the size of the box, this may take some time")
+	var finalErr error
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			ui.Message(fmt.Sprintf("Uploading box, attempt %d", i+1))
+		}
 
-	resp, err := client.Upload(artifactFilePath, url)
+		resp, err := client.Upload(artifactFilePath, url)
+		if err != nil {
+			finalErr = err
+			ui.Message(fmt.Sprintf(
+				"Error uploading box! Will retry in 10 seconds. Error: %s", err))
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		if resp.StatusCode != 200 {
+			finalErr = fmt.Errorf("bad HTTP status: %d", resp.StatusCode)
+			ui.Message(fmt.Sprintf(
+				"Error uploading box! Will retry in 10 seconds. Status: %d",
+				resp.StatusCode))
+			time.Sleep(10 * time.Second)
+			continue
+		}
 
-	if err != nil || (resp.StatusCode != 200) {
-		state.Put("error", fmt.Errorf("Error uploading Box: %s", err))
+		finalErr = nil
+	}
+
+	if finalErr != nil {
+		state.Put("error", finalErr)
 		return multistep.ActionHalt
 	}
 


### PR DESCRIPTION
Fixes #2167 

This adds a retry mechanism to the box upload for the `vagrant-cloud` post-processor. This post-processor is relatively deprecated (not formally, we'll keep API compat), so there aren't good tests around it, but we just do a basic 3 time retry. 
