### PR TITLE
Fixes #2434 by adding OpenStack Glance metadata support

### DIFF
--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -8,7 +8,8 @@ import (
 
 // ImageConfig is for common configuration related to creating Images.
 type ImageConfig struct {
-	ImageName string `mapstructure:"image_name"`
+	ImageName     string            `mapstructure:"image_name"`
+	ImageMetadata map[string]string `mapstructure:"metadata"`
 }
 
 func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -30,7 +30,8 @@ func (s *stepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 	// Create the image
 	ui.Say(fmt.Sprintf("Creating the image: %s", config.ImageName))
 	imageId, err := servers.CreateImage(client, server.ID, servers.CreateImageOpts{
-		Name: config.ImageName,
+		Name:     config.ImageName,
+		Metadata: config.ImageMetadata,
 	}).ExtractImageID()
 	if err != nil {
 		err := fmt.Errorf("Error creating image: %s", err)

--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -96,6 +96,8 @@ can be configured for this builder.
 * `rackconnect_wait` (boolean) - For rackspace, whether or not to wait for
   Rackconnect to assign the machine an IP address before connecting via SSH.
   Defaults to false.
+* `metadata` (object of key/value strings) - Glance metadata that will be applied
+  to the image.
 
 ## Basic Example: Rackspace public cloud
 


### PR DESCRIPTION
I'm submitting this for discussion at a minimum. Haven't been able to test yet due to some flakiness with my Helion account, but will test with a private OpenStack tomorrow.

In the meantime, @darrenhaken does this look like what you were looking for, basically the equivalent of the AWS AMI tags, but for OpenStack Glance images.

An example of the metadata in a Packer build config is:

```json
{
  "builders" :[{
    "type": "openstack",
    "ssh_username": "ubuntu",
    "image_name": "Test image",
    "metadata": {
      "distro": "Ubuntu Trusty"
    },
    "source_image": "564be9dd-5a06-4a26-ba50-9453f972e483",
    "flavor": "100"
  }]
}
```

Once the image has been written to Glance, running:

```shell
nova image show <YourImageID>
```
will show the custom metadata.