### PR TITLE
When using a Null builder, this error message is incorrect.

### DIFF
--- a/builder/null/config.go
+++ b/builder/null/config.go
@@ -33,7 +33,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 	if c.CommConfig.SSHHost == "" {
 		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("host must be specified"))
+			fmt.Errorf("ssh_host must be specified"))
 	}
 
 	if c.CommConfig.SSHUsername == "" {


### PR DESCRIPTION
It outputs `* host must be specified` instead of `* ssh_host must be specified`.

