### PR TITLE
Use snapshot size if you don't specify a VolumeSize

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -32,7 +32,6 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 	for _, blockDevice := range b {
 		ebsBlockDevice := &ec2.EBSBlockDevice{
 			VolumeType:          aws.String(blockDevice.VolumeType),
-			VolumeSize:          aws.Long(blockDevice.VolumeSize),
 			DeleteOnTermination: aws.Boolean(blockDevice.DeleteOnTermination),
 		}
 
@@ -46,6 +45,11 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 			ebsBlockDevice.SnapshotID = aws.String(blockDevice.SnapshotId)
 		} else if blockDevice.Encrypted {
 			ebsBlockDevice.Encrypted = aws.Boolean(blockDevice.Encrypted)
+		}
+
+		// Use snapshot size if you don't specify a VolumeSize
+		if blockDevice.VolumeSize != 0 {
+			ebsBlockDevice.VolumeSize = aws.Long(blockDevice.VolumeSize)
 		}
 
 		mapping := &ec2.BlockDeviceMapping{

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -81,6 +81,22 @@ func TestBlockDevice(t *testing.T) {
 				VirtualName: aws.String("ephemeral0"),
 			},
 		},
+		{
+			Config: &BlockDevice{
+				DeviceName:          "/dev/sdb",
+				VolumeType:          "standard",
+				DeleteOnTermination: true,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/sdb"),
+				VirtualName: aws.String(""),
+				EBS: &ec2.EBSBlockDevice{
+					VolumeType:          aws.String("standard"),
+					DeleteOnTermination: aws.Boolean(true),
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
I got following error while creating instance from source ami by packer without VolumeSize attribute in EbsBlockDevice.

```
2015/07/21 14:27:02 ui error: ==> aws-CentOS-6.5: Error launching source instance: InvalidBlockDeviceMapping: Volume of size 0GB is smaller than  snapshot 'snap-5a16c2d9', expect size >= 16GB
==> aws-CentOS-6.5:     status code: 400, request id: []
```

According to reference, VolumeSize is optional parameter and use snapshot size automatically when VolumeSize isn't specified.
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html

Packer version: 0.8.2
Packer log: https://gist.github.com/Sheile/5434f00f722e4bc01cf9
Reproduce json: https://gist.github.com/Sheile/a384ca5f7883d9194a16
Reproduce command: `PACKER_LOG=1 /opt/packer/packer build sample.json`

----

It seems to me that problem caused by zero value in golang.
A type of VolumeSize attribute in ec2.EBSBlockDevice is nullable(`*int64`) at https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go and skip nil attributes in https://github.com/aws/aws-sdk-go/blob/master/internal/protocol/json/jsonutil/build.go or others.
BlockDevice structure on packer has VolumeSize attribute with `int64`(not pointer).