### PR TITLE
fix file download provisioner

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -47,10 +47,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	var errs *packer.MultiError
-	if _, err := os.Stat(p.config.Source); err != nil {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("Bad source '%s': %s", p.config.Source, err))
-	}
 
 	if p.config.Direction != "download" && p.config.Direction != "upload" {
 		errs = packer.MultiErrorAppend(errs,


### PR DESCRIPTION
when file used with download direction we don't need
to check source on builder because it on machine.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>