### PR TITLE
Don't delete iso_url when it's a local file

### DIFF
--- a/common/download.go
+++ b/common/download.go
@@ -117,6 +117,7 @@ func (d *DownloadClient) Get() (string, error) {
 	var finalPath string
 	if url.Scheme == "file" && !d.config.CopyFile {
 		finalPath = url.Path
+		log.Printf("Using local file: %s", finalPath)
 
 		// Remove forward slash on absolute Windows file URLs before processing
 		if runtime.GOOS == "windows" && len(finalPath) > 0 && finalPath[0] == '/' {

--- a/common/download.go
+++ b/common/download.go
@@ -101,7 +101,7 @@ func (d *DownloadClient) Cancel() {
 func (d *DownloadClient) Get() (string, error) {
 	// If we already have the file and it matches, then just return the target path.
 	if verify, _ := d.VerifyChecksum(d.config.TargetPath); verify {
-		log.Println("Initial checksum matched, no download needed.")
+		log.Println("[DEBUG] Initial checksum matched, no download needed.")
 		return d.config.TargetPath, nil
 	}
 
@@ -120,7 +120,7 @@ func (d *DownloadClient) Get() (string, error) {
 		// This is a special case where we use a source file that already exists
 		// locally and we don't make a copy. Normally we would copy or download.
 		finalPath = url.Path
-		log.Printf("Using local file: %s", finalPath)
+		log.Printf("[DEBUG] Using local file: %s", finalPath)
 
 		// Remove forward slash on absolute Windows file URLs before processing
 		if runtime.GOOS == "windows" && len(finalPath) > 0 && finalPath[0] == '/' {
@@ -143,7 +143,7 @@ func (d *DownloadClient) Get() (string, error) {
 			return "", err
 		}
 
-		log.Printf("Downloading: %s", url.String())
+		log.Printf("[DEBUG] Downloading: %s", url.String())
 		err = d.downloader.Download(f, url)
 		f.Close()
 		if err != nil {

--- a/common/download_test.go
+++ b/common/download_test.go
@@ -340,6 +340,10 @@ func TestHashForType(t *testing.T) {
 	}
 }
 
+// TestDownloadFileUrl tests a special case where we use a local file for
+// iso_url. In this case we can still verify the checksum but we should not
+// delete the file if the checksum fails. Instead we'll just error and let the
+// user fix the checksum.
 func TestDownloadFileUrl(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -361,14 +365,10 @@ func TestDownloadFileUrl(t *testing.T) {
 
 	client := NewDownloadClient(config)
 
-	filename, err := client.Get()
-	defer os.Remove(config.TargetPath)
-	if err != nil {
-		t.Fatalf("Failed to download test file")
-	}
-
-	if sourcePath != filename {
-		t.Errorf("Filename doesn't match; expected %s got %s", sourcePath, filename)
+	// Verify that we fail to match the checksum
+	_, err = client.Get()
+	if err.Error() != "checksums didn't match expected: 6e6f7065" {
+		t.Fatalf("Unexpected failure; expected checksum not to match")
 	}
 
 	if _, err = os.Stat(sourcePath); err != nil {

--- a/common/test-fixtures/fileurl/cake
+++ b/common/test-fixtures/fileurl/cake
@@ -1,0 +1,1 @@
+delicious chocolate cake


### PR DESCRIPTION
You can specify a local file that already exists for iso_url.

- You can make a copy (or not).
- You can also add a checksum (or not).
- If you add a wrong checksum and don't make a copy, packer deletes the original. This is bad!

We fix this by handling the special case. Includes a test. Fixes #2603