### PR TITLE
Add AppVeyor configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# appveyor.yml reference : http://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+skip_tags: true
+
+os: Windows Server 2012 R2
+
+environment:
+  GOPATH: c:\gopath
+  matrix:
+  - GOARCH: 386
+    GOVERSION: 1.4.2
+  - GOARCH: amd64
+    GOVERSION: 1.4.2
+
+clone_folder: c:\gopath\src\github.com\mitchellh\packer
+
+install:
+  - set Path=c:\go\bin;%Path%
+  - echo %Path%
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-%GOARCH%.msi
+  - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
+  - go version
+  - go env
+  - go get -d -v -t ./...
+
+build_script:
+  - go test -v ./...
+
+test: off
+
+deploy: off


### PR DESCRIPTION
Packer lacks an official Windows CI server.

This commit adds a configuration file for AppVeyor, which is a Windows CI
service (free for open-source projects), which could be used to provide build
and test status for windows/amd64 and windows/386.

/cc @mitchellh: Requires linking AppVeyor to the repo, similar to TravisCI I guess.