### PR TITLE
Make EBS block device mapping optional for ephemeral virtual names.

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/packer/template/interpolate"
+	"strings"
 )
 
 // BlockDevice
@@ -47,9 +48,12 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 		}
 
 		mapping := &ec2.BlockDeviceMapping{
-			EBS:         ebsBlockDevice,
-			DeviceName:  aws.String(blockDevice.DeviceName),
-			VirtualName: aws.String(blockDevice.VirtualName),
+		  DeviceName:  aws.String(blockDevice.DeviceName),
+		  VirtualName: aws.String(blockDevice.VirtualName),
+		}
+
+		if !strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
+		  mapping.EBS = ebsBlockDevice
 		}
 
 		if blockDevice.NoDevice {


### PR DESCRIPTION
This commit fixes #2360, however, I am unsure of its exact completeness in terms of 1) Should the VirtualName and Ebs be exclusively set, and 2) is using the "ephemeral" prefix sufficient to determine if Ebs should be set.

I based this changed loosely off of: 
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html
Where the VirtualName and Ebs are considered optional.