### PR TITLE
Fix powershell elevated not setting variables properly.

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -399,7 +399,7 @@ func (p *Provisioner) createCommandText() (command string, err error) {
 		Vars: flattenedEnvVars,
 		Path: p.config.RemotePath,
 	}
-	command, err = interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
+	command, err = interpolate.Render(p.config.ElevatedExecuteCommand, &p.config.ctx)
 	if err != nil {
 		return "", fmt.Errorf("Error processing command: %s", err)
 	}


### PR DESCRIPTION
Ref: #2378

When running elevated provisioner packer was using the regular executeCommand format, this was causing powershell to nest the command in another powershell executing where the variables get replaced, and since they are not yet set they replace to empty, causing command to then look like
```& { = virtualbox-ovf; =Test Name; =thebar; c:/Windows/Temp/script.ps1; exit }```
Sending an error to the screen, not setting the variables, but still executing the script.
EG :

Decoded
```
powershell "& { $env:PACKER_BUILDER_TYPE="virtualbox-ovf"; $env:PACKER_BUILD_NAME="Test Name"; c:/Windows/Temp/script.ps1; exit $LastExitCode}"; exit $LASTEXITCODE
```

Encoded
```
<Arguments>/c powershell.exe -EncodedCommand cABvAHcAZQByAHMAaABlAGwAbAAgACIAJgAgAHsAIAAkAGUAbgB2ADoAUABBAEMASwBFAFIAXwBCAFUASQBMAEQARQBSAF8AVABZAFAARQA9ACIAdgBpAHIAdAB1AGEAbABiAG8AeAAtAG8AdgBmACIAOwAgACQAZQBuAHYAOgBQAEEAQwBLAEUAUgBfAEIAVQBJAEwARABfAE4AQQBNAEUAPQAiAFQAZQBzAHQAIABOAGEAbQBlACIAOwAgAGMAOgAvAFcAaQBuAGQAbwB3AHMALwBUAGUAbQBwAC8AcwBjAHIAaQBwAHQALgBwAHMAMQA7ACAAZQB4AGkAdAAgACQATABhAHMAdABFAHgAaQB0AEMAbwBkAGUAfQAiADsAIABlAHgAaQB0ACAAJABMAEEAUwBUAEUAWABJAFQAQwBPAEQARQA= &gt; %TEMP%packer-55b56b05-d18b-472a-16ae-8d78a444b2b0.out 2&gt;&amp;1</Arguments>
```