### PR TITLE
Post-Processor/Vsphere: Added overwrite option

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -121,7 +121,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ovftool_uri += "/Resources/" + p.config.ResourcePool
 	}
 
-	options := []string{
+	args := []string{
 		fmt.Sprintf("--noSSLVerify=%t", p.config.Insecure),
 		"--acceptAllEulas",
 		fmt.Sprintf("--name=%s", p.config.VMName),
@@ -135,25 +135,18 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
 
-	args := []string{
-		fmt.Sprintf("%s", vmx),
-		fmt.Sprintf("%s", ovftool_uri),
-	}
-
 	if p.config.Overwrite == true {
-		options = append(options, "--overwrite")
+		args = append(args, "--overwrite")
 	}
 
 	if len(p.config.Options) > 0 {
-		options = append(options, p.config.Options...)
+		args = append(args, p.config.Options...)
 	}
 
-	command := append(options, args...)
-
-	ui.Message(fmt.Sprintf("Uploading %s to vSphere", vmx))
+	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
 	var out bytes.Buffer
-	log.Printf("Starting ovftool with parameters: %s", strings.Join(command, " "))
-	cmd := exec.Command("ovftool", command...)
+	log.Printf("Starting ovftool with parameters: %s", strings.Join(args, " "))
+	cmd := exec.Command("ovftool", args...)
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
 		return nil, false, fmt.Errorf("Failed: %s\nStdout: %s", err, out.String())

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -22,19 +22,20 @@ var builtins = map[string]string{
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	Cluster      string `mapstructure:"cluster"`
-	Datacenter   string `mapstructure:"datacenter"`
-	Datastore    string `mapstructure:"datastore"`
-	DiskMode     string `mapstructure:"disk_mode"`
-	Host         string `mapstructure:"host"`
-	Insecure     bool   `mapstructure:"insecure"`
-	Overwrite    bool   `mapstructure:"overwrite"`
-	Password     string `mapstructure:"password"`
-	ResourcePool string `mapstructure:"resource_pool"`
-	Username     string `mapstructure:"username"`
-	VMFolder     string `mapstructure:"vm_folder"`
-	VMName       string `mapstructure:"vm_name"`
-	VMNetwork    string `mapstructure:"vm_network"`
+	Cluster      string   `mapstructure:"cluster"`
+	Datacenter   string   `mapstructure:"datacenter"`
+	Datastore    string   `mapstructure:"datastore"`
+	DiskMode     string   `mapstructure:"disk_mode"`
+	Host         string   `mapstructure:"host"`
+	Insecure     bool     `mapstructure:"insecure"`
+	Options      []string `mapstructure:"options"`
+	Overwrite    bool     `mapstructure:"overwrite"`
+	Password     string   `mapstructure:"password"`
+	ResourcePool string   `mapstructure:"resource_pool"`
+	Username     string   `mapstructure:"username"`
+	VMFolder     string   `mapstructure:"vm_folder"`
+	VMName       string   `mapstructure:"vm_name"`
+	VMNetwork    string   `mapstructure:"vm_network"`
 
 	ctx interpolate.Context
 }
@@ -143,12 +144,16 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		options = append(options, "--overwrite")
 	}
 
+	if len(p.config.Options) > 0 {
+		options = append(options, p.config.Options...)
+	}
+
 	command := append(options, args...)
 
 	ui.Message(fmt.Sprintf("Uploading %s to vSphere", vmx))
 	var out bytes.Buffer
 	log.Printf("Starting ovftool with parameters: %s", strings.Join(command, " "))
-	cmd := exec.Command("ovftool", args...)
+	cmd := exec.Command("ovftool", command...)
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
 		return nil, false, fmt.Errorf("Failed: %s\nStdout: %s", err, out.String())

--- a/website/source/docs/post-processors/vsphere.html.markdown
+++ b/website/source/docs/post-processors/vsphere.html.markdown
@@ -58,3 +58,7 @@ Optional:
 
 -   `overwrite` (boolean) - If it's true force the system to overwrite the
   existing files instead create new ones. Default is false
+
+* `options` (array of strings) - Custom options to add in ovftool. See `ovftool
+  --help` to list all the options
+

--- a/website/source/docs/post-processors/vsphere.html.markdown
+++ b/website/source/docs/post-processors/vsphere.html.markdown
@@ -59,6 +59,5 @@ Optional:
 -   `overwrite` (boolean) - If it's true force the system to overwrite the
   existing files instead create new ones. Default is false
 
-* `options` (array of strings) - Custom options to add in ovftool. See `ovftool
+-   `options` (array of strings) - Custom options to add in ovftool. See `ovftool
   --help` to list all the options
-

--- a/website/source/docs/post-processors/vsphere.html.markdown
+++ b/website/source/docs/post-processors/vsphere.html.markdown
@@ -53,4 +53,8 @@ Optional:
 
 -   `vm_folder` (string) - The folder within the datastore to store the VM.
 
--   `vm_network` (string) - The name of the VM network this VM will be added to.
+-   `vm_network` (string) - The name of the VM network this VM will be
+  added to.
+
+-   `overwrite` (boolean) - If it's true force the system to overwrite the
+  existing files instead create new ones. Default is false


### PR DESCRIPTION
Hi, 

In [Foehn](http://www.foehn.co.uk/) we are happy user of packer. So the first thing that I need to say is thanks for this software. 

This PR added the *overwrite* option in vsphere, as default is False and it's not required. This option rewrite all the files and create always the same vm name/disk name. (We're using this to deploy to staging). 

The overwrite option in ovftool is describe as following: 

```
 -o /--overwrite                 : Force overwrites of existing files.
```

Updated:

I added a new option called *options*, with this you can send the option that you want in the ovftool command. For example like this

```javascript
        {
          "type": "vsphere",
          "cluster": "XXX",
          "datacenter": "XXXXXX",
          "host": "XXX",
          "password": "XXXX",
          "username": "XXXX",
          "vm_name": "test-packer",
          "disk_mode": "thin",
          "options": [
            "--powerOffTarget",
            "--powerOn"
          ]
        }
````

Many thanks again for this software. 
Regards.
Eloy


