### PR TITLE
Update Make and Build.sh so it works on MinGW

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,7 +62,16 @@ case $(uname) in
         ;;
 esac
 OLDIFS=$IFS
-IFS=: MAIN_GOPATH=($GOPATH)
+IFS=:
+case $(uname) in
+    MINGW*)
+        IFS=";"
+        ;;
+    MSYS*)
+        IFS=";"
+        ;;
+esac
+MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory


### PR DESCRIPTION
Using Make and Build.sh was not fully working on windows and builds will receive errors when compiling under MinGW.


```
λ make dev
==> Getting dependencies...
==> Removing old directory...
==> Building...
Number of parallel builds: 4

-->   windows/amd64: github.com/mitchellh/packer
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-amazon-chroot
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-amazon-ebs
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-amazon-instance
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-digitalocean
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-docker
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-file
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-googlecompute
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-null
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-openstack
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-parallels-iso
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-parallels-pvm
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-qemu
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-virtualbox-iso
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-virtualbox-ovf
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-vmware-iso
-->   windows/amd64: github.com/mitchellh/packer/plugin/builder-vmware-vmx
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-artifice
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-atlas
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-compress
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-docker-import
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-docker-push
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-docker-save
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-docker-tag
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-vagrant
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-vagrant-cloud
-->   windows/amd64: github.com/mitchellh/packer/plugin/post-processor-vsphere
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-ansible-local
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-chef-client
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-chef-solo
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-file
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-powershell
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-puppet-masterless
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-puppet-server
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-salt-masterless
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-shell
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-shell-local
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-windows-restart
-->   windows/amd64: github.com/mitchellh/packer/plugin/provisioner-windows-shell
==> Copying binaries for this platform...
cp: target `C/bin/' is not a directory: No such file or directory
make.exe": *** [dev] Error 1
```

```
λ make test
Running tests on:
refs/heads/master
8484c2e2a05c5a9a22c61d0cdb0df09f612b5691
go test ./...  -timeout=10s
ok      github.com/mitchellh/packer     0.250s
ok      github.com/mitchellh/packer/builder/amazon/chroot       0.252s
ok      github.com/mitchellh/packer/builder/amazon/common       0.326s
ok      github.com/mitchellh/packer/builder/amazon/ebs  0.318s
ok      github.com/mitchellh/packer/builder/amazon/instance     0.283s
ok      github.com/mitchellh/packer/builder/digitalocean        0.375s
ok      github.com/mitchellh/packer/builder/docker      0.238s
ok      github.com/mitchellh/packer/builder/file        0.110s
ok      github.com/mitchellh/packer/builder/googlecompute       1.751s
ok      github.com/mitchellh/packer/builder/null        0.678s
ok      github.com/mitchellh/packer/builder/openstack   0.156s
ok      github.com/mitchellh/packer/builder/parallels/common    2.971s
ok      github.com/mitchellh/packer/builder/parallels/iso       0.206s
ok      github.com/mitchellh/packer/builder/parallels/pvm       0.117s
ok      github.com/mitchellh/packer/builder/qemu        0.541s
ok      github.com/mitchellh/packer/builder/virtualbox/common   2.932s
ok      github.com/mitchellh/packer/builder/virtualbox/iso      0.227s
ok      github.com/mitchellh/packer/builder/virtualbox/ovf      0.112s
ok      github.com/mitchellh/packer/builder/vmware/common       5.712s
ok      github.com/mitchellh/packer/builder/vmware/iso  0.349s
ok      github.com/mitchellh/packer/builder/vmware/vmx  0.170s
ok      github.com/mitchellh/packer/command     0.238s
ok      github.com/mitchellh/packer/common      0.313s
ok      github.com/mitchellh/packer/common/json 0.054s
?       github.com/mitchellh/packer/common/ssh  [no test files]
ok      github.com/mitchellh/packer/common/uuid 0.055s
ok      github.com/mitchellh/packer/communicator/ssh    0.439s
ok      github.com/mitchellh/packer/communicator/winrm  0.110s
ok      github.com/mitchellh/packer/fix 0.061s
ok      github.com/mitchellh/packer/helper/builder/testing      0.046s
ok      github.com/mitchellh/packer/helper/communicator 0.125s
ok      github.com/mitchellh/packer/helper/config       0.048s
ok      github.com/mitchellh/packer/helper/flag-kv      0.041s
ok      github.com/mitchellh/packer/helper/flag-slice   0.041s
ok      github.com/mitchellh/packer/packer      0.292s
ok      github.com/mitchellh/packer/packer/plugin       0.763s
ok      github.com/mitchellh/packer/packer/rpc  0.335s
ok      github.com/mitchellh/packer/plugin/builder-amazon-chroot        0.214s
ok      github.com/mitchellh/packer/plugin/builder-amazon-ebs   0.195s
ok      github.com/mitchellh/packer/plugin/builder-amazon-instance      0.223s
ok      github.com/mitchellh/packer/plugin/builder-digitalocean 0.133s
ok      github.com/mitchellh/packer/plugin/builder-docker       0.116s
?       github.com/mitchellh/packer/plugin/builder-file [no test files]
ok      github.com/mitchellh/packer/plugin/builder-googlecompute        0.210s
ok      github.com/mitchellh/packer/plugin/builder-null 0.200s
ok      github.com/mitchellh/packer/plugin/builder-openstack    0.361s
ok      github.com/mitchellh/packer/plugin/builder-parallels-iso        0.326s
ok      github.com/mitchellh/packer/plugin/builder-parallels-pvm        0.210s
ok      github.com/mitchellh/packer/plugin/builder-qemu 0.189s
ok      github.com/mitchellh/packer/plugin/builder-virtualbox-iso       0.149s
ok      github.com/mitchellh/packer/plugin/builder-virtualbox-ovf       0.132s
ok      github.com/mitchellh/packer/plugin/builder-vmware-iso   0.320s
ok      github.com/mitchellh/packer/plugin/builder-vmware-vmx   0.204s
?       github.com/mitchellh/packer/plugin/post-processor-artifice      [no test files]
ok      github.com/mitchellh/packer/plugin/post-processor-atlas 0.171s
ok      github.com/mitchellh/packer/plugin/post-processor-compress      0.113s
ok      github.com/mitchellh/packer/plugin/post-processor-docker-import 0.136s
ok      github.com/mitchellh/packer/plugin/post-processor-docker-push   0.204s
ok      github.com/mitchellh/packer/plugin/post-processor-docker-save   0.225s
ok      github.com/mitchellh/packer/plugin/post-processor-docker-tag    0.142s
ok      github.com/mitchellh/packer/plugin/post-processor-vagrant       0.155s
ok      github.com/mitchellh/packer/plugin/post-processor-vagrant-cloud 0.151s
ok      github.com/mitchellh/packer/plugin/post-processor-vsphere       0.223s
ok      github.com/mitchellh/packer/plugin/provisioner-ansible-local    0.142s
ok      github.com/mitchellh/packer/plugin/provisioner-chef-client      0.154s
ok      github.com/mitchellh/packer/plugin/provisioner-chef-solo        0.287s
ok      github.com/mitchellh/packer/plugin/provisioner-file     0.285s
?       github.com/mitchellh/packer/plugin/provisioner-powershell       [no test files]
ok      github.com/mitchellh/packer/plugin/provisioner-puppet-masterless        0.188s
ok      github.com/mitchellh/packer/plugin/provisioner-puppet-server    0.304s
ok      github.com/mitchellh/packer/plugin/provisioner-salt-masterless  0.270s
ok      github.com/mitchellh/packer/plugin/provisioner-shell    0.143s
?       github.com/mitchellh/packer/plugin/provisioner-shell-local      [no test files]
?       github.com/mitchellh/packer/plugin/provisioner-windows-restart  [no test files]
?       github.com/mitchellh/packer/plugin/provisioner-windows-shell    [no test files]
ok      github.com/mitchellh/packer/post-processor/artifice     0.161s
ok      github.com/mitchellh/packer/post-processor/atlas        0.133s
ok      github.com/mitchellh/packer/post-processor/compress     0.161s
ok      github.com/mitchellh/packer/post-processor/docker-import        0.154s
ok      github.com/mitchellh/packer/post-processor/docker-push  0.237s
ok      github.com/mitchellh/packer/post-processor/docker-save  0.170s
ok      github.com/mitchellh/packer/post-processor/docker-tag   0.166s
ok      github.com/mitchellh/packer/post-processor/vagrant      0.238s
ok      github.com/mitchellh/packer/post-processor/vagrant-cloud        0.098s
ok      github.com/mitchellh/packer/post-processor/vsphere      0.090s
ok      github.com/mitchellh/packer/provisioner/ansible-local   0.219s
ok      github.com/mitchellh/packer/provisioner/chef-client     0.202s
ok      github.com/mitchellh/packer/provisioner/chef-solo       0.166s
ok      github.com/mitchellh/packer/provisioner/file    0.110s
ok      github.com/mitchellh/packer/provisioner/powershell      0.420s
ok      github.com/mitchellh/packer/provisioner/puppet-masterless       0.168s
ok      github.com/mitchellh/packer/provisioner/puppet-server   0.115s
ok      github.com/mitchellh/packer/provisioner/salt-masterless 0.183s
ok      github.com/mitchellh/packer/provisioner/shell   0.235s
ok      github.com/mitchellh/packer/provisioner/shell-local     0.225s
ok      github.com/mitchellh/packer/provisioner/windows-restart 0.329s
ok      github.com/mitchellh/packer/provisioner/windows-shell   0.301s
ok      github.com/mitchellh/packer/template    0.045s
ok      github.com/mitchellh/packer/template/interpolate        0.037s
/bin/sh: /<GOPATH>/src/github.com/mitchellh/packer/C:/MinGW/msys/1.0/bin/make.exe: No such file or directory
make.exe": *** [test] Error 127
```
GOPATH is not what actually shows, im just mascarading my actual location.