### PR TITLE
Add 1/10th second delay between key events to VNC for QEMU

### DIFF
--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -177,7 +177,9 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		}
 
 		c.KeyEvent(keyCode, true)
+		time.Sleep(time.Second/10)
 		c.KeyEvent(keyCode, false)
+		time.Sleep(time.Second/10)
 
 		if keyShift {
 			c.KeyEvent(KeyLeftShift, false)


### PR DESCRIPTION
Issue #1663 was fixed for VMWare, but not QEMU where it's also an issue.  I ran into this earlier today and adding 1/10th of a second fixed it.