### PR TITLE
builder/amazon: output WinRM password for debug mode [GH-2336]

### DIFF
--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -19,6 +19,7 @@ import (
 // StepGetPassword reads the password from a Windows server and sets it
 // on the WinRM config.
 type StepGetPassword struct {
+	Debug   bool
 	Comm    *communicator.Config
 	Timeout time.Duration
 }
@@ -85,6 +86,13 @@ WaitLoop:
 			}
 		}
 	}
+
+	// In debug-mode, we output the password
+	if s.Debug {
+		ui.Message(fmt.Sprintf(
+			"Password (since debug is enabled): %s", s.Comm.WinRMPassword))
+	}
+
 	return multistep.ActionContinue
 }
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -119,6 +119,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Tags:                     b.config.RunTags,
 		},
 		&awscommon.StepGetPassword{
+			Debug:   b.config.PackerDebug,
 			Comm:    &b.config.RunConfig.Comm,
 			Timeout: b.config.WindowsPasswordTimeout,
 		},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -204,6 +204,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Tags:                     b.config.RunTags,
 		},
 		&awscommon.StepGetPassword{
+			Debug:   b.config.PackerDebug,
 			Comm:    &b.config.RunConfig.Comm,
 			Timeout: b.config.WindowsPasswordTimeout,
 		},


### PR DESCRIPTION
Fixes #2336 

With `-debug` enabled, this outputs the WinRM password.