### PR TITLE
Fix for #2496 AWS credentials for instance based AMIs

### DIFF
--- a/builder/amazon/instance/step_upload_bundle.go
+++ b/builder/amazon/instance/step_upload_bundle.go
@@ -36,13 +36,24 @@ func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
+	accessKey := config.AccessKey
+	secretKey := config.SecretKey
+	accessConfig, err := config.AccessConfig.Config()
+	if err == nil && accessKey == "" && secretKey == "" {
+		credentials, err := accessConfig.Credentials.Get()
+		if err == nil {
+			accessKey = credentials.AccessKeyID
+			secretKey = credentials.SecretAccessKey
+		}
+	}
+
 	config.ctx.Data = uploadCmdData{
-		AccessKey:       config.AccessKey,
+		AccessKey:       accessKey,
 		BucketName:      config.S3Bucket,
 		BundleDirectory: config.BundleDestination,
 		ManifestPath:    manifestPath,
 		Region:          region,
-		SecretKey:       config.SecretKey,
+		SecretKey:       secretKey,
 	}
 	config.BundleUploadCommand, err = interpolate.Render(config.BundleUploadCommand, &config.ctx)
 	if err != nil {


### PR DESCRIPTION
Fix for https://github.com/mitchellh/packer/issues/2496 - `.AccessKey` and `.SecretKey` not being populated when uploading bundles for instance based AMIs for AWS. This might be a bit too localised or specific so let me know if I should be generalising this somehow. If in doubt it reverts to current behaviour.