### PR TITLE
builder/googlecompute: default SSH settings properly [GH-2340]

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -97,6 +97,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 
 	var errs *packer.MultiError
+	if es := c.Comm.Prepare(&c.ctx); len(es) > 0 {
+		errs = packer.MultiErrorAppend(errs, es...)
+	}
 
 	// Process required parameters.
 	if c.ProjectId == "" {

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -152,6 +152,35 @@ func TestConfigPrepare(t *testing.T) {
 	}
 }
 
+func TestConfigDefaults(t *testing.T) {
+	cases := []struct {
+		Read  func(c *Config) interface{}
+		Value interface{}
+	}{
+		{
+			func(c *Config) interface{} { return c.Comm.Type },
+			"ssh",
+		},
+
+		{
+			func(c *Config) interface{} { return c.Comm.SSHPort },
+			22,
+		},
+	}
+
+	for _, tc := range cases {
+		raw := testConfig(t)
+
+		c, warns, errs := NewConfig(raw)
+		testConfigOk(t, warns, errs)
+
+		actual := tc.Read(c)
+		if actual != tc.Value {
+			t.Fatalf("bad: %#v", actual)
+		}
+	}
+}
+
 func testAccountFile(t *testing.T) string {
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {


### PR DESCRIPTION
Fixes #2340 

We weren't calling `Prepare` on the communicator settings properly. Did that and added tests.