### PR TITLE
Puppet masterless provisioner optionally cleans staging directory

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -45,6 +45,9 @@ type Config struct {
 	// permissions in this directory.
 	StagingDir string `mapstructure:"staging_directory"`
 
+	// If true, staging directory is removed after executing puppet.
+	CleanStagingDir bool `mapstructure:"clean_staging_directory"`
+
 	// The directory from which the command will be executed.
 	// Packer requires the directory to exist when running puppet.
 	WorkingDir string `mapstructure:"working_directory"`
@@ -237,6 +240,12 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return fmt.Errorf("Puppet exited with a non-zero exit status: %d", cmd.ExitStatus)
 	}
 
+	if p.config.CleanStagingDir {
+		if err := p.removeDir(ui, comm, p.config.StagingDir); err != nil {
+			return fmt.Errorf("Error removing staging directory: %s", err)
+		}
+	}
+
 	return nil
 }
 
@@ -312,6 +321,22 @@ func (p *Provisioner) uploadManifests(ui packer.Ui, comm packer.Communicator) (s
 func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir string) error {
 	cmd := &packer.RemoteCmd{
 		Command: fmt.Sprintf("mkdir -p '%s'", dir),
+	}
+
+	if err := cmd.StartWithUi(comm, ui); err != nil {
+		return err
+	}
+
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf("Non-zero exit status.")
+	}
+
+	return nil
+}
+
+func (p *Provisioner) removeDir(ui packer.Ui, comm packer.Communicator, dir string) error {
+	cmd := &packer.RemoteCmd{
+		Command: fmt.Sprintf("rm -fr '%s'", dir),
 	}
 
 	if err := cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
When puppet is executed in masterless mode it didn't remove
staging directory, this can be a problem because it leaves all
the modules and manifests in the built image.
This is specially problematic when building docker images as they
can be left in the layers unless an specific cleanup is done after
running puppet.

This change adds a flag `clean_staging_directory` to puppet
masterless provisioner so it takes care of this cleanup.