### PR TITLE
Add sftp file transfer support

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -15,20 +15,21 @@ type Config struct {
 	Type string `mapstructure:"communicator"`
 
 	// SSH
-	SSHHost              string        `mapstructure:"ssh_host"`
-	SSHPort              int           `mapstructure:"ssh_port"`
-	SSHUsername          string        `mapstructure:"ssh_username"`
-	SSHPassword          string        `mapstructure:"ssh_password"`
-	SSHPrivateKey        string        `mapstructure:"ssh_private_key_file"`
-	SSHPty               bool          `mapstructure:"ssh_pty"`
-	SSHTimeout           time.Duration `mapstructure:"ssh_timeout"`
-	SSHDisableAgent      bool          `mapstructure:"ssh_disable_agent"`
-	SSHHandshakeAttempts int           `mapstructure:"ssh_handshake_attempts"`
-	SSHBastionHost       string        `mapstructure:"ssh_bastion_host"`
-	SSHBastionPort       int           `mapstructure:"ssh_bastion_port"`
-	SSHBastionUsername   string        `mapstructure:"ssh_bastion_username"`
-	SSHBastionPassword   string        `mapstructure:"ssh_bastion_password"`
-	SSHBastionPrivateKey string        `mapstructure:"ssh_bastion_private_key_file"`
+	SSHHost               string        `mapstructure:"ssh_host"`
+	SSHPort               int           `mapstructure:"ssh_port"`
+	SSHUsername           string        `mapstructure:"ssh_username"`
+	SSHPassword           string        `mapstructure:"ssh_password"`
+	SSHPrivateKey         string        `mapstructure:"ssh_private_key_file"`
+	SSHPty                bool          `mapstructure:"ssh_pty"`
+	SSHTimeout            time.Duration `mapstructure:"ssh_timeout"`
+	SSHDisableAgent       bool          `mapstructure:"ssh_disable_agent"`
+	SSHHandshakeAttempts  int           `mapstructure:"ssh_handshake_attempts"`
+	SSHBastionHost        string        `mapstructure:"ssh_bastion_host"`
+	SSHBastionPort        int           `mapstructure:"ssh_bastion_port"`
+	SSHBastionUsername    string        `mapstructure:"ssh_bastion_username"`
+	SSHBastionPassword    string        `mapstructure:"ssh_bastion_password"`
+	SSHBastionPrivateKey  string        `mapstructure:"ssh_bastion_private_key_file"`
+	SSHFileTransferMethod string        `mapstructure:"ssh_file_transfer_method"`
 
 	// WinRM
 	WinRMUser     string        `mapstructure:"winrm_username"`
@@ -93,6 +94,10 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		}
 	}
 
+	if c.SSHFileTransferMethod == "" {
+		c.SSHFileTransferMethod = "scp"
+	}
+
 	// Validation
 	var errs []error
 	if c.SSHUsername == "" {
@@ -114,6 +119,12 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 			errs = append(errs, errors.New(
 				"ssh_bastion_password or ssh_bastion_private_key_file must be specified"))
 		}
+	}
+
+	if c.SSHFileTransferMethod != "scp" && c.SSHFileTransferMethod != "sftp" {
+		errs = append(errs, fmt.Errorf(
+			"ssh_file_transfer_method ('%s') is invalid, valid methods: sftp, scp",
+			c.SSHFileTransferMethod))
 	}
 
 	return errs

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -162,6 +162,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 			SSHConfig:    sshConfig,
 			Pty:          s.Config.SSHPty,
 			DisableAgent: s.Config.SSHDisableAgent,
+			UseSftp:      s.Config.SSHFileTransferMethod == "sftp",
 		}
 
 		log.Println("[INFO] Attempting SSH connection...")

--- a/test/fixtures/provisioner-file/dir_no_trailing_sftp.json
+++ b/test/fixtures/provisioner-file/dir_no_trailing_sftp.json
@@ -1,0 +1,23 @@
+{
+    "builders": [{
+        "type": "amazon-ebs",
+        "ami_name": "packer-test {{timestamp}}",
+        "instance_type": "t2.micro",
+        "region": "us-east-1",
+        "ssh_username": "ec2-user",
+	"ssh_file_transfer_method": "sftp",
+        "source_ami": "ami-8da458e6",
+        "tags": {
+            "packer-test": "true"
+        }
+    }],
+
+    "provisioners": [{
+        "type": "file",
+        "source": "dir",
+        "destination": "/tmp"
+    }, {
+        "type": "shell",
+        "inline": ["cat /tmp/dir/file.txt"]
+    }]
+}

--- a/test/fixtures/provisioner-file/dir_with_trailing_sftp.json
+++ b/test/fixtures/provisioner-file/dir_with_trailing_sftp.json
@@ -1,0 +1,23 @@
+{
+    "builders": [{
+        "type": "amazon-ebs",
+        "ami_name": "packer-test {{timestamp}}",
+        "instance_type": "t2.micro",
+        "region": "us-east-1",
+        "ssh_username": "ec2-user",
+	"ssh_file_transfer_method": "sftp",
+        "source_ami": "ami-8da458e6",
+        "tags": {
+            "packer-test": "true"
+        }
+    }],
+
+    "provisioners": [{
+        "type": "file",
+        "source": "dir/",
+        "destination": "/tmp"
+    }, {
+        "type": "shell",
+        "inline": ["cat /tmp/file.txt"]
+    }]
+}

--- a/test/fixtures/provisioner-file/file_sftp.json
+++ b/test/fixtures/provisioner-file/file_sftp.json
@@ -1,0 +1,23 @@
+{
+    "builders": [{
+        "type": "amazon-ebs",
+        "ami_name": "packer-test {{timestamp}}",
+        "instance_type": "t2.micro",
+        "region": "us-east-1",
+        "ssh_username": "ec2-user",
+	"ssh_file_transfer_method": "sftp",
+        "source_ami": "ami-8da458e6",
+        "tags": {
+            "packer-test": "true"
+        }
+    }],
+
+    "provisioners": [{
+        "type": "file",
+        "source": "file.txt",
+        "destination": "/tmp/file.txt"
+    }, {
+        "type": "shell",
+        "inline": ["cat /tmp/file.txt"]
+    }]
+}

--- a/test/provisioner_file.bats
+++ b/test/provisioner_file.bats
@@ -32,3 +32,21 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"337 miles"* ]]
 }
+
+@test "file provisioner: single file through sftp" {
+    run packer build $FIXTURE_ROOT/file_sftp.json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"24901 miles"* ]]
+}
+
+@test "file provisioner: directory through sftp (no trailing slash)" {
+    run packer build $FIXTURE_ROOT/dir_no_trailing_sftp.json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"337 miles"* ]]
+}
+
+@test "file provisioner: directory through sftp (with trailing slash)" {
+    run packer build $FIXTURE_ROOT/dir_with_trailing_sftp.json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"337 miles"* ]]
+}

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -94,6 +94,9 @@ The SSH communicator has the following options:
 
   * `ssh_bastion_private_key_file` (string) - A private key file to use
     to authenticate with the bastion host.
+	
+  * `ssh_file_transfer_method` (`scp` or `sftp`) - How to transfer files, Secure
+    copy (default) or SSH File Transfer Protocol.
 
 ## WinRM Communicator
 


### PR DESCRIPTION
Adds a new config option: "ssh_file_transfer_method", which can be set to "scp"
or "sftp" (defaults to "scp")

Quoting @mitchellh in https://github.com/mitchellh/packer/issues/1991: "If I saw an SFTP PR though, I'd be happy to merge it." Well, here it is :) 