### PR TITLE
amazon builder: always base64 encode ec2 user data

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -54,14 +54,13 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 			return multistep.ActionHalt
 		}
 
-		// Test if it is encoded already, and if not, encode it
-		if _, err := base64.StdEncoding.DecodeString(string(contents)); err != nil {
-			log.Printf("[DEBUG] base64 encoding user data...")
-			contents = []byte(base64.StdEncoding.EncodeToString(contents))
-		}
-
 		userData = string(contents)
+	}
 
+	// Test if it is encoded already, and if not, encode it
+	if _, err := base64.StdEncoding.DecodeString(userData); err != nil {
+		log.Printf("[DEBUG] base64 encoding user data...")
+		userData = base64.StdEncoding.EncodeToString([]byte(userData))
 	}
 
 	ui.Say("Launching a source AWS instance...")


### PR DESCRIPTION
The AWS api sdk requires ec2 user data to be base64 encoded. This was only the case for content read from a user_data_file. Now the ec2 user data is always base64 encoded, even when coming from the inline version of the packer template (user_data).

@cbednarski please review and merge

Closes #2616