### PR TITLE
openstack builder: report error if auth env vars are missing

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -58,8 +58,8 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		c.Username = os.Getenv("SDK_USERNAME")
 	}
 
-	// Get as much as possible from the end
-	ao, _ := openstack.AuthOptionsFromEnv()
+	// Get as much as possible from the env
+	ao, authErr := openstack.AuthOptionsFromEnv()
 
 	// Override values if we have them in our config
 	overrides := []struct {
@@ -80,6 +80,10 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 			*s.To = *s.From
 		}
 	}
+
+    if ao.IdentityEndpoint == "" || ao.Username == "" || ao.Password == "" {
+        return []error{authErr}
+    }
 
 	// Build the client itself
 	client, err := openstack.NewClient(ao.IdentityEndpoint)


### PR DESCRIPTION
When running packer to build for OpenStack I've often forgot to source my authentication credentials.  Without these changes I get this cryptic warning:

```
openstack output will be in this color.

1 error(s) occurred:

* Get /: unsupported protocol scheme ""
```

The gophercloud package is providing an appropriate error for us but we are just throwing it away.  With this change we'll bubble the error up and it now looks like:

```
openstack output will be in this color.

1 error(s) occurred:

* Environment variable OS_AUTH_URL needs to be set.
```