### PR TITLE
Document `remote_port` option for vmware-iso builder

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -369,6 +369,8 @@ fill in the required `remote_*` configurations:
 Additionally, there are some optional configurations that you'll likely
 have to modify as well:
 
+* `remote_port` - The SSH port of the remote machine
+
 * `remote_datastore` - The path to the datastore where the VM will be
   stored on the ESXi machine.
 


### PR DESCRIPTION
Hi,

I noticed that the `remote_port` option isn't documented for the `vmware-iso` builder. This PR adds a few words into the docs about it!

Thanks