### PR TITLE
Fix #2830.

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -43,7 +43,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 
 	securityGroupIds := make([]*string, len(tempSecurityGroupIds))
 	for i, sg := range tempSecurityGroupIds {
-		securityGroupIds[i] = &sg
+		securityGroupIds[i] = aws.String(sg)
 	}
 
 	userData := s.UserData


### PR DESCRIPTION
This change allows multiple security groups to work with the AWS builders.