### PR TITLE
Fix bug on WinRM connector

### DIFF
--- a/helper/communicator/step_connect.go
+++ b/helper/communicator/step_connect.go
@@ -53,6 +53,7 @@ func (s *StepConnect) Run(state multistep.StateBag) multistep.StepAction {
 			Config:      s.Config,
 			Host:        s.Host,
 			WinRMConfig: s.WinRMConfig,
+			WinRMPort:   s.SSHPort,
 		},
 	}
 	for k, v := range s.CustomConnect {

--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -25,6 +25,7 @@ type StepConnectWinRM struct {
 	Config      *Config
 	Host        func(multistep.StateBag) (string, error)
 	WinRMConfig func(multistep.StateBag) (*WinRMConfig, error)
+	WinRMPort   func(multistep.StateBag) (int, error)
 }
 
 func (s *StepConnectWinRM) Run(state multistep.StateBag) multistep.StepAction {
@@ -96,6 +97,13 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 			continue
 		}
 		port := s.Config.WinRMPort
+		if s.WinRMPort != nil {
+			port, err = s.WinRMPort(state)
+			if err != nil {
+				log.Printf("[DEBUG] Error getting WinRM port: %s", err)
+				continue
+			}
+		}
 
 		user := s.Config.WinRMUser
 		password := s.Config.WinRMPassword


### PR DESCRIPTION
Ref #2399

Add s.SSHPort variable as the port WinRM uses to connect. This is needed on any builder where the port used to connect is not the guest winrm port but a nated port on the host.

Similar behavior is used by the SSH communicator.