### PR TITLE
builder/qemu: default acceleration to tcg on Windows [GH-2284]

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -153,7 +154,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if b.config.Accelerator == "" {
-		b.config.Accelerator = "kvm"
+		if runtime.GOOS == "windows" {
+			b.config.Accelerator = "tcg"
+		} else {
+			b.config.Accelerator = "kvm"
+		}
 	}
 
 	if b.config.HTTPPortMin == 0 {


### PR DESCRIPTION
Fixes #2284 

This changes the default accelerator to `tcg` on Windows. I'm not sure what the implication is of this for other defaults but I'm believing the issue in that this is required.