### PR TITLE
Update calls to amazon to match the upstream

### DIFF
--- a/builder/amazon/chroot/step_attach_volume.go
+++ b/builder/amazon/chroot/step_attach_volume.go
@@ -35,8 +35,8 @@ func (s *StepAttachVolume) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say(fmt.Sprintf("Attaching the root volume to %s", attachVolume))
 	_, err := ec2conn.AttachVolume(&ec2.AttachVolumeInput{
-		InstanceID: instance.InstanceID,
-		VolumeID:   &volumeId,
+		InstanceId: instance.InstanceId,
+		VolumeId:   &volumeId,
 		Device:     &attachVolume,
 	})
 	if err != nil {
@@ -58,7 +58,7 @@ func (s *StepAttachVolume) Run(state multistep.StateBag) multistep.StepAction {
 		Refresh: func() (interface{}, string, error) {
 			attempts := 0
 			for attempts < 30 {
-				resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIDs: []*string{&volumeId}})
+				resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIds: []*string{&volumeId}})
 				if err != nil {
 					return nil, "", err
 				}
@@ -107,7 +107,7 @@ func (s *StepAttachVolume) CleanupFunc(state multistep.StateBag) error {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Detaching EBS volume...")
-	_, err := ec2conn.DetachVolume(&ec2.DetachVolumeInput{VolumeID: &s.volumeId})
+	_, err := ec2conn.DetachVolume(&ec2.DetachVolumeInput{VolumeId: &s.volumeId})
 	if err != nil {
 		return fmt.Errorf("Error detaching EBS volume: %s", err)
 	}
@@ -120,7 +120,7 @@ func (s *StepAttachVolume) CleanupFunc(state multistep.StateBag) error {
 		StepState: state,
 		Target:    "detached",
 		Refresh: func() (interface{}, string, error) {
-			resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIDs: []*string{&s.volumeId}})
+			resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIds: []*string{&s.volumeId}})
 			if err != nil {
 				return nil, "", err
 			}

--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -45,16 +45,16 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ui.Say("Creating the root volume...")
-	vs := *rootDevice.EBS.VolumeSize
-	if s.RootVolumeSize > *rootDevice.EBS.VolumeSize {
+	vs := *rootDevice.Ebs.VolumeSize
+	if s.RootVolumeSize > *rootDevice.Ebs.VolumeSize {
 		vs = s.RootVolumeSize
 	}
 	createVolume := &ec2.CreateVolumeInput{
 		AvailabilityZone: instance.Placement.AvailabilityZone,
 		Size:             aws.Int64(vs),
-		SnapshotID:       rootDevice.EBS.SnapshotID,
-		VolumeType:       rootDevice.EBS.VolumeType,
-		IOPS:             rootDevice.EBS.IOPS,
+		SnapshotId:       rootDevice.Ebs.SnapshotId,
+		VolumeType:       rootDevice.Ebs.VolumeType,
+		Iops:             rootDevice.Ebs.Iops,
 	}
 	log.Printf("Create args: %s", createVolume)
 
@@ -67,7 +67,7 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the volume ID so we remember to delete it later
-	s.volumeId = *createVolumeResp.VolumeID
+	s.volumeId = *createVolumeResp.VolumeId
 	log.Printf("Volume ID: %s", s.volumeId)
 
 	// Wait for the volume to become ready
@@ -76,7 +76,7 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 		StepState: state,
 		Target:    "available",
 		Refresh: func() (interface{}, string, error) {
-			resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIDs: []*string{&s.volumeId}})
+			resp, err := ec2conn.DescribeVolumes(&ec2.DescribeVolumesInput{VolumeIds: []*string{&s.volumeId}})
 			if err != nil {
 				return nil, "", err
 			}
@@ -107,7 +107,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Deleting the created EBS volume...")
-	_, err := ec2conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeID: &s.volumeId})
+	_, err := ec2conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: &s.volumeId})
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error deleting EBS volume: %s", err))
 	}

--- a/builder/amazon/chroot/step_instance_info.go
+++ b/builder/amazon/chroot/step_instance_info.go
@@ -34,7 +34,7 @@ func (s *StepInstanceInfo) Run(state multistep.StateBag) multistep.StepAction {
 	log.Printf("Instance ID: %s", instanceId)
 
 	// Query the entire instance metadata
-	instancesResp, err := ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{InstanceIDs: []*string{&instanceId}})
+	instancesResp, err := ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{InstanceIds: []*string{&instanceId}})
 	if err != nil {
 		err := fmt.Errorf("Error getting instance data: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -27,21 +27,21 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	for i, device := range image.BlockDeviceMappings {
 		newDevice := device
 		if *newDevice.DeviceName == *image.RootDeviceName {
-			if newDevice.EBS != nil {
-				newDevice.EBS.SnapshotID = aws.String(snapshotId)
+			if newDevice.Ebs != nil {
+				newDevice.Ebs.SnapshotId = aws.String(snapshotId)
 			} else {
-				newDevice.EBS = &ec2.EBSBlockDevice{SnapshotID: aws.String(snapshotId)}
+				newDevice.Ebs = &ec2.EbsBlockDevice{SnapshotId: aws.String(snapshotId)}
 			}
 
-			if s.RootVolumeSize > *newDevice.EBS.VolumeSize {
-				newDevice.EBS.VolumeSize = aws.Int64(s.RootVolumeSize)
+			if s.RootVolumeSize > *newDevice.Ebs.VolumeSize {
+				newDevice.Ebs.VolumeSize = aws.Int64(s.RootVolumeSize)
 			}
 		}
 
 		// assume working from a snapshot, so we unset the Encrypted field if set,
 		// otherwise AWS API will return InvalidParameter
-		if newDevice.EBS != nil && newDevice.EBS.Encrypted != nil {
-			newDevice.EBS.Encrypted = nil
+		if newDevice.Ebs != nil && newDevice.Ebs.Encrypted != nil {
+			newDevice.Ebs.Encrypted = nil
 		}
 
 		blockDevices[i] = newDevice
@@ -51,7 +51,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
-		registerOpts.SRIOVNetSupport = aws.String("simple")
+		registerOpts.SriovNetSupport = aws.String("simple")
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
@@ -62,16 +62,16 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the AMI ID in the state
-	ui.Say(fmt.Sprintf("AMI: %s", *registerResp.ImageID))
+	ui.Say(fmt.Sprintf("AMI: %s", *registerResp.ImageId))
 	amis := make(map[string]string)
-	amis[*ec2conn.Config.Region] = *registerResp.ImageID
+	amis[*ec2conn.Config.Region] = *registerResp.ImageId
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},
 		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageID),
+		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageId),
 		StepState: state,
 	}
 
@@ -102,8 +102,8 @@ func buildRegisterOpts(config *Config, image *ec2.Image, blockDevices []*ec2.Blo
 	}
 
 	if config.AMIVirtType != "hvm" {
-		registerOpts.KernelID = image.KernelID
-		registerOpts.RAMDiskID = image.RAMDiskID
+		registerOpts.KernelId = image.KernelId
+		registerOpts.RamdiskId = image.RamdiskId
 	}
 
 	return registerOpts

--- a/builder/amazon/chroot/step_register_ami_test.go
+++ b/builder/amazon/chroot/step_register_ami_test.go
@@ -9,10 +9,10 @@ import (
 
 func testImage() ec2.Image {
 	return ec2.Image{
-		ImageID:      aws.String("ami-abcd1234"),
+		ImageId:      aws.String("ami-abcd1234"),
 		Name:         aws.String("ami_test_name"),
 		Architecture: aws.String("x86_64"),
-		KernelID:     aws.String("aki-abcd1234"),
+		KernelId:     aws.String("aki-abcd1234"),
 	}
 }
 
@@ -38,9 +38,9 @@ func TestStepRegisterAmi_buildRegisterOpts_pv(t *testing.T) {
 		t.Fatalf("Unexpected Name value: expected %s got %s\n", expected, *opts.Name)
 	}
 
-	expected = *image.KernelID
-	if *opts.KernelID != expected {
-		t.Fatalf("Unexpected KernelId value: expected %s got %s\n", expected, *opts.KernelID)
+	expected = *image.KernelId
+	if *opts.KernelId != expected {
+		t.Fatalf("Unexpected KernelId value: expected %s got %s\n", expected, *opts.KernelId)
 	}
 
 }
@@ -67,7 +67,7 @@ func TestStepRegisterAmi_buildRegisterOpts_hvm(t *testing.T) {
 		t.Fatalf("Unexpected Name value: expected %s got %s\n", expected, *opts.Name)
 	}
 
-	if opts.KernelID != nil {
-		t.Fatalf("Unexpected KernelId value: expected nil got %s\n", *opts.KernelID)
+	if opts.KernelId != nil {
+		t.Fatalf("Unexpected KernelId value: expected nil got %s\n", *opts.KernelId)
 	}
 }

--- a/builder/amazon/chroot/step_snapshot.go
+++ b/builder/amazon/chroot/step_snapshot.go
@@ -28,7 +28,7 @@ func (s *StepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 	description := fmt.Sprintf("Packer: %s", time.Now().String())
 
 	createSnapResp, err := ec2conn.CreateSnapshot(&ec2.CreateSnapshotInput{
-		VolumeID:    &volumeId,
+		VolumeId:    &volumeId,
 		Description: &description,
 	})
 	if err != nil {
@@ -39,7 +39,7 @@ func (s *StepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the snapshot ID so we can delete it later
-	s.snapshotId = *createSnapResp.SnapshotID
+	s.snapshotId = *createSnapResp.SnapshotId
 	ui.Message(fmt.Sprintf("Snapshot ID: %s", s.snapshotId))
 
 	// Wait for the snapshot to be ready
@@ -48,7 +48,7 @@ func (s *StepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 		StepState: state,
 		Target:    "completed",
 		Refresh: func() (interface{}, string, error) {
-			resp, err := ec2conn.DescribeSnapshots(&ec2.DescribeSnapshotsInput{SnapshotIDs: []*string{&s.snapshotId}})
+			resp, err := ec2conn.DescribeSnapshots(&ec2.DescribeSnapshotsInput{SnapshotIds: []*string{&s.snapshotId}})
 			if err != nil {
 				return nil, "", err
 			}
@@ -86,7 +86,7 @@ func (s *StepSnapshot) Cleanup(state multistep.StateBag) {
 		ec2conn := state.Get("ec2").(*ec2.EC2)
 		ui := state.Get("ui").(packer.Ui)
 		ui.Say("Removing snapshot since we cancelled or halted...")
-		_, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{SnapshotID: &s.snapshotId})
+		_, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{SnapshotId: &s.snapshotId})
 		if err != nil {
 			ui.Error(fmt.Sprintf("Error: %s", err))
 		}

--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -75,7 +75,7 @@ func (a *Artifact) Destroy() error {
 		regionConn := ec2.New(regionConfig)
 
 		input := &ec2.DeregisterImageInput{
-			ImageID: &imageId,
+			ImageId: &imageId,
 		}
 		if _, err := regionConn.DeregisterImage(input); err != nil {
 			errors = append(errors, err)

--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -30,7 +30,7 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 	var blockDevices []*ec2.BlockDeviceMapping
 
 	for _, blockDevice := range b {
-		ebsBlockDevice := &ec2.EBSBlockDevice{
+		ebsBlockDevice := &ec2.EbsBlockDevice{
 			VolumeType:          aws.String(blockDevice.VolumeType),
 			VolumeSize:          aws.Int64(blockDevice.VolumeSize),
 			DeleteOnTermination: aws.Bool(blockDevice.DeleteOnTermination),
@@ -38,12 +38,12 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 
 		// IOPS is only valid for SSD Volumes
 		if blockDevice.VolumeType != "" && blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
-			ebsBlockDevice.IOPS = aws.Int64(blockDevice.IOPS)
+			ebsBlockDevice.Iops = aws.Int64(blockDevice.IOPS)
 		}
 
 		// You cannot specify Encrypted if you specify a Snapshot ID
 		if blockDevice.SnapshotId != "" {
-			ebsBlockDevice.SnapshotID = aws.String(blockDevice.SnapshotId)
+			ebsBlockDevice.SnapshotId = aws.String(blockDevice.SnapshotId)
 		} else if blockDevice.Encrypted {
 			ebsBlockDevice.Encrypted = aws.Bool(blockDevice.Encrypted)
 		}
@@ -54,7 +54,7 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 		}
 
 		if !strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
-			mapping.EBS = ebsBlockDevice
+			mapping.Ebs = ebsBlockDevice
 		}
 
 		if blockDevice.NoDevice {

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -25,8 +25,8 @@ func TestBlockDevice(t *testing.T) {
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
 				VirtualName: aws.String(""),
-				EBS: &ec2.EBSBlockDevice{
-					SnapshotID:          aws.String("snap-1234"),
+				Ebs: &ec2.EbsBlockDevice{
+					SnapshotId:          aws.String("snap-1234"),
 					VolumeType:          aws.String("standard"),
 					VolumeSize:          aws.Int64(8),
 					DeleteOnTermination: aws.Bool(true),
@@ -42,7 +42,7 @@ func TestBlockDevice(t *testing.T) {
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
 				VirtualName: aws.String(""),
-				EBS: &ec2.EBSBlockDevice{
+				Ebs: &ec2.EbsBlockDevice{
 					VolumeType:          aws.String(""),
 					VolumeSize:          aws.Int64(8),
 					DeleteOnTermination: aws.Bool(false),
@@ -61,11 +61,11 @@ func TestBlockDevice(t *testing.T) {
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
 				VirtualName: aws.String(""),
-				EBS: &ec2.EBSBlockDevice{
+				Ebs: &ec2.EbsBlockDevice{
 					VolumeType:          aws.String("io1"),
 					VolumeSize:          aws.Int64(8),
 					DeleteOnTermination: aws.Bool(true),
-					IOPS:                aws.Int64(1000),
+					Iops:                aws.Int64(1000),
 				},
 			},
 		},

--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -17,14 +17,14 @@ func SSHHost(e *ec2.EC2, private bool) func(multistep.StateBag) (string, error) 
 		for j := 0; j < 2; j++ {
 			var host string
 			i := state.Get("instance").(*ec2.Instance)
-			if i.VPCID != nil && *i.VPCID != "" {
-				if i.PublicIPAddress != nil && *i.PublicIPAddress != "" && !private {
-					host = *i.PublicIPAddress
+			if i.VpcId != nil && *i.VpcId != "" {
+				if i.PublicIpAddress != nil && *i.PublicIpAddress != "" && !private {
+					host = *i.PublicIpAddress
 				} else {
-					host = *i.PrivateIPAddress
+					host = *i.PrivateIpAddress
 				}
-			} else if i.PublicDNSName != nil && *i.PublicDNSName != "" {
-				host = *i.PublicDNSName
+			} else if i.PublicDnsName != nil && *i.PublicDnsName != "" {
+				host = *i.PublicDnsName
 			}
 
 			if host != "" {
@@ -32,14 +32,14 @@ func SSHHost(e *ec2.EC2, private bool) func(multistep.StateBag) (string, error) 
 			}
 
 			r, err := e.DescribeInstances(&ec2.DescribeInstancesInput{
-				InstanceIDs: []*string{i.InstanceID},
+				InstanceIds: []*string{i.InstanceId},
 			})
 			if err != nil {
 				return "", err
 			}
 
 			if len(r.Reservations) == 0 || len(r.Reservations[0].Instances) == 0 {
-				return "", fmt.Errorf("instance not found: %s", *i.InstanceID)
+				return "", fmt.Errorf("instance not found: %s", *i.InstanceId)
 			}
 
 			state.Put("instance", &r.Reservations[0].Instances[0])

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -39,7 +39,7 @@ type StateChangeConf struct {
 func AMIStateRefreshFunc(conn *ec2.EC2, imageId string) StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeImages(&ec2.DescribeImagesInput{
-			ImageIDs: []*string{&imageId},
+			ImageIds: []*string{&imageId},
 		})
 		if err != nil {
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAMIID.NotFound" {
@@ -70,7 +70,7 @@ func AMIStateRefreshFunc(conn *ec2.EC2, imageId string) StateRefreshFunc {
 func InstanceStateRefreshFunc(conn *ec2.EC2, instanceId string) StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIDs: []*string{&instanceId},
+			InstanceIds: []*string{&instanceId},
 		})
 		if err != nil {
 			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
@@ -101,7 +101,7 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, instanceId string) StateRefreshFunc
 func SpotRequestStateRefreshFunc(conn *ec2.EC2, spotRequestId string) StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIDs: []*string{&spotRequestId},
+			SpotInstanceRequestIds: []*string{&spotRequestId},
 		})
 
 		if err != nil {

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -90,7 +90,7 @@ func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, 
 	regionconn := ec2.New(awsConfig)
 	resp, err := regionconn.CopyImage(&ec2.CopyImageInput{
 		SourceRegion:  &source,
-		SourceImageID: &imageId,
+		SourceImageId: &imageId,
 		Name:          &name,
 	})
 
@@ -102,14 +102,14 @@ func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, 
 	stateChange := StateChangeConf{
 		Pending:   []string{"pending"},
 		Target:    "available",
-		Refresh:   AMIStateRefreshFunc(regionconn, *resp.ImageID),
+		Refresh:   AMIStateRefreshFunc(regionconn, *resp.ImageId),
 		StepState: state,
 	}
 
 	if _, err := WaitForState(&stateChange); err != nil {
 		return "", fmt.Errorf("Error waiting for AMI (%s) in region (%s): %s",
-			*resp.ImageID, target, err)
+			*resp.ImageId, target, err)
 	}
 
-	return *resp.ImageID, nil
+	return *resp.ImageId, nil
 }

--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -41,7 +41,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 
 			// Retrieve image list for given AMI
 			imageResp, err := regionconn.DescribeImages(&ec2.DescribeImagesInput{
-				ImageIDs: resourceIds,
+				ImageIds: resourceIds,
 			})
 
 			if err != nil {
@@ -62,9 +62,9 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 
 			// Add only those with a Snapshot ID, i.e. not Ephemeral
 			for _, device := range image.BlockDeviceMappings {
-				if device.EBS != nil && device.EBS.SnapshotID != nil {
-					ui.Say(fmt.Sprintf("Tagging snapshot: %s", *device.EBS.SnapshotID))
-					resourceIds = append(resourceIds, device.EBS.SnapshotID)
+				if device.Ebs != nil && device.Ebs.SnapshotId != nil {
+					ui.Say(fmt.Sprintf("Tagging snapshot: %s", *device.Ebs.SnapshotId))
+					resourceIds = append(resourceIds, device.Ebs.SnapshotId)
 				}
 			}
 

--- a/builder/amazon/common/step_deregister_ami.go
+++ b/builder/amazon/common/step_deregister_ami.go
@@ -36,7 +36,7 @@ func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		// deregister image(s) by that name
 		for _, i := range resp.Images {
 			_, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
-				ImageID: i.ImageID,
+				ImageId: i.ImageId,
 			})
 
 			if err != nil {
@@ -45,7 +45,7 @@ func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			ui.Say(fmt.Sprintf("Deregistered AMI %s, id: %s", s.AMIName, *i.ImageID))
+			ui.Say(fmt.Sprintf("Deregistered AMI %s, id: %s", s.AMIName, *i.ImageId))
 		}
 	}
 

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -111,7 +111,7 @@ func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-cha
 		}
 
 		resp, err := ec2conn.GetPasswordData(&ec2.GetPasswordDataInput{
-			InstanceID: instance.InstanceID,
+			InstanceId: instance.InstanceId,
 		})
 		if err != nil {
 			err := fmt.Errorf("Error retrieving auto-generated instance password: %s", err)

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -66,10 +66,10 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		adds := make([]*ec2.LaunchPermission, len(s.Users))
 		for i, u := range s.Users {
 			users[i] = aws.String(u)
-			adds[i] = &ec2.LaunchPermission{UserID: aws.String(u)}
+			adds[i] = &ec2.LaunchPermission{UserId: aws.String(u)}
 		}
 		options["users"] = &ec2.ModifyImageAttributeInput{
-			UserIDs: users,
+			UserIds: users,
 			LaunchPermission: &ec2.LaunchPermissionModifications{
 				Add: adds,
 			},
@@ -94,7 +94,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		})
 		for name, input := range options {
 			ui.Message(fmt.Sprintf("Modifying: %s", name))
-			input.ImageID = &ami
+			input.ImageId = &ami
 			_, err := regionconn.ModifyImageAttribute(input)
 			if err != nil {
 				err := fmt.Errorf("Error modify AMI attributes: %s", err)

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -41,7 +41,7 @@ func (s *StepPreValidate) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if len(resp.Images) > 0 {
-		err := fmt.Errorf("Error: name conflicts with an existing AMI: %s", *resp.Images[0].ImageID)
+		err := fmt.Errorf("Error: name conflicts with an existing AMI: %s", *resp.Images[0].ImageId)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -43,7 +43,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	group := &ec2.CreateSecurityGroupInput{
 		GroupName:   &groupName,
 		Description: aws.String("Temporary group for Packer"),
-		VPCID:       &s.VpcId,
+		VpcId:       &s.VpcId,
 	}
 	groupResp, err := ec2conn.CreateSecurityGroup(group)
 	if err != nil {
@@ -53,15 +53,15 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the group ID so we can delete it later
-	s.createdGroupId = *groupResp.GroupID
+	s.createdGroupId = *groupResp.GroupId
 
 	// Authorize the SSH access for the security group
 	req := &ec2.AuthorizeSecurityGroupIngressInput{
-		GroupID:    groupResp.GroupID,
-		IPProtocol: aws.String("tcp"),
+		GroupId:    groupResp.GroupId,
+		IpProtocol: aws.String("tcp"),
 		FromPort:   aws.Int64(int64(port)),
 		ToPort:     aws.Int64(int64(port)),
-		CIDRIP:     aws.String("0.0.0.0/0"),
+		CidrIp:     aws.String("0.0.0.0/0"),
 	}
 
 	// We loop and retry this a few times because sometimes the security
@@ -105,7 +105,7 @@ func (s *StepSecurityGroup) Cleanup(state multistep.StateBag) {
 
 	var err error
 	for i := 0; i < 5; i++ {
-		_, err = ec2conn.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupID: &s.createdGroupId})
+		_, err = ec2conn.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: &s.createdGroupId})
 		if err == nil {
 			break
 		}

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -23,7 +23,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Inspecting the source AMI...")
-	imageResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIDs: []*string{&s.SourceAmi}})
+	imageResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{&s.SourceAmi}})
 	if err != nil {
 		err := fmt.Errorf("Error querying AMI: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/ebs/builder_acc_test.go
+++ b/builder/amazon/ebs/builder_acc_test.go
@@ -71,7 +71,7 @@ func checkAMISharing(count int, uid, group string) builderT.TestCheckFunc {
 		ec2conn, _ := testEC2Conn()
 		imageResp, err := ec2conn.DescribeImageAttribute(&ec2.DescribeImageAttributeInput{
 			Attribute: aws.String("launchPermission"),
-			ImageID:   aws.String(artifact.Amis["us-east-1"]),
+			ImageId:   aws.String(artifact.Amis["us-east-1"]),
 		})
 
 		if err != nil {
@@ -86,7 +86,7 @@ func checkAMISharing(count int, uid, group string) builderT.TestCheckFunc {
 
 		userFound := false
 		for _, lp := range imageResp.LaunchPermissions {
-			if lp.UserID != nil && uid == *lp.UserID {
+			if lp.UserId != nil && uid == *lp.UserId {
 				userFound = true
 			}
 		}

--- a/builder/amazon/ebs/step_cleanup_volumes.go
+++ b/builder/amazon/ebs/step_cleanup_volumes.go
@@ -62,9 +62,9 @@ func (s *stepCleanupVolumes) Cleanup(state multistep.StateBag) {
 	var vl []*string
 	volList := make(map[string]string)
 	for _, bdm := range instance.BlockDeviceMappings {
-		if bdm.EBS != nil {
-			vl = append(vl, bdm.EBS.VolumeID)
-			volList[*bdm.EBS.VolumeID] = *bdm.DeviceName
+		if bdm.Ebs != nil {
+			vl = append(vl, bdm.Ebs.VolumeId)
+			volList[*bdm.Ebs.VolumeId] = *bdm.DeviceName
 		}
 	}
 
@@ -88,7 +88,7 @@ func (s *stepCleanupVolumes) Cleanup(state multistep.StateBag) {
 	// available, remove them from the list of volumes
 	for _, v := range resp.Volumes {
 		if v.State != nil && *v.State != "available" {
-			delete(volList, *v.VolumeID)
+			delete(volList, *v.VolumeId)
 		}
 	}
 
@@ -109,7 +109,7 @@ func (s *stepCleanupVolumes) Cleanup(state multistep.StateBag) {
 	// Destroy remaining volumes
 	for k, _ := range volList {
 		ui.Say(fmt.Sprintf("Destroying volume (%s)...", k))
-		_, err := ec2conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeID: aws.String(k)})
+		_, err := ec2conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: aws.String(k)})
 		if err != nil {
 			ui.Say(fmt.Sprintf("Error deleting volume: %s", k))
 		}

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -22,7 +22,7 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 	// Create the image
 	ui.Say(fmt.Sprintf("Creating the AMI: %s", config.AMIName))
 	createOpts := &ec2.CreateImageInput{
-		InstanceID:          instance.InstanceID,
+		InstanceId:          instance.InstanceId,
 		Name:                &config.AMIName,
 		BlockDeviceMappings: config.BlockDevices.BuildAMIDevices(),
 	}
@@ -36,16 +36,16 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the AMI ID in the state
-	ui.Message(fmt.Sprintf("AMI: %s", *createResp.ImageID))
+	ui.Message(fmt.Sprintf("AMI: %s", *createResp.ImageId))
 	amis := make(map[string]string)
-	amis[*ec2conn.Config.Region] = *createResp.ImageID
+	amis[*ec2conn.Config.Region] = *createResp.ImageId
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},
 		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *createResp.ImageID),
+		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *createResp.ImageId),
 		StepState: state,
 	}
 
@@ -57,7 +57,7 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIDs: []*string{createResp.ImageID}})
+	imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
 	if err != nil {
 		err := fmt.Errorf("Error searching for AMI: %s", err)
 		state.Put("error", err)
@@ -84,7 +84,7 @@ func (s *stepCreateAMI) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Deregistering the AMI because cancelation or error...")
-	deregisterOpts := &ec2.DeregisterImageInput{ImageID: s.image.ImageID}
+	deregisterOpts := &ec2.DeregisterImageInput{ImageId: s.image.ImageId}
 	if _, err := ec2conn.DeregisterImage(deregisterOpts); err != nil {
 		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %s", err))
 		return

--- a/builder/amazon/ebs/step_modify_instance.go
+++ b/builder/amazon/ebs/step_modify_instance.go
@@ -21,11 +21,11 @@ func (s *stepModifyInstance) Run(state multistep.StateBag) multistep.StepAction 
 		ui.Say("Enabling Enhanced Networking...")
 		simple := "simple"
 		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceID:      instance.InstanceID,
-			SRIOVNetSupport: &ec2.AttributeValue{Value: &simple},
+			InstanceId:      instance.InstanceId,
+			SriovNetSupport: &ec2.AttributeValue{Value: &simple},
 		})
 		if err != nil {
-			err := fmt.Errorf("Error enabling Enhanced Networking on %s: %s", *instance.InstanceID, err)
+			err := fmt.Errorf("Error enabling Enhanced Networking on %s: %s", *instance.InstanceId, err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/amazon/ebs/step_stop_instance.go
+++ b/builder/amazon/ebs/step_stop_instance.go
@@ -26,7 +26,7 @@ func (s *stepStopInstance) Run(state multistep.StateBag) multistep.StepAction {
 	// Stop the instance so we can create an AMI from it
 	ui.Say("Stopping the source instance...")
 	_, err := ec2conn.StopInstances(&ec2.StopInstancesInput{
-		InstanceIDs: []*string{instance.InstanceID},
+		InstanceIds: []*string{instance.InstanceId},
 	})
 	if err != nil {
 		err := fmt.Errorf("Error stopping instance: %s", err)
@@ -40,7 +40,7 @@ func (s *stepStopInstance) Run(state multistep.StateBag) multistep.StepAction {
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"running", "stopping"},
 		Target:    "stopped",
-		Refresh:   awscommon.InstanceStateRefreshFunc(ec2conn, *instance.InstanceID),
+		Refresh:   awscommon.InstanceStateRefreshFunc(ec2conn, *instance.InstanceId),
 		StepState: state,
 	}
 	_, err = awscommon.WaitForState(&stateChange)

--- a/builder/amazon/ebs/tags_acc_test.go
+++ b/builder/amazon/ebs/tags_acc_test.go
@@ -40,7 +40,7 @@ func checkTags() builderT.TestCheckFunc {
 		// describe the image, get block devices with a snapshot
 		ec2conn, _ := testEC2Conn()
 		imageResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
-			ImageIDs: []*string{aws.String(artifact.Amis["us-east-1"])},
+			ImageIds: []*string{aws.String(artifact.Amis["us-east-1"])},
 		})
 
 		if err != nil {
@@ -56,14 +56,14 @@ func checkTags() builderT.TestCheckFunc {
 		// Check only those with a Snapshot ID, i.e. not Ephemeral
 		var snapshots []*string
 		for _, device := range image.BlockDeviceMappings {
-			if device.EBS != nil && device.EBS.SnapshotID != nil {
-				snapshots = append(snapshots, device.EBS.SnapshotID)
+			if device.Ebs != nil && device.Ebs.SnapshotId != nil {
+				snapshots = append(snapshots, device.Ebs.SnapshotId)
 			}
 		}
 
 		// grab matching snapshot info
 		resp, err := ec2conn.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
-			SnapshotIDs: snapshots,
+			SnapshotIds: snapshots,
 		})
 
 		if err != nil {

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -31,7 +31,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
-		registerOpts.SRIOVNetSupport = aws.String("simple")
+		registerOpts.SriovNetSupport = aws.String("simple")
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
@@ -42,16 +42,16 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set the AMI ID in the state
-	ui.Say(fmt.Sprintf("AMI: %s", *registerResp.ImageID))
+	ui.Say(fmt.Sprintf("AMI: %s", *registerResp.ImageId))
 	amis := make(map[string]string)
-	amis[*ec2conn.Config.Region] = *registerResp.ImageID
+	amis[*ec2conn.Config.Region] = *registerResp.ImageId
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},
 		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageID),
+		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageId),
 		StepState: state,
 	}
 


### PR DESCRIPTION
- see http://aws.amazon.com/releasenotes/2948141298714307
- run awsmigrate-renamer on each amazon module (chroot, instance, etc.)