### PR TITLE
builder/amazon/instance: set valid bundle prefix [GH-2328]

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -50,6 +50,12 @@ type Builder struct {
 }
 
 func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
+	configs := make([]interface{}, len(raws)+1)
+	configs[0] = map[string]interface{}{
+		"bundle_prefix": "image-{{timestamp}}",
+	}
+	copy(configs[1:], raws)
+
 	b.config.ctx.Funcs = awscommon.TemplateFuncs
 	err := config.Decode(&b.config, &config.DecodeOpts{
 		Interpolate:        true,
@@ -60,17 +66,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 				"bundle_vol_command",
 			},
 		},
-	}, raws...)
+	}, configs...)
 	if err != nil {
 		return nil, err
 	}
 
 	if b.config.BundleDestination == "" {
 		b.config.BundleDestination = "/tmp"
-	}
-
-	if b.config.BundlePrefix == "" {
-		b.config.BundlePrefix = "image-{{timestamp}}"
 	}
 
 	if b.config.BundleUploadCommand == "" {

--- a/builder/amazon/instance/builder_test.go
+++ b/builder/amazon/instance/builder_test.go
@@ -130,7 +130,6 @@ func TestBuilderPrepare_BundlePrefix(t *testing.T) {
 	b := &Builder{}
 	config := testConfig()
 
-	config["bundle_prefix"] = ""
 	warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)


### PR DESCRIPTION
Fixes #2328 

We now need to set defaults (at least the ones that need to be interpolated) _before_ `config.Decode` is called. This does that.