### PR TITLE
Make manifest_file work as either file.pp or a directory

### DIFF
--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -41,9 +41,11 @@ The reference of available configuration options is listed below.
 Required parameters:
 
 * `manifest_file` (string) - This is either a path to a puppet manifest (`.pp`
-  file) _or_ a directory containing multiple manifests that puppet will apply.
-  These file(s) must exist on your local system and will be uploaded to the
-  remote machine.
+  file) _or_ a directory containing multiple manifests that puppet will apply
+  (the ["main manifest"][1]). These file(s) must exist on your local system and
+  will be uploaded to the remote machine.
+
+  [1]: https://docs.puppetlabs.com/puppet/latest/reference/dirs_manifest.html
 
 Optional parameters:
 
@@ -66,9 +68,8 @@ Optional parameters:
   the "manifestdir" setting on Puppet.
 
   ~> `manifest_dir` is passed to `puppet apply` as the `--manifestdir` option.
-     This option was deprecated in puppet 3.6, and is slated to be removed in
-     puppet 4.0. If you have multiple manifests you should simply use
-     `manifest_file` instead.
+     This option was deprecated in puppet 3.6, and removed in puppet 4.0. If you
+     have multiple manifests you should use `manifest_file` instead.
 
 * `module_paths` (array of strings) - This is an array of paths to module
   directories on your local filesystem. These will be uploaded to the remote

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -40,9 +40,10 @@ The reference of available configuration options is listed below.
 
 Required parameters:
 
-* `manifest_file` (string) - The manifest file for Puppet to use in order
-  to compile and run a catalog. This file must exist on your local system
-  and will be uploaded to the remote machine.
+* `manifest_file` (string) - This is either a path to a puppet manifest (`.pp`
+  file) _or_ a directory containing multiple manifests that puppet will apply.
+  These file(s) must exist on your local system and will be uploaded to the
+  remote machine.
 
 Optional parameters:
 
@@ -63,6 +64,11 @@ Optional parameters:
   manifest file uses imports. This directory doesn't necessarily contain
   the `manifest_file`. It is a separate directory that will be set as
   the "manifestdir" setting on Puppet.
+
+  ~> `manifest_dir` is passed to `puppet apply` as the `--manifestdir` option.
+     This option was deprecated in puppet 3.6, and is slated to be removed in
+     puppet 4.0. If you have multiple manifests you should simply use
+     `manifest_file` instead.
 
 * `module_paths` (array of strings) - This is an array of paths to module
   directories on your local filesystem. These will be uploaded to the remote


### PR DESCRIPTION
- Includes documentation to clarify how you should configure packer for puppet with multiple manifests
- Fixes #2373