### PR TITLE
Fix setting ami_groups

### DIFF
--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -50,9 +50,9 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		}
 
 		for i, g := range s.Groups {
-			groups[i] = &g
+			groups[i] = aws.String(g)
 			adds[i] = &ec2.LaunchPermission{
-				Group: &g,
+				Group: aws.String(g),
 			}
 		}
 		addGroups.UserGroups = groups

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -44,12 +44,21 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 
 	if len(s.Groups) > 0 {
 		groups := make([]*string, len(s.Groups))
+		adds := make([]*ec2.LaunchPermission, len(s.Groups))
+		addGroups := &ec2.ModifyImageAttributeInput{
+			LaunchPermission: &ec2.LaunchPermissionModifications{},
+		}
+
 		for i, g := range s.Groups {
 			groups[i] = &g
+			adds[i] = &ec2.LaunchPermission{
+				Group: &g,
+			}
 		}
-		options["groups"] = &ec2.ModifyImageAttributeInput{
-			UserGroups: groups,
-		}
+		addGroups.UserGroups = groups
+		addGroups.LaunchPermission.Add = adds
+
+		options["groups"] = addGroups
 	}
 
 	if len(s.Users) > 0 {


### PR DESCRIPTION
Setting `ami_groups` to `"all"` is currently broken due to a change in the EC2 API:
```
    amazon-ebs: Modifying: groups
==> amazon-ebs: Error modify AMI attributes: MissingParameter: The request must contain the parameter LaunchPermission
==> amazon-ebs: 	status code: 400, request id: []
```

This sets the `LaunchPermission` parameter appropriately. Related to #2305.