### PR TITLE
Parallels: Apply default settings on the VM creation step.

### DIFF
--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -44,6 +44,9 @@ type Driver interface {
 	// Send scancodes to the vm using the prltype python script.
 	SendKeyScanCodes(string, ...string) error
 
+	// Apply default сonfiguration settings to the virtual machine
+	SetDefaultConfiguration(string) error
+
 	// Finds the MAC address of the NIC nic0
 	Mac(string) (string, error)
 

--- a/builder/parallels/common/driver_10.go
+++ b/builder/parallels/common/driver_10.go
@@ -5,3 +5,27 @@ package common
 type Parallels10Driver struct {
 	Parallels9Driver
 }
+
+func (d *Parallels10Driver) SetDefaultConfiguration(vmName string) error {
+	commands := make([][]string, 12)
+	commands[0] = []string{"set", vmName, "--cpus", "1"}
+	commands[1] = []string{"set", vmName, "--memsize", "512"}
+	commands[2] = []string{"set", vmName, "--startup-view", "same"}
+	commands[3] = []string{"set", vmName, "--on-shutdown", "close"}
+	commands[4] = []string{"set", vmName, "--on-window-close", "keep-running"}
+	commands[5] = []string{"set", vmName, "--auto-share-camera", "off"}
+	commands[6] = []string{"set", vmName, "--smart-guard", "off"}
+	commands[7] = []string{"set", vmName, "--shared-cloud", "off"}
+	commands[8] = []string{"set", vmName, "--shared-profile", "off"}
+	commands[9] = []string{"set", vmName, "--smart-mount", "off"}
+	commands[10] = []string{"set", vmName, "--sh-app-guest-to-host", "off"}
+	commands[11] = []string{"set", vmName, "--sh-app-host-to-guest", "off"}
+
+	for _, command := range commands {
+		err := d.Prlctl(command...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -255,6 +255,25 @@ func prepend(head string, tail []string) []string {
 	return tmp
 }
 
+func (d *Parallels9Driver) SetDefaultConfiguration(vmName string) error {
+	commands := make([][]string, 7)
+	commands[0] = []string{"set", vmName, "--cpus", "1"}
+	commands[1] = []string{"set", vmName, "--memsize", "512"}
+	commands[2] = []string{"set", vmName, "--startup-view", "same"}
+	commands[3] = []string{"set", vmName, "--on-shutdown", "close"}
+	commands[4] = []string{"set", vmName, "--on-window-close", "keep-running"}
+	commands[5] = []string{"set", vmName, "--auto-share-camera", "off"}
+	commands[6] = []string{"set", vmName, "--smart-guard", "off"}
+
+	for _, command := range commands {
+		err := d.Prlctl(command...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *Parallels9Driver) Mac(vmName string) (string, error) {
 	var stdout bytes.Buffer
 


### PR DESCRIPTION
This PR adds default configuration settings for the virtual machine. 
The main goal is disable some integration features while creating the VM in Parallels Desktop 10 and higher. 

Actually, these features should be disabled in the Packer's artifact:
- Shared Cloud (share iCloud/Dropbox/Google Drive with VM)
- Shared Profile (share user folders like ~/Documents, ~/Pictures, etc. with VM)
- Smart Mount (share external drives and volumes with VM)
- Sharing applications Guest -> Host
- Sharing applications Host -> Guest 

P.s. There are different functions in driver structs because some prlctl options appeared only in Parallels Desktop 10 release.

I hope, this PR has a chance to be merged before 0.8.0 release. :)

cc:\ @mitchellh, @rickard-von-essen 