### PR TITLE
Fix VMWare often not removing files properly when terminated

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -39,6 +39,9 @@ type Driver interface {
 	// Stop stops a VM specified by the path to the VMX given.
 	Stop(string) error
 
+	// Delete deletes a VM specified by the path to the VMX given.
+	Delete(string) error
+
 	// SuppressMessages modifies the VMX or surrounding directory so that
 	// VMware doesn't show any annoying messages.
 	SuppressMessages(string) error

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -102,6 +102,15 @@ func (d *Fusion5Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Fusion5Driver) Delete(vmxPath string) error {
+	cmd := exec.Command(d.vmrunPath(), "-T", "fusion", "deleteVM", vmxPath)
+	if _, _, err := runAndLog(cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *Fusion5Driver) SuppressMessages(vmxPath string) error {
 	dir := filepath.Dir(vmxPath)
 	base := filepath.Base(vmxPath)

--- a/builder/vmware/common/driver_mock.go
+++ b/builder/vmware/common/driver_mock.go
@@ -43,6 +43,10 @@ type DriverMock struct {
 	StopPath   string
 	StopErr    error
 
+	DeleteCalled bool
+	DeletePath   string
+	DeleteErr    error
+
 	SuppressMessagesCalled bool
 	SuppressMessagesPath   string
 	SuppressMessagesErr    error
@@ -109,6 +113,12 @@ func (d *DriverMock) Stop(path string) error {
 	d.StopCalled = true
 	d.StopPath = path
 	return d.StopErr
+}
+
+func (d *DriverMock) Delete(path string) error {
+	d.DeleteCalled = true
+	d.DeletePath = path
+	return d.DeleteErr
 }
 
 func (d *DriverMock) SuppressMessages(path string) error {

--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -124,6 +124,15 @@ func (d *Player5Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Player5Driver) Delete(vmxPath string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "ws", "deleteVM", vmxPath)
+	if _, _, err := runAndLog(cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *Player5Driver) SuppressMessages(vmxPath string) error {
 	return nil
 }

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -97,6 +97,15 @@ func (d *Workstation9Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Workstation9Driver) Delete(vmxPath string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "ws", "deleteVM", vmxPath)
+	if _, _, err := runAndLog(cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *Workstation9Driver) SuppressMessages(vmxPath string) error {
 	return nil
 }

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -83,6 +83,10 @@ func (d *ESX5Driver) Stop(vmxPathLocal string) error {
 	return d.sh("vim-cmd", "vmsvc/power.off", d.vmId)
 }
 
+func (d *ESX5Driver) Delete(vmxPathLocal string) error {
+	return d.sh("vim-cmd", "vmsvc/destroy", d.vmId)
+}
+
 func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	vmxPath := filepath.ToSlash(filepath.Join(d.outputDir, filepath.Base(vmxPathLocal)))
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {

--- a/helper/communicator/step_connect.go
+++ b/helper/communicator/step_connect.go
@@ -53,6 +53,7 @@ func (s *StepConnect) Run(state multistep.StateBag) multistep.StepAction {
 			Config:      s.Config,
 			Host:        s.Host,
 			WinRMConfig: s.WinRMConfig,
+			WinRMPort:   s.SSHPort,
 		},
 	}
 	for k, v := range s.CustomConnect {

--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -25,6 +25,7 @@ type StepConnectWinRM struct {
 	Config      *Config
 	Host        func(multistep.StateBag) (string, error)
 	WinRMConfig func(multistep.StateBag) (*WinRMConfig, error)
+	WinRMPort   func(multistep.StateBag) (int, error)
 }
 
 func (s *StepConnectWinRM) Run(state multistep.StateBag) multistep.StepAction {
@@ -96,6 +97,13 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 			continue
 		}
 		port := s.Config.WinRMPort
+		if s.WinRMPort != nil {
+			port, err = s.WinRMPort(state)
+			if err != nil {
+				log.Printf("[DEBUG] Error getting WinRM port: %s", err)
+				continue
+			}
+		}
 
 		user := s.Config.WinRMUser
 		password := s.Config.WinRMPassword


### PR DESCRIPTION
Ref: #2452

The VMWare builder sometimes does not delete the files/vm correctly when terminated in the middle of the run, or terminated due to error and cant connect to the VM to shutdown. 
This is due to it not issuing a force terminate command for cleanup like virtualbox does.

This is still WIP, added the pull request for visibility and if anyone can contribute.

