### PR TITLE
Fix inconsistent spelling

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -158,7 +158,7 @@ AMI if one with the same name already exists. Default `false`.
   generate a temporary keypair. `ssh_private_key_file` must be specified
   with this.
 
-* `ssh_private_ip` (bool) - If true, then SSH will always use the private
+* `ssh_private_ip` (boolean) - If true, then SSH will always use the private
   IP if available.
 
 * `subnet_id` (string) - If using VPC, the ID of the subnet, such as

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -197,7 +197,7 @@ AMI if one with the same name already exists. Default `false`.
   generate a temporary keypair. `ssh_private_key_file` must be specified
   with this.
 
-* `ssh_private_ip` (bool) - If true, then SSH will always use the private
+* `ssh_private_ip` (boolean) - If true, then SSH will always use the private
   IP if available.
 
 * `subnet_id` (string) - If using VPC, the ID of the subnet, such as

--- a/website/source/docs/builders/virtualbox-iso.html.markdown
+++ b/website/source/docs/builders/virtualbox-iso.html.markdown
@@ -199,7 +199,7 @@ can be configured for this builder.
   Packer will choose a randomly available port in this range to use as the
   host port.
 
-* `ssh_skip_nat_mapping` (bool) - Defaults to false. When enabled, Packer does
+* `ssh_skip_nat_mapping` (boolean) - Defaults to false. When enabled, Packer does
   not setup forwarded port mapping for SSH requests and uses `ssh_port` on the
   host to communicate to the virtual machine
 

--- a/website/source/docs/builders/virtualbox-ovf.html.markdown
+++ b/website/source/docs/builders/virtualbox-ovf.html.markdown
@@ -174,7 +174,7 @@ can be configured for this builder.
   Packer will choose a randomly available port in this range to use as the
   host port.
 
-* `ssh_skip_nat_mapping` (bool) - Defaults to false. When enabled, Packer does
+* `ssh_skip_nat_mapping` (boolean) - Defaults to false. When enabled, Packer does
   not setup forwarded port mapping for SSH requests and uses `ssh_port` on the
   host to communicate to the virtual machine
 

--- a/website/source/docs/post-processors/compress.html.markdown
+++ b/website/source/docs/post-processors/compress.html.markdown
@@ -34,7 +34,7 @@ If you want more control over how the archive is created you can specify the fol
   that support it, from 1 through 9 inclusive. Typically higher compression
   levels take longer but produce smaller files. Defaults to `6`
 
-* `keep_input_artifact` (bool) - Keep source files; defaults to `false`
+* `keep_input_artifact` (boolean) - Keep source files; defaults to `false`
 
 ### Supported Formats
 

--- a/website/source/docs/provisioners/puppet-server.html.markdown
+++ b/website/source/docs/provisioners/puppet-server.html.markdown
@@ -51,7 +51,7 @@ required. They are listed below:
 * `facter` (object of key/value strings) - Additional Facter facts to make available to the
   Puppet run.
 
-* `ignore_exit_codes` (bool) - If true, Packer will never consider the
+* `ignore_exit_codes` (boolean) - If true, Packer will never consider the
   provisioner a failure.
 
 * `options` (string) - Additional command line options to pass

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -67,7 +67,7 @@ The SSH communicator has the following options:
   * `ssh_private_key_file` (string) - Path to a PEM encoded private key
     file to use to authentiate with SSH.
 
-  * `ssh_pty` (bool) - If true, a PTY will be requested for the SSH connection.
+  * `ssh_pty` (boolean) - If true, a PTY will be requested for the SSH connection.
     This defaults to false.
 
   * `ssh_timeout` (string) - The time to wait for SSH to become available.
@@ -77,7 +77,7 @@ The SSH communicator has the following options:
   * `ssh_handshake_attempts` (int) - The number of handshakes to attempt with
     SSH once it can connect. This defaults to 10.
 
-  * `ssh_disable_agent` (bool) - If true, SSH agent forwarding will be disabled.
+  * `ssh_disable_agent` (boolean) - If true, SSH agent forwarding will be disabled.
 
   * `ssh_bastion_host` (string) - A bastion host to use for the actual
     SSH connection.

--- a/website/source/docs/templates/push.html.markdown
+++ b/website/source/docs/templates/push.html.markdown
@@ -59,7 +59,7 @@ each category, the available configuration keys are alphabetized.
 * `token` (string) - An access token to use to authenticate to the build
   service.
 
-* `vcs` (bool) - If true, Packer will detect your VCS (if there is one)
+* `vcs` (boolean) - If true, Packer will detect your VCS (if there is one)
   and only upload the files that are tracked by the VCS. This is useful
   for automatically excluding ignored files. This defaults to false.
 


### PR DESCRIPTION
`(boolean)` is used in most cases, but `(bool)` is used in places.

I ran `find website/source/**/*.(markdown|md) | xargs sed -i 's/(bool)/(boolean)/g'`