### PR TITLE
bring back api_url to support DO like api

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -6,6 +6,7 @@ package digitalocean
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/digitalocean/godo"
 	"github.com/mitchellh/multistep"
@@ -37,6 +38,13 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	client := godo.NewClient(oauth2.NewClient(oauth2.NoContext, &apiTokenSource{
 		AccessToken: b.config.APIToken,
 	}))
+	if b.config.APIURL != "" {
+		u, err := url.Parse(b.config.APIURL)
+		if err != nil {
+			return nil, fmt.Errorf("DigitalOcean: Invalid API URL, %s.", err)
+		}
+		client.BaseURL = u
+	}
 
 	// Set up the state
 	state := new(multistep.BasicStateBag)

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Comm                communicator.Config `mapstructure:",squash"`
 
 	APIToken string `mapstructure:"api_token"`
+	APIURL   string `mapstructure:"api_url"`
 
 	Region string `mapstructure:"region"`
 	Size   string `mapstructure:"size"`
@@ -57,7 +58,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		// Default to environment variable for api_token, if it exists
 		c.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
 	}
-
+	if c.APIURL == "" {
+		c.APIURL = os.Getenv("DIGITALOCEAN_API_URL")
+	}
 	if c.SnapshotName == "" {
 		def, err := interpolate.Render("packer-{{timestamp}}", nil)
 		if err != nil {

--- a/website/source/docs/builders/digitalocean.html.markdown
+++ b/website/source/docs/builders/digitalocean.html.markdown
@@ -55,6 +55,10 @@ builder.
 
 ### Optional:
 
+-   `api_url` (string) - Non standard api endpoint URL. Set this if you are
+    using a DigitalOcean API compatible service. It can also be specified via
+    environment variable `DIGITALOCEAN_API_URL`.
+
 -   `droplet_name` (string) - The name assigned to the droplet. DigitalOcean
     sets the hostname of the machine to this value.
 


### PR DESCRIPTION
allow specify api_url for access DO api, so other hosting with DO like
api can use packer

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>