### PR TITLE
Added retry logic around the ssh handshake, using a goroutine

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -67,20 +67,20 @@ func ConnectToSSH(address string, config *Config, timeout uint8, retry uint8) (c
 	attempts := retry
 
 	for attempts > 0 {
-		connection := make(chan bool, 1)
-		elapsed := time.After(time.Duration(timeout) * time.Second)
+		connectionEstablished := make(chan bool, 1)
+		timeoutExceeded := time.After(time.Duration(timeout) * time.Second)
 		go func() {
 			communicator, err = New(address, config)
-			connection <- true
+			connectionEstablished <- true
 		}()
 	WaitForHandshake:
 		for {
 			select {
-			case ok := <-connection:
+			case ok := <-connectionEstablished:
 				if ok {
 					return communicator, err
 				}
-			case <-elapsed:
+			case <-timeoutExceeded:
 				log.Printf("[WARN] Failed to establish an SSH connection after %d seconds", timeout)
 				break WaitForHandshake
 			}

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -5,10 +5,11 @@ package ssh
 import (
 	"bytes"
 	"fmt"
-	"github.com/mitchellh/packer/packer"
-	"golang.org/x/crypto/ssh"
 	"net"
 	"testing"
+
+	"github.com/mitchellh/packer/packer"
+	"golang.org/x/crypto/ssh"
 )
 
 // private key for mock server

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -165,7 +165,8 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 		}
 
 		log.Println("[INFO] Attempting SSH connection...")
-		comm, err = ssh.New(address, config)
+		// Abort after 20 seconds, retry 3 times.
+		comm, err = ssh.ConnectToSSH(address, config, 20, 3)
 		if err != nil {
 			log.Printf("[DEBUG] SSH handshake err: %s", err)
 
@@ -175,7 +176,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 			if strings.Contains(err.Error(), "authenticate") {
 				log.Printf(
 					"[DEBUG] Detected authentication error. Increasing handshake attempts.")
-				handshakeAttempts += 1
+				handshakeAttempts++
 			}
 
 			if handshakeAttempts < s.Config.SSHHandshakeAttempts {

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -165,7 +165,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 		}
 
 		log.Println("[INFO] Attempting SSH connection...")
-		// Abort after 20 seconds, retry 3 times.
+		// Abort the handshake after 20 seconds, try 3 times.
 		comm, err = ssh.ConnectToSSH(address, config, 20, 3)
 		if err != nil {
 			log.Printf("[DEBUG] SSH handshake err: %s", err)


### PR DESCRIPTION
Still not sure how to test this.

Also, some of the code implies that a connection is reused from earlier in the `waitForSSH()` call. I'm not sure it's safe to reuse a TCP connection in this context because there are potentially multiple goroutines in flight talking to the same SSH connection (though one goroutine may have hung earlier). It smells like a race condition to me, but if it's actually just the address (string) it should be safe.

Potentially fixes #2333 