### PR TITLE
Support source_image_name in OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -83,6 +83,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepRunSourceServer{
 			Name:             b.config.ImageName,
 			SourceImage:      b.config.SourceImage,
+			SourceImageName:  b.config.SourceImageName,
 			SecurityGroups:   b.config.SecurityGroups,
 			Networks:         b.config.Networks,
 			AvailabilityZone: b.config.AvailabilityZone,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -15,6 +15,7 @@ type RunConfig struct {
 	SSHInterface   string              `mapstructure:"ssh_interface"`
 
 	SourceImage      string   `mapstructure:"source_image"`
+	SourceImageName  string   `mapstructure:"source_image_name"`
 	Flavor           string   `mapstructure:"flavor"`
 	AvailabilityZone string   `mapstructure:"availability_zone"`
 	RackconnectWait  bool     `mapstructure:"rackconnect_wait"`
@@ -42,8 +43,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	// Validation
 	errs := c.Comm.Prepare(ctx)
-	if c.SourceImage == "" {
-		errs = append(errs, errors.New("A source_image must be specified"))
+	if c.SourceImage == "" && c.SourceImageName == "" {
+		errs = append(errs, errors.New("Either a source_image or a source_image_name must be specified"))
+	} else if len(c.SourceImage) > 0 && len(c.SourceImageName) > 0 {
+		errs = append(errs, errors.New("Only a source_image or a source_image_name can be specified, not both."))
 	}
 
 	if c.Flavor == "" {

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -14,6 +14,7 @@ import (
 type StepRunSourceServer struct {
 	Name             string
 	SourceImage      string
+	SourceImageName  string
 	SecurityGroups   []string
 	Networks         []string
 	AvailabilityZone string
@@ -57,6 +58,7 @@ func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction
 		CreateOptsBuilder: servers.CreateOpts{
 			Name:             s.Name,
 			ImageRef:         s.SourceImage,
+			ImageName:        s.SourceImageName,
 			FlavorRef:        flavor,
 			SecurityGroups:   s.SecurityGroups,
 			Networks:         networks,

--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -49,7 +49,7 @@ builder.
     have `cloud-init` installed so that the keypair gets assigned properly.
 
 -   `source_image_name` (string) - The name of the base image to use. This
-    is an alternative way of providig `source_image` and only either of them
+    is an alternative way of providing `source_image` and only either of them
     can be specified.
 
 -   `username` (string) - The username used to connect to the OpenStack service.

--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -48,6 +48,10 @@ builder.
     Unless you specify completely custom SSH settings, the source image must
     have `cloud-init` installed so that the keypair gets assigned properly.
 
+-   `source_image_name` (string) - The name of the base image to use. This
+    is an alternative way of providig `source_image` and only either of them
+    can be specified.
+
 -   `username` (string) - The username used to connect to the OpenStack service.
     If not specified, Packer will use the environment variable `OS_USERNAME`,
     if set.


### PR DESCRIPTION
As gophercloud supports source_image_name let's allow that in builder
configuration also. This an alternative way of providing source_image.