### PR TITLE
#2346 updated to AMI that doesn't require accepting marketplace terms

### DIFF
--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -54,7 +54,7 @@ briefly. Create a file `example.json` and fill it with the following contents:
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-c65be9ae",
+    "source_ami": "ami-de0d9eb7",
     "instance_type": "t1.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"

--- a/website/source/intro/getting-started/parallel-builds.html.markdown
+++ b/website/source/intro/getting-started/parallel-builds.html.markdown
@@ -93,7 +93,7 @@ The entire template should now look like this:
 		"access_key": "{{user `aws_access_key`}}",
 		"secret_key": "{{user `aws_secret_key`}}",
 		"region": "us-east-1",
-		"source_ami": "ami-c65be9ae",
+		"source_ami": "ami-de0d9eb7",
 		"instance_type": "t1.micro",
 		"ssh_username": "ubuntu",
 		"ami_name": "packer-example {{timestamp}}"


### PR DESCRIPTION
Updated to same AMI as in main readme.md which is from community AMIs and therefore doesn't require accepting the AWS marketplace terms before using in Packer build.