### PR TITLE
openstack builder: log which IP address SSH will use

### DIFF
--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -23,6 +23,7 @@ func CommHost(
 		// If we have a specific interface, try that
 		if sshinterface != "" {
 			if addr := sshAddrFromPool(s, sshinterface); addr != "" {
+				log.Printf("[DEBUG] Using IP address %s from specified interface %s for SSH", addr, sshinterface)
 				return addr, nil
 			}
 		}
@@ -30,15 +31,18 @@ func CommHost(
 		// If we have a floating IP, use that
 		ip := state.Get("access_ip").(*floatingip.FloatingIP)
 		if ip != nil && ip.IP != "" {
+			log.Printf("[DEBUG] Using floating IP %s for SSH", ip.IP)
 			return ip.IP, nil
 		}
 
 		if s.AccessIPv4 != "" {
+			log.Printf("[DEBUG] Using AccessIPv4 %s for SSH", s.AccessIPv4)
 			return s.AccessIPv4, nil
 		}
 
 		// Try to get it from the requested interface
 		if addr := sshAddrFromPool(s, sshinterface); addr != "" {
+			log.Printf("[DEBUG] Using IP address %s for SSH", addr)
 			return addr, nil
 		}
 


### PR DESCRIPTION
Another patch from the thread on the mailing list (https://groups.google.com/d/msg/packer-tool/Squ0nStU5_8/ZVq4rUAxgToJ) about issues building against Rackspace, this one adds extra debug logging to the openstack builder, as to which IP address will be used for SSH (and why).

This PR is my attempt to tidy this change up for submission, having split it out from the quick and dirty patch I posted in the mailing list thread, but I am very new to golang, so apologies in advance if this is all wrong...