### PR TITLE
provisioner/puppet-server: Add ignore exit codes option

### DIFF
--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -38,6 +38,10 @@ type Config struct {
 	// The directory where files will be uploaded. Packer requires write
 	// permissions in this directory.
 	StagingDir string `mapstructure:"staging_dir"`
+
+	// If true, packer will ignore all exit-codes from a puppet run
+	IgnoreExitCodes bool `mapstructure:"ignore_exit_codes"`
+
 }
 
 type Provisioner struct {
@@ -200,7 +204,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return err
 	}
 
-	if cmd.ExitStatus != 0 && cmd.ExitStatus != 2 {
+	if cmd.ExitStatus != 0 && cmd.ExitStatus != 2 && !p.config.IgnoreExitCodes {
 		return fmt.Errorf("Puppet exited with a non-zero exit status: %d", cmd.ExitStatus)
 	}
 


### PR DESCRIPTION
This adds the ability to ignore exit codes given by puppet when it encounters errors in a run. Sometimes [puppet](https://docs.puppetlabs.com/references/3.6.2/man/agent.html) will return exit code 6 which meant that there were both errors and warnings. As a side-effect this will break out of the packer run and won't continue, for most cases a status 6 doesn't necessarily mean that the puppet provision didn't work as expected. 