### PR TITLE
Updated how vmx entries are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
   * core: `min_packer_version`  field in configs work [GH-2356]
+  * core: The `build_name` and `build_type` functions work in provisioners [GH-2367]
   * builder/amazon: Fix issue with sharing AMIs when using `ami_users` [GH-2308]
   * builder/amazon: Fix for tag creation when creating new ec2 instance [GH-2317]
   * builder/amazon: Fix issue with creating AMIs with multiple device mappings [GH-2320]

--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -51,8 +51,8 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 
 		ui.Message("Detaching ISO from CD-ROM device...")
 
-		vmxData[ide+"devicetype"] = "cdrom-raw"
-		vmxData[ide+"filename"] = "auto detect"
+		vmxData[ide+"deviceType"] = "cdrom-raw"
+		vmxData[ide+"fileName"] = "auto detect"
 	}
 
 	ui.Message("Disabling VNC server...")

--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -61,8 +61,8 @@ func TestStepCleanVMX_floppyPath(t *testing.T) {
 		Value string
 	}{
 		{"floppy0.present", "FALSE"},
-		{"floppy0.filetype", ""},
-		{"floppy0.filename", ""},
+		{"floppy0.fileType", ""},
+		{"floppy0.fileName", ""},
 	}
 
 	for _, tc := range cases {
@@ -109,9 +109,9 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 		Key   string
 		Value string
 	}{
-		{"ide0:0.filename", "auto detect"},
-		{"ide0:0.devicetype", "cdrom-raw"},
-		{"ide0:1.filename", "bar"},
+		{"ide0:0.fileName", "auto detect"},
+		{"ide0:0.deviceType", "cdrom-raw"},
+		{"ide0:1.fileName", "bar"},
 		{"foo", "bar"},
 	}
 
@@ -130,12 +130,12 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 
 const testVMXFloppyPath = `
 floppy0.present = "TRUE"
-floppy0.filetype = "file"
+floppy0.fileType = "file"
 `
 
 const testVMXISOPath = `
-ide0:0.devicetype = "cdrom-image"
-ide0:0.filename = "foo"
-ide0:1.filename = "bar"
+ide0:0.deviceType = "cdrom-image"
+ide0:0.fileName = "foo"
+ide0:1.fileName = "bar"
 foo = "bar"
 `

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"regexp"
-	"strings"
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
@@ -53,7 +52,6 @@ func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
 	// Set custom data
 	for k, v := range s.CustomData {
 		log.Printf("Setting VMX: '%s' = '%s'", k, v)
-		k = strings.ToLower(k)
 		vmxData[k] = v
 	}
 

--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -38,14 +38,14 @@ func (s *StepCloneVMX) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	var diskName string
-	if _, ok := vmxData["scsi0:0.filename"]; ok {
-		diskName = vmxData["scsi0:0.filename"]
+	if _, ok := vmxData["scsi0:0.fileName"]; ok {
+		diskName = vmxData["scsi0:0.fileName"]
 	}
-	if _, ok := vmxData["sata0:0.filename"]; ok {
-		diskName = vmxData["sata0:0.filename"]
+	if _, ok := vmxData["sata0:0.fileName"]; ok {
+		diskName = vmxData["sata0:0.fileName"]
 	}
-	if _, ok := vmxData["ide0:0.filename"]; ok {
-		diskName = vmxData["ide0:0.filename"]
+	if _, ok := vmxData["ide0:0.fileName"]; ok {
+		diskName = vmxData["ide0:0.fileName"]
 	}
 	if diskName == "" {
 		err := fmt.Errorf("Root disk filename could not be found!")


### PR DESCRIPTION
VMWare added the virtualSSD flag to disks, but they made it case sensitive, so i removed the ToLower. At the same time, it also requires no quotes around the value, so i added an array to look for that (and any future cases where they do this)

The key was created like this: `sata0:0.virtualssd = "1"`
but must be like this to work: `sata0:0.virtualSSD = 1`