### PR TITLE
AppVeyor: only build master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ version: "{build}"
 
 skip_tags: true
 
+branches:
+  only:
+    - master
+
 os: Windows Server 2012 R2
 
 environment:


### PR DESCRIPTION
AppVeyor builds all branches per default.
Add a configuration setting to only build the master branch.

See http://www.appveyor.com/docs/branches#white-and-blacklisting for details.

For the record, AppVeyor builds can skipped by annotating the commit message
according to http://www.appveyor.com/docs/how-to/skip-build
Useful for e.g. website commits since the builds are slow (queue+2x12min).

[skip appveyor]