### PR TITLE
helper/config: copy buildname/buildtype properly

### DIFF
--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -42,6 +42,8 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		if config.InterpolateContext == nil {
 			config.InterpolateContext = ctx
 		} else {
+			config.InterpolateContext.BuildName = ctx.BuildName
+			config.InterpolateContext.BuildType = ctx.BuildType
 			config.InterpolateContext.TemplatePath = ctx.TemplatePath
 			config.InterpolateContext.UserVariables = ctx.UserVariables
 		}

--- a/helper/config/decode_test.go
+++ b/helper/config/decode_test.go
@@ -74,6 +74,36 @@ func TestDecode(t *testing.T) {
 				},
 			},
 		},
+
+		"build name": {
+			[]interface{}{
+				map[string]interface{}{
+					"name": "{{build_name}}",
+				},
+				map[string]interface{}{
+					"packer_build_name": "foo",
+				},
+			},
+			&Target{
+				Name: "foo",
+			},
+			nil,
+		},
+
+		"build type": {
+			[]interface{}{
+				map[string]interface{}{
+					"name": "{{build_type}}",
+				},
+				map[string]interface{}{
+					"packer_builder_type": "foo",
+				},
+			},
+			&Target{
+				Name: "foo",
+			},
+			nil,
+		},
 	}
 
 	for k, tc := range cases {

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -71,7 +71,7 @@ func funcGenBuildName(ctx *Context) interface{} {
 func funcGenBuildType(ctx *Context) interface{} {
 	return func() (string, error) {
 		if ctx == nil || ctx.BuildType == "" {
-			return "", errors.New("build_name not available")
+			return "", errors.New("build_type not available")
 		}
 
 		return ctx.BuildType, nil


### PR DESCRIPTION
Fixes #2363 

We were forgetting to set the build name and build type for existing contexts. I'm going to add tests now but the logic is there.