### PR TITLE
website: remove packer push var interpolation

### DIFF
--- a/website/source/docs/templates/push.html.markdown
+++ b/website/source/docs/templates/push.html.markdown
@@ -89,6 +89,3 @@ files to include:
   }
 }
 ```
-
-~> **Variable interpolation** is not currently possible in Packer push
-configurations. This will be fixed in an upcoming release.


### PR DESCRIPTION
This removes a message that is no longer accurate and fixed in https://github.com/mitchellh/packer/issues/1861