### PR TITLE
Fix for tag creation when creating new ec2 instance.

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -256,7 +256,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 	ec2Tags := make([]*ec2.Tag, 1, len(s.Tags)+1)
 	ec2Tags[0] = &ec2.Tag{Key: aws.String("Name"), Value: aws.String("Packer Builder")}
 	for k, v := range s.Tags {
-		ec2Tags = append(ec2Tags, &ec2.Tag{Key: &k, Value: &v})
+		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
 	}
 
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{


### PR DESCRIPTION
Fixes tag creation when initiating new EC2 machine. 
kudos to @iaintshine for help with solving this out. 