### PR TITLE
Fix NULL builder config documentation.

### DIFF
--- a/website/source/docs/builders/null.html.markdown
+++ b/website/source/docs/builders/null.html.markdown
@@ -20,8 +20,8 @@ no provisioners are defined, but it will connect to the specified host via ssh.
 
 ```javascript
 {
-  "type":     "null",
-  "host":     "127.0.0.1",
+  "type":         "null",
+  "ssh_host":     "127.0.0.1",
   "ssh_username": "foo",
   "ssh_password": "bar"
 }


### PR DESCRIPTION
Change from "host" to "ssh_host" was introduced in d545431f9bc735f