### PR TITLE
amazon builder: only fetch password for winrm

### DIFF
--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -26,11 +26,10 @@ type StepGetPassword struct {
 
 func (s *StepGetPassword) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	image := state.Get("source_image").(*ec2.Image)
 
-	// Skip if we're not Windows...
-	if image.Platform == nil || *image.Platform != "windows" {
-		log.Printf("[INFO] Not Windows, skipping get password...")
+	// Skip if we're not using winrm
+	if s.Comm.Type != "winrm" {
+		log.Printf("[INFO] Not using winrm communicator, skipping get password...")
 		return multistep.ActionContinue
 	}
 


### PR DESCRIPTION
The amazon builder tries to always fetch a password for use with the winrm communicator for images with a platform of "windows". This unnecessarily delays the launch process of the instance.

This patch changes this behaviour to fetch the password depending on the use of the winrm communicator. Especially for ssh (even for windows images) the password will no longer be fetched.

@cbednarski please review and merge