### PR TITLE
helper/communicator: support disabling SSH agent

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -37,6 +37,9 @@ type Config struct {
 
 	// Pty, if true, will request a pty from the remote end.
 	Pty bool
+
+	// DisableAgent, if true, will not forward the SSH agent.
+	DisableAgent bool
 }
 
 // Creates a new packer.Communicator implementation over SSH. This takes
@@ -284,6 +287,11 @@ func (c *comm) reconnect() (err error) {
 
 func (c *comm) connectToAgent() {
 	if c.client == nil {
+		return
+	}
+
+	if c.config.DisableAgent {
+		log.Printf("[INFO] SSH agent forwarding is diabled.")
 		return
 	}
 

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	SSHPrivateKey        string        `mapstructure:"ssh_private_key_file"`
 	SSHPty               bool          `mapstructure:"ssh_pty"`
 	SSHTimeout           time.Duration `mapstructure:"ssh_timeout"`
+	SSHDisableAgent      bool          `mapstructure:"ssh_disable_agent"`
 	SSHHandshakeAttempts int           `mapstructure:"ssh_handshake_attempts"`
 	SSHBastionHost       string        `mapstructure:"ssh_bastion_host"`
 	SSHBastionPort       int           `mapstructure:"ssh_bastion_port"`

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -158,9 +158,10 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 
 		// Then we attempt to connect via SSH
 		config := &ssh.Config{
-			Connection: connFunc,
-			SSHConfig:  sshConfig,
-			Pty:        s.Config.SSHPty,
+			Connection:   connFunc,
+			SSHConfig:    sshConfig,
+			Pty:          s.Config.SSHPty,
+			DisableAgent: s.Config.SSHDisableAgent,
 		}
 
 		log.Println("[INFO] Attempting SSH connection...")

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -77,6 +77,8 @@ The SSH communicator has the following options:
   * `ssh_handshake_attempts` (int) - The number of handshakes to attempt with
     SSH once it can connect. This defaults to 10.
 
+  * `ssh_disable_agent` (bool) - If true, SSH agent forwarding will be disabled.
+
   * `ssh_bastion_host` (string) - A bastion host to use for the actual
     SSH connection.
 


### PR DESCRIPTION
We forgot to get this in for 0.8.0. :( Easily fixed though.