### PR TITLE
Guard against uninitialized pointers in io.Copy in WinRM calls

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -85,8 +85,13 @@ func (c *Communicator) Start(rc *packer.RemoteCmd) error {
 func runCommand(shell *winrm.Shell, cmd *winrm.Command, rc *packer.RemoteCmd) {
 	defer shell.Close()
 
-	go io.Copy(rc.Stdout, cmd.Stdout)
-	go io.Copy(rc.Stderr, cmd.Stderr)
+	if rc.Stdout != nil && cmd.Stdout != nil {
+		go io.Copy(rc.Stdout, cmd.Stdout)
+	}
+
+	if rc.Stderr != nil && cmd.Stderr != nil {
+		go io.Copy(rc.Stderr, cmd.Stderr)
+	}
 
 	cmd.Wait()
 

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -87,10 +87,14 @@ func runCommand(shell *winrm.Shell, cmd *winrm.Command, rc *packer.RemoteCmd) {
 
 	if rc.Stdout != nil && cmd.Stdout != nil {
 		go io.Copy(rc.Stdout, cmd.Stdout)
+	} else {
+		log.Printf("[WARN] Failed to read stdout for command '%s'", rc.Command)
 	}
 
 	if rc.Stderr != nil && cmd.Stderr != nil {
 		go io.Copy(rc.Stderr, cmd.Stderr)
+	} else {
+		log.Printf("[WARN] Failed to read stderr for command '%s'", rc.Command)
 	}
 
 	cmd.Wait()


### PR DESCRIPTION
Should fix #2416

I don't have a repro case so there is no test. I have added a log message so we can see if there is some weird behavior here as a result of not crashing.