### PR TITLE
builder/amazon-instance: Don't specify empty Virtualization Type

### DIFF
--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/multistep"
 	awscommon "github.com/mitchellh/packer/builder/amazon/common"
@@ -20,15 +21,17 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say("Registering the AMI...")
 	registerOpts := &ec2.RegisterImageInput{
 		ImageLocation:       &manifestPath,
-		Name:                &config.AMIName,
+		Name:                aws.String(config.AMIName),
 		BlockDeviceMappings: config.BlockDevices.BuildAMIDevices(),
-		VirtualizationType:  &config.AMIVirtType,
+	}
+
+	if config.AMIVirtType != "" {
+		registerOpts.VirtualizationType = aws.String(config.AMIVirtType)
 	}
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
-		simple := "simple"
-		registerOpts.SRIOVNetSupport = &simple
+		registerOpts.SRIOVNetSupport = aws.String("simple")
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)


### PR DESCRIPTION
Fixes https://github.com/mitchellh/packer/issues/2329