### PR TITLE
Fix case for ethernet.generatedAddress property lookup in VMX

### DIFF
--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -39,7 +39,7 @@ func CommHost(config *SSHConfig) func(multistep.StateBag) (string, error) {
 		var ok bool
 		macAddress := ""
 		if macAddress, ok = vmxData["ethernet0.address"]; !ok || macAddress == "" {
-			if macAddress, ok = vmxData["ethernet0.generatedaddress"]; !ok || macAddress == "" {
+			if macAddress, ok = vmxData["ethernet0.generatedAddress"]; !ok || macAddress == "" {
 				return "", errors.New("couldn't find MAC address in VMX")
 			}
 		}


### PR DESCRIPTION
With the lowercase version the VMX builder can't figure out what the VM's IP is, and will not be able to connect over SSH.