### PR TITLE
Added interactive mode to remote shell provisioner

### DIFF
--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -33,6 +33,10 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 	if p.config.RemotePath == "" {
 		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
 	}
+
+	if p.config.Interactive {
+		t.Errorf("unexpected interactive: %t", p.config.Interactive)
+	}
 }
 
 func TestProvisionerPrepare_InlineShebang(t *testing.T) {


### PR DESCRIPTION
This pull request is intended to get some some initial feedback.

The intent of this feature is to allow shell provisioners to be developed iteratively during a single packer run. it introduces an boolean configutation parameter of "interactive", which, when true, replaces the normal script execution sequence with the following menu:

```bash
==> qemu: [0] scripts/init.sh
==> qemu: [1] scripts/bats.sh
==> qemu: [2] scripts/cleanup.sh
==> qemu: [3] scripts/cleanup_spec.sh
==> qemu: [4] scripts/zerodisk.sh
==> qemu: [5] scripts/zerodisk_spec.sh
==> qemu: Enter script number to execute, or: (c) continue, (m) enter script path
```

This allows the user to execute, monitor, modify, and add provisioning scripts.  

A suggested approach would be to drive this with a user variable, default to false, and allow override at the command line:

```json
"variables": {
  "interactive": "false"
},
provisioners: [{
  "type": "shell",
  "interactive": "{{ user `interactive` }}"
}]
```

```bash
packer build -var 'interactive=true' template.json 
```

I have found this feature very useful as have some of my clients.

What do you think?  I see the following as potential concerns:

1. This seems to overlap with the `-debug` option.  Perhaps this is better implemented as a debug option?  We could have the option to press enter simple continue.
1. This change is local to the `shell` provisioner but feels like a more global mode of execution.  Not sure if the logic to provide this menu should go into another part of the codebase and used by the provisioner with some kind of fancy callbacks or something.  Not being a Go expert I wouldn't know the best way to factor this.
1. Other rough edges due to my lack of experience with Go. 