### PR TITLE
[vsphere post processor] Make ResourcePool optional. Upload the template to an specific host

### DIFF
--- a/website/source/docs/post-processors/vsphere.html.markdown
+++ b/website/source/docs/post-processors/vsphere.html.markdown
@@ -35,7 +35,7 @@ Required:
   endpoint.
 
 * `resource_pool` (string) - The resource pool to upload the VM to.
-  This is _not required_ if `datastore` is specified.
+  This is _not required_.
 
 * `username` (string) - The username to use to authenticate to the vSphere
   endpoint.


### PR DESCRIPTION
Using " " as a ResourcePool like the documentation suggests doesn't work [1]. This PR fixes it

This PR also allows to upload the template to an specific host appending it to the cluster name:
```
"resource_pool": "<cluste-name>/<host-name>"
```

[1] "This can be " " if you do not have resource pools configured". https://www.packer.io/docs/post-processors/vsphere.html#resource_pool