### PR TITLE
Update to match AWS api changes in aws/aws-sdk-go#313

### DIFF
--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -52,12 +52,12 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 	}
 	createVolume := &ec2.CreateVolumeInput{
 		AvailabilityZone: instance.Placement.AvailabilityZone,
-		Size:             aws.Long(vs),
+		Size:             aws.Int64(vs),
 		SnapshotID:       rootDevice.EBS.SnapshotID,
 		VolumeType:       rootDevice.EBS.VolumeType,
 		IOPS:             rootDevice.EBS.IOPS,
 	}
-	log.Printf("Create args: %s", awsutil.StringValue(createVolume))
+	log.Printf("Create args: %s", awsutil.Prettify(createVolume))
 
 	createVolumeResp, err := ec2conn.CreateVolume(createVolume)
 	if err != nil {

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -34,7 +34,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 			}
 
 			if s.RootVolumeSize > *newDevice.EBS.VolumeSize {
-				newDevice.EBS.VolumeSize = aws.Long(s.RootVolumeSize)
+				newDevice.EBS.VolumeSize = aws.Int64(s.RootVolumeSize)
 			}
 		}
 

--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -30,20 +30,20 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 	for _, blockDevice := range b {
 		ebsBlockDevice := &ec2.EBSBlockDevice{
 			VolumeType:          aws.String(blockDevice.VolumeType),
-			VolumeSize:          aws.Long(blockDevice.VolumeSize),
-			DeleteOnTermination: aws.Boolean(blockDevice.DeleteOnTermination),
+			VolumeSize:          aws.Int64(blockDevice.VolumeSize),
+			DeleteOnTermination: aws.Bool(blockDevice.DeleteOnTermination),
 		}
 
 		// IOPS is only valid for SSD Volumes
 		if blockDevice.VolumeType != "" && blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
-			ebsBlockDevice.IOPS = aws.Long(blockDevice.IOPS)
+			ebsBlockDevice.IOPS = aws.Int64(blockDevice.IOPS)
 		}
 
 		// You cannot specify Encrypted if you specify a Snapshot ID
 		if blockDevice.SnapshotId != "" {
 			ebsBlockDevice.SnapshotID = aws.String(blockDevice.SnapshotId)
 		} else if blockDevice.Encrypted {
-			ebsBlockDevice.Encrypted = aws.Boolean(blockDevice.Encrypted)
+			ebsBlockDevice.Encrypted = aws.Bool(blockDevice.Encrypted)
 		}
 
 		mapping := &ec2.BlockDeviceMapping{

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -31,8 +31,8 @@ func TestBlockDevice(t *testing.T) {
 				EBS: &ec2.EBSBlockDevice{
 					SnapshotID:          aws.String("snap-1234"),
 					VolumeType:          aws.String("standard"),
-					VolumeSize:          aws.Long(8),
-					DeleteOnTermination: aws.Boolean(true),
+					VolumeSize:          aws.Int64(8),
+					DeleteOnTermination: aws.Bool(true),
 				},
 			},
 		},
@@ -47,8 +47,8 @@ func TestBlockDevice(t *testing.T) {
 				VirtualName: aws.String(""),
 				EBS: &ec2.EBSBlockDevice{
 					VolumeType:          aws.String(""),
-					VolumeSize:          aws.Long(8),
-					DeleteOnTermination: aws.Boolean(false),
+					VolumeSize:          aws.Int64(8),
+					DeleteOnTermination: aws.Bool(false),
 				},
 			},
 		},
@@ -67,9 +67,9 @@ func TestBlockDevice(t *testing.T) {
 				VirtualName: aws.String("ephemeral0"),
 				EBS: &ec2.EBSBlockDevice{
 					VolumeType:          aws.String("io1"),
-					VolumeSize:          aws.Long(8),
-					DeleteOnTermination: aws.Boolean(true),
-					IOPS:                aws.Long(1000),
+					VolumeSize:          aws.Int64(8),
+					DeleteOnTermination: aws.Bool(true),
+					IOPS:                aws.Int64(1000),
 				},
 			},
 		},
@@ -84,11 +84,11 @@ func TestBlockDevice(t *testing.T) {
 		expected := []*ec2.BlockDeviceMapping{tc.Result}
 		got := blockDevices.BuildAMIDevices()
 		if !reflect.DeepEqual(expected, got) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.StringValue(expected), awsutil.StringValue(got))
+			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.Prettify(expected), awsutil.Prettify(got))
 		}
 
 		if !reflect.DeepEqual(expected, blockDevices.BuildLaunchDevices()) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.StringValue(expected), awsutil.StringValue(blockDevices.BuildLaunchDevices()))
+			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.Prettify(expected), awsutil.Prettify(blockDevices.BuildLaunchDevices()))
 		}
 	}
 }

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -141,8 +141,8 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 			ImageID:             &s.SourceAMI,
 			InstanceType:        &s.InstanceType,
 			UserData:            &userData,
-			MaxCount:            aws.Long(1),
-			MinCount:            aws.Long(1),
+			MaxCount:            aws.Int64(1),
+			MinCount:            aws.Int64(1),
 			IAMInstanceProfile:  &ec2.IAMInstanceProfileSpecification{Name: &s.IamInstanceProfile},
 			BlockDeviceMappings: s.BlockDevices.BuildLaunchDevices(),
 			Placement:           &ec2.Placement{AvailabilityZone: &s.AvailabilityZone},
@@ -151,11 +151,11 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 		if s.SubnetId != "" && s.AssociatePublicIpAddress {
 			runOpts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
 				&ec2.InstanceNetworkInterfaceSpecification{
-					DeviceIndex:              aws.Long(0),
+					DeviceIndex:              aws.Int64(0),
 					AssociatePublicIPAddress: &s.AssociatePublicIpAddress,
 					SubnetID:                 &s.SubnetId,
 					Groups:                   securityGroupIds,
-					DeleteOnTermination:      aws.Boolean(true),
+					DeleteOnTermination:      aws.Bool(true),
 				},
 			}
 		} else {
@@ -185,11 +185,11 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 				IAMInstanceProfile: &ec2.IAMInstanceProfileSpecification{Name: &s.IamInstanceProfile},
 				NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 					&ec2.InstanceNetworkInterfaceSpecification{
-						DeviceIndex:              aws.Long(0),
+						DeviceIndex:              aws.Int64(0),
 						AssociatePublicIPAddress: &s.AssociatePublicIpAddress,
 						SubnetID:                 &s.SubnetId,
 						Groups:                   securityGroupIds,
-						DeleteOnTermination:      aws.Boolean(true),
+						DeleteOnTermination:      aws.Bool(true),
 					},
 				},
 				Placement: &ec2.SpotPlacement{

--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -59,8 +59,8 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	req := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupID:    groupResp.GroupID,
 		IPProtocol: aws.String("tcp"),
-		FromPort:   aws.Long(int64(port)),
-		ToPort:     aws.Long(int64(port)),
+		FromPort:   aws.Int64(int64(port)),
+		ToPort:     aws.Int64(int64(port)),
 		CIDRIP:     aws.String("0.0.0.0/0"),
 	}
 

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -287,10 +287,10 @@ func (p *Provisioner) createKnifeConfig(ui packer.Ui, comm packer.Communicator, 
 
 	ctx := p.config.ctx
 	ctx.Data = &ConfigTemplate{
-		NodeName:             nodeName,
-		ServerUrl:            serverUrl,
-		ClientKey:            clientKey,
-		SslVerifyMode:        sslVerifyMode,
+		NodeName:      nodeName,
+		ServerUrl:     serverUrl,
+		ClientKey:     clientKey,
+		SslVerifyMode: sslVerifyMode,
 	}
 	configString, err := interpolate.Render(tpl, &ctx)
 	if err != nil {


### PR DESCRIPTION
Applied:

    gofmt -w -r 'aws.Boolean(a) -> aws.Bool(a)' ./
    gofmt -w -r 'aws.Long(a) -> aws.Int64(a)' ./
    gofmt -w -r 'aws.Double(a) -> aws.Float64(a)' ./
    gofmt -w -r 'awsutil.StringValue -> awsutil.Prettify' ./

Please merge after https://github.com/aws/aws-sdk-go/pull/313