### PR TITLE
Revert backwards-compatibility break in VMX option casing

### DIFF
--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -39,7 +39,7 @@ func CommHost(config *SSHConfig) func(multistep.StateBag) (string, error) {
 		var ok bool
 		macAddress := ""
 		if macAddress, ok = vmxData["ethernet0.address"]; !ok || macAddress == "" {
-			if macAddress, ok = vmxData["ethernet0.generatedAddress"]; !ok || macAddress == "" {
+			if macAddress, ok = vmxData["ethernet0.generatedaddress"]; !ok || macAddress == "" {
 				return "", errors.New("couldn't find MAC address in VMX")
 			}
 		}

--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -2,11 +2,12 @@ package common
 
 import (
 	"fmt"
-	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/packer"
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 // This step cleans up the VMX by removing or changing this prior to
@@ -51,8 +52,8 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 
 		ui.Message("Detaching ISO from CD-ROM device...")
 
-		vmxData[ide+"deviceType"] = "cdrom-raw"
-		vmxData[ide+"fileName"] = "auto detect"
+		vmxData[ide+"devicetype"] = "cdrom-raw"
+		vmxData[ide+"filename"] = "auto detect"
 	}
 
 	ui.Message("Disabling VNC server...")

--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -61,8 +61,8 @@ func TestStepCleanVMX_floppyPath(t *testing.T) {
 		Value string
 	}{
 		{"floppy0.present", "FALSE"},
-		{"floppy0.fileType", ""},
-		{"floppy0.fileName", ""},
+		{"floppy0.filetype", ""},
+		{"floppy0.filename", ""},
 	}
 
 	for _, tc := range cases {
@@ -109,9 +109,9 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 		Key   string
 		Value string
 	}{
-		{"ide0:0.fileName", "auto detect"},
-		{"ide0:0.deviceType", "cdrom-raw"},
-		{"ide0:1.fileName", "bar"},
+		{"ide0:0.filename", "auto detect"},
+		{"ide0:0.devicetype", "cdrom-raw"},
+		{"ide0:1.filename", "bar"},
 		{"foo", "bar"},
 	}
 
@@ -130,12 +130,12 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 
 const testVMXFloppyPath = `
 floppy0.present = "TRUE"
-floppy0.fileType = "file"
+floppy0.filetype = "file"
 `
 
 const testVMXISOPath = `
-ide0:0.deviceType = "cdrom-image"
-ide0:0.fileName = "foo"
-ide0:1.fileName = "bar"
+ide0:0.devicetype = "cdrom-image"
+ide0:0.filename = "foo"
+ide0:1.filename = "bar"
 foo = "bar"
 `

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
@@ -52,6 +53,7 @@ func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
 	// Set custom data
 	for k, v := range s.CustomData {
 		log.Printf("Setting VMX: '%s' = '%s'", k, v)
+		k = strings.ToLower(k)
 		vmxData[k] = v
 	}
 

--- a/builder/vmware/common/vmx.go
+++ b/builder/vmware/common/vmx.go
@@ -17,7 +17,7 @@ import (
 func ParseVMX(contents string) map[string]string {
 	results := make(map[string]string)
 
-	lineRe := regexp.MustCompile(`^(.+?)\s*=\s*"?(.*?)"?\s*$`)
+	lineRe := regexp.MustCompile(`^(.+?)\s*=\s*"(.*?)"\s*$`)
 
 	for _, line := range strings.Split(contents, "\n") {
 		matches := lineRe.FindStringSubmatch(line)
@@ -25,7 +25,8 @@ func ParseVMX(contents string) map[string]string {
 			continue
 		}
 
-		results[matches[1]] = matches[2]
+		key := strings.ToLower(matches[1])
+		results[key] = matches[2]
 	}
 
 	return results
@@ -42,22 +43,9 @@ func EncodeVMX(contents map[string]string) string {
 		i++
 	}
 
-	// a list of VMX key fragments that should not be wrapped in quotes,
-	// fragments because multiple disks can use the virtualSSD suffix
-	noQuotes := []string {
-		"virtualSSD",
-	}
-
 	sort.Strings(keys)
 	for _, k := range keys {
-		pat := "%s = \"%s\"\n"
-		for _, q := range noQuotes {
-			if strings.Contains(k, q) {
-				pat = "%s = %s\n"
-				break;
-			}
-		}
-		buf.WriteString(fmt.Sprintf(pat, k, contents[k]))
+		buf.WriteString(fmt.Sprintf("%s = \"%s\"\n", k, contents[k]))
 	}
 
 	return buf.String()

--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -38,14 +38,14 @@ func (s *StepCloneVMX) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	var diskName string
-	if _, ok := vmxData["scsi0:0.fileName"]; ok {
-		diskName = vmxData["scsi0:0.fileName"]
+	if _, ok := vmxData["scsi0:0.filename"]; ok {
+		diskName = vmxData["scsi0:0.filename"]
 	}
-	if _, ok := vmxData["sata0:0.fileName"]; ok {
-		diskName = vmxData["sata0:0.fileName"]
+	if _, ok := vmxData["sata0:0.filename"]; ok {
+		diskName = vmxData["sata0:0.filename"]
 	}
-	if _, ok := vmxData["ide0:0.fileName"]; ok {
-		diskName = vmxData["ide0:0.fileName"]
+	if _, ok := vmxData["ide0:0.filename"]; ok {
+		diskName = vmxData["ide0:0.filename"]
 	}
 	if diskName == "" {
 		err := fmt.Errorf("Root disk filename could not be found!")


### PR DESCRIPTION
PR #2309 introduced case-sensitive options in VMX files. This is to support a case-sensitive option called `virtualSSD`. The change made all options case-sensitive, which causes problems with external VMX options provided in user templates. To prevent breakage, this change is being reverted.

- Fixes #2574
- Reverts #2542
- Reverts #2309