### PR TITLE
Fix other characters in docs displayed incorrectly

### DIFF
--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -28,7 +28,7 @@ use. For example, the Docker builder has a "docker" communicator that uses
 ## Using a Communicator
 
 By default, the SSH communicator is usually used. Additional configuration
-may not even be necesssary, since some builders such as Amazon automatically
+may not even be necessary, since some builders such as Amazon automatically
 configure everything.
 
 However, to specify a communicator, you set the `communicator` key within

--- a/website/source/intro/hashicorp-ecosystem.html.markdown
+++ b/website/source/intro/hashicorp-ecosystem.html.markdown
@@ -14,7 +14,7 @@ HashiCorp is the creator of the open source projects Vagrant, Packer, Terraform,
 
 If you are using Packer to build machine images and deployable artifacts, it's likely that you need a solution for deploying those artifacts. Terraform is our tool for creating, combining, and modifying infrastructure.
 
-Below are summaries of HashiCorp’s open source projects and a graphic showing how Atlas connects them to create a full application delivery workflow.
+Below are summaries of HashiCorp's open source projects and a graphic showing how Atlas connects them to create a full application delivery workflow.
 
 # HashiCorp Ecosystem
 ![Atlas Workflow](docs/atlas-workflow.png)
@@ -27,6 +27,6 @@ Below are summaries of HashiCorp’s open source projects and a graphic showing 
 
 [Consul](https://consul.io/?utm_source=packer&utm_campaign=HashicorpEcosystem) is a HashiCorp tool for service discovery, service registry, and health checks. In the Atlas workflow Consul is configured at the Packer build stage and identifies the service(s) contained in each artifact. Since Consul is configured at the build phase with Packer, when the artifact is deployed with Terraform, it is fully configured with dependencies and service discovery pre-baked. This greatly reduces the risk of an unhealthy node in production due to configuration failure at runtime.
 
-[Serf](https://serfdom.io/?utm_source=packer&utm_campaign=HashicorpEcosystem) is a HashiCorp tool for cluster membership and failure detection. Consul uses Serf’s gossip protocol as the foundation for service discovery.
+[Serf](https://serfdom.io/?utm_source=packer&utm_campaign=HashicorpEcosystem) is a HashiCorp tool for cluster membership and failure detection. Consul uses Serf's gossip protocol as the foundation for service discovery.
 
 [Vagrant](https://www.vagrantup.com/?utm_source=packer&utm_campaign=HashicorpEcosystem) is a HashiCorp tool for managing development environments that mirror production. Vagrant environments reduce the friction of developing a project and reduce the risk of unexpected behavior appearing after deployment. Vagrant boxes can be built in parallel with production artifacts with Packer to maintain parity between development and production.


### PR DESCRIPTION
Found some others, <a target="_blank" href="https://www.packer.io/intro/hashicorp-ecosystem.html">same page</a> :-)
Linked to #2430.

<img width="379" alt="screen shot 2015-07-12 at 00 06 13" src="https://cloud.githubusercontent.com/assets/6195629/8635712/e220d6a6-282a-11e5-913d-0e9460ebd56f.png">
==
<img width="226" alt="screen shot 2015-07-12 at 00 09 14" src="https://cloud.githubusercontent.com/assets/6195629/8635713/e2250578-282a-11e5-9963-8115b7dab717.png">

