### PR TITLE
provisioner/shell: randomize default script name

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -18,8 +19,6 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/template/interpolate"
 )
-
-const DefaultRemotePath = "/tmp/script.sh"
 
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
@@ -102,7 +101,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.RemotePath == "" {
-		p.config.RemotePath = DefaultRemotePath
+		p.config.RemotePath = fmt.Sprintf(
+			"/tmp/script_%d.sh", rand.Intn(9999))
 	}
 
 	if p.config.Scripts == nil {

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -30,7 +30,7 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.RemotePath != DefaultRemotePath {
+	if p.config.RemotePath == "" {
 		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
 	}
 }


### PR DESCRIPTION
Fixes #1872 

Randomize the name to help fight against weird non-determinism in Windows delete/create ordering of files.