### PR TITLE
Fix character being displayed incorrectly in hashicorp ecosystem page

### DIFF
--- a/website/source/intro/hashicorp-ecosystem.html.markdown
+++ b/website/source/intro/hashicorp-ecosystem.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 HashiCorp is the creator of the open source projects Vagrant, Packer, Terraform, Serf, and Consul, and the commercial product Atlas. Packer is just one piece of the ecosystem HashiCorp has built to make application delivery a versioned, auditable, repeatable, and collaborative process. To learn more about our beliefs on the qualities of the modern datacenter and responsible application delivery, read [The Atlas Mindset: Version Control for Infrastructure](https://hashicorp.com/blog/atlas-mindset.html/?utm_source=packer&utm_campaign=HashicorpEcosystem).
 
-If you are using Packer to build machine images and deployable artifacts, it’s likely that you need a solution for deploying those artifacts. Terraform is our tool for creating, combining, and modifying infrastructure.
+If you are using Packer to build machine images and deployable artifacts, it's likely that you need a solution for deploying those artifacts. Terraform is our tool for creating, combining, and modifying infrastructure.
 
 Below are summaries of HashiCorp’s open source projects and a graphic showing how Atlas connects them to create a full application delivery workflow.
 


### PR DESCRIPTION
Super duper tiny documentation modification which should fix the character output in the <a href="https://www.packer.io/intro/hashicorp-ecosystem.html" target="_blank">"hashicorp ecosystem" page</a>:

<img width="239" alt="screen shot 2015-07-11 at 19 43 38" src="https://cloud.githubusercontent.com/assets/6195629/8634931/ecc32fc0-2805-11e5-8734-d7452cfde55d.png">