### PR TITLE
openstack: store updated accessIPv4 from RackConnect

### DIFF
--- a/builder/openstack/step_wait_for_rackconnect.go
+++ b/builder/openstack/step_wait_for_rackconnect.go
@@ -39,6 +39,7 @@ func (s *StepWaitForRackConnect) Run(state multistep.StateBag) multistep.StepAct
 		}
 
 		if server.Metadata["rackconnect_automation_status"] == "DEPLOYED" {
+			state.Put("server", server)
 			break
 		}
 


### PR DESCRIPTION
Another patch from the thread on the mailing list (https://groups.google.com/d/msg/packer-tool/Squ0nStU5_8/ZVq4rUAxgToJ) about issues building against Rackspace.

This one updates the server object in the state bag with the one with the updated accessIPv4 value, as this changes during the process of RackConnect automation. Prior to this change, attempting to build against a Rackspace Cloud account with RackConnect v2 enabled would result in Packer waiting for RCv2 automation to complete... and then attempting to connect with the wrong IP address anyway.

This PR is my attempt to tidy this change up for submission, having split it out from the quick and dirty patch I posted in the mailing list thread, but I am very new to golang, so apologies in advance if this is all wrong...