### PR TITLE
Don't add ephemeral block devices to the EBS mapping

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/packer/template/interpolate"
+	"strings"
 )
 
 // BlockDevice
@@ -47,9 +48,12 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 		}
 
 		mapping := &ec2.BlockDeviceMapping{
-			EBS:         ebsBlockDevice,
-			DeviceName:  aws.String(blockDevice.DeviceName),
-			VirtualName: aws.String(blockDevice.VirtualName),
+		  DeviceName:  aws.String(blockDevice.DeviceName),
+		  VirtualName: aws.String(blockDevice.VirtualName),
+		}
+
+		if !strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
+		  mapping.EBS = ebsBlockDevice
 		}
 
 		if blockDevice.NoDevice {

--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -1,10 +1,11 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/packer/template/interpolate"
-	"strings"
 )
 
 // BlockDevice
@@ -48,12 +49,12 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 		}
 
 		mapping := &ec2.BlockDeviceMapping{
-		  DeviceName:  aws.String(blockDevice.DeviceName),
-		  VirtualName: aws.String(blockDevice.VirtualName),
+			DeviceName:  aws.String(blockDevice.DeviceName),
+			VirtualName: aws.String(blockDevice.VirtualName),
 		}
 
 		if !strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
-		  mapping.EBS = ebsBlockDevice
+			mapping.EBS = ebsBlockDevice
 		}
 
 		if blockDevice.NoDevice {

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -21,7 +21,6 @@ func TestBlockDevice(t *testing.T) {
 				VolumeType:          "standard",
 				VolumeSize:          8,
 				DeleteOnTermination: true,
-				IOPS:                1000,
 			},
 
 			Result: &ec2.BlockDeviceMapping{

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -17,7 +17,6 @@ func TestBlockDevice(t *testing.T) {
 		{
 			Config: &BlockDevice{
 				DeviceName:          "/dev/sdb",
-				VirtualName:         "ephemeral0",
 				SnapshotId:          "snap-1234",
 				VolumeType:          "standard",
 				VolumeSize:          8,
@@ -27,7 +26,7 @@ func TestBlockDevice(t *testing.T) {
 
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String("ephemeral0"),
+				VirtualName: aws.String(""),
 				EBS: &ec2.EBSBlockDevice{
 					SnapshotID:          aws.String("snap-1234"),
 					VolumeType:          aws.String("standard"),
@@ -55,7 +54,6 @@ func TestBlockDevice(t *testing.T) {
 		{
 			Config: &BlockDevice{
 				DeviceName:          "/dev/sdb",
-				VirtualName:         "ephemeral0",
 				VolumeType:          "io1",
 				VolumeSize:          8,
 				DeleteOnTermination: true,
@@ -64,13 +62,24 @@ func TestBlockDevice(t *testing.T) {
 
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String("ephemeral0"),
+				VirtualName: aws.String(""),
 				EBS: &ec2.EBSBlockDevice{
 					VolumeType:          aws.String("io1"),
 					VolumeSize:          aws.Long(8),
 					DeleteOnTermination: aws.Boolean(true),
 					IOPS:                aws.Long(1000),
 				},
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName:  "/dev/sdb",
+				VirtualName: "ephemeral0",
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/sdb"),
+				VirtualName: aws.String("ephemeral0"),
 			},
 		},
 	}

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -93,11 +93,14 @@ func TestBlockDevice(t *testing.T) {
 		expected := []*ec2.BlockDeviceMapping{tc.Result}
 		got := blockDevices.BuildAMIDevices()
 		if !reflect.DeepEqual(expected, got) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.StringValue(expected), awsutil.StringValue(got))
+			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s",
+				awsutil.StringValue(expected), awsutil.StringValue(got))
 		}
 
 		if !reflect.DeepEqual(expected, blockDevices.BuildLaunchDevices()) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s", awsutil.StringValue(expected), awsutil.StringValue(blockDevices.BuildLaunchDevices()))
+			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s",
+				awsutil.StringValue(expected),
+				awsutil.StringValue(blockDevices.BuildLaunchDevices()))
 		}
 	}
 }


### PR DESCRIPTION
Ephemeral devices are part of the EC2 instance and not part of EBS.

- Fixes #2360
- Closes #2322
- Closes #2365

I cherry picked commits from two related PRs and performed some cleanup. Thanks @tommyulfsparre and @aspring