### PR TITLE
update the documented datatype for facter to 'object of key/value str…

### DIFF
--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -50,7 +50,7 @@ Optional parameters:
   various [configuration template variables](/docs/templates/configuration-templates.html)
   available. See below for more information.
 
-* `facter` (object, string keys and values) - Additional
+* `facter` (object of key/value strings) - Additional
   [facts](http://puppetlabs.com/puppet/related-projects/facter) to make
   available when Puppet is running.
 

--- a/website/source/docs/provisioners/puppet-server.html.markdown
+++ b/website/source/docs/provisioners/puppet-server.html.markdown
@@ -48,7 +48,7 @@ required. They are listed below:
   the node on your disk. This defaults to nothing, in which case a client
   private key won't be uploaded.
 
-* `facter` (hash) - Additional Facter facts to make available to the
+* `facter` (object of key/value strings) - Additional Facter facts to make available to the
   Puppet run.
 
 * `options` (string) - Additional command line options to pass


### PR DESCRIPTION
…ings' for both puppet provisioners.

This is a minor change to the documentation for the Puppet provisioners. I found the facter datatype for puppet-server to be confusing and changed it to 'object of key/value strings' since this more accurately reflects what it is, I think.

I also made the same change to puppet-client for consistency. `Object of key/value strings` was chosen because this is what is commonly used in the documentation for other Packer components.