### PR TITLE
Update `inventory_groups` documentation for clarity

### DIFF
--- a/website/source/docs/provisioners/ansible-local.html.markdown
+++ b/website/source/docs/provisioners/ansible-local.html.markdown
@@ -41,15 +41,16 @@ Optional:
 * `extra_arguments` (array of strings) - An array of extra arguments to pass to the
   ansible command. By default, this is empty.
 
-* `inventory_groups` (string) - You can let Packer generate a temporary inventory
-  for you. It will contains only `127.0.0.1`. Thanks to `inventory_groups`,
-  packer will set the current machine into different groups and will
-  generate an inventory like:
+* `inventory_groups` (string) -  A comma-separated list of groups to which
+  packer will assign the host `127.0.0.1`. A value of `my_group_1,my_group_2`
+  will generate an Ansible inventory like:
 
-  [my_group_1]
-  127.0.0.1
-  [my_group_2]
-  127.0.0.1
+```text
+[my_group_1]
+127.0.0.1
+[my_group_2]
+127.0.0.1
+```
 
 * `inventory_file` (string) - The inventory file to be used by ansible.
   This file must exist on your local system and will be uploaded to the


### PR DESCRIPTION
Adds a little more information about the structure of the string that the `inventory_group` key takes. Also added `<code>` markdown so that the example inventory is shown in its own block.