### PR TITLE
Improve artifact validation for docker builder

### DIFF
--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -65,7 +65,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		log.Printf("[DEBUG] Container will be exported to %s", b.config.ExportPath)
 		steps = append(steps, new(StepExport))
 	} else {
-		return nil, ErrArtifactNotUsed
+		return nil, errArtifactNotUsed
 	}
 
 	// Setup the state bag and initial state for the steps

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -9,8 +9,10 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-const BuilderId = "packer.docker"
-const BuilderIdImport = "packer.post-processor.docker-import"
+const (
+	BuilderId       = "packer.docker"
+	BuilderIdImport = "packer.post-processor.docker-import"
+)
 
 type Builder struct {
 	config *Config
@@ -54,10 +56,16 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&common.StepProvision{},
 	}
 
-	if b.config.Commit {
+	if b.config.Discard {
+		log.Print("[DEBUG] Container will be discarded")
+	} else if b.config.Commit {
+		log.Print("[DEBUG] Container will be committed")
 		steps = append(steps, new(StepCommit))
-	} else {
+	} else if b.config.ExportPath != "" {
+		log.Printf("[DEBUG] Container will be exported to %s", b.config.ExportPath)
 		steps = append(steps, new(StepExport))
+	} else {
+		return nil, ErrArtifactNotUsed
 	}
 
 	// Setup the state bag and initial state for the steps

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -13,10 +13,10 @@ import (
 )
 
 var (
-	ErrArtifactNotUsed     = fmt.Errorf("No instructions given for handling the artifact; expected commit, discard, or export_path")
-	ErrArtifactUseConflict = fmt.Errorf("Cannot specify more than one of commit, discard, and export_path")
-	ErrExportPathNotFile   = fmt.Errorf("export_path must be a file, not a directory")
-	ErrImageNotSpecified   = fmt.Errorf("Image must be specified")
+	errArtifactNotUsed     = fmt.Errorf("No instructions given for handling the artifact; expected commit, discard, or export_path")
+	errArtifactUseConflict = fmt.Errorf("Cannot specify more than one of commit, discard, and export_path")
+	errExportPathNotFile   = fmt.Errorf("export_path must be a file, not a directory")
+	errImageNotSpecified   = fmt.Errorf("Image must be specified")
 )
 
 type Config struct {
@@ -89,20 +89,20 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		errs = packer.MultiErrorAppend(errs, es...)
 	}
 	if c.Image == "" {
-		errs = packer.MultiErrorAppend(errs, ErrImageNotSpecified)
+		errs = packer.MultiErrorAppend(errs, errImageNotSpecified)
 	}
 
 	if (c.ExportPath != "" && c.Commit) || (c.ExportPath != "" && c.Discard) || (c.Commit && c.Discard) {
-		errs = packer.MultiErrorAppend(errs, ErrArtifactUseConflict)
+		errs = packer.MultiErrorAppend(errs, errArtifactUseConflict)
 	}
 
 	if c.ExportPath == "" && !c.Commit && !c.Discard {
-		errs = packer.MultiErrorAppend(errs, ErrArtifactNotUsed)
+		errs = packer.MultiErrorAppend(errs, errArtifactNotUsed)
 	}
 
 	if c.ExportPath != "" {
 		if fi, err := os.Stat(c.ExportPath); err == nil && fi.IsDir() {
-			errs = packer.MultiErrorAppend(errs, ErrExportPathNotFile)
+			errs = packer.MultiErrorAppend(errs, errExportPathNotFile)
 		}
 	}
 

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -63,11 +63,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Defaults
 	if len(c.RunCommand) == 0 {
-		c.RunCommand = []string{
-			"-d", "-i", "-t",
-			"{{.Image}}",
-			"/bin/bash",
-		}
+		c.RunCommand = []string{"-d", "-i", "-t", "{{.Image}}", "/bin/bash"}
 	}
 
 	// Default Pull if it wasn't set

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	RunCommand []string `mapstructure:"run_command"`
 	Volumes    map[string]string
 
-	// This is used to login to dockerhub to pull a private base container
-	// For pushing to dockerhub, see the docker post-processors
+	// This is used to login to dockerhub to pull a private base container. For
+	// pushing to dockerhub, see the docker post-processors
 	Login         bool
 	LoginEmail    string `mapstructure:"login_email"`
 	LoginPassword string `mapstructure:"login_password"`
@@ -89,8 +89,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		errs = packer.MultiErrorAppend(errs, es...)
 	}
 	if c.Image == "" {
-		errs = packer.MultiErrorAppend(errs,
-			ErrImageNotSpecified)
+		errs = packer.MultiErrorAppend(errs, ErrImageNotSpecified)
 	}
 
 	if (c.ExportPath != "" && c.Commit) || (c.ExportPath != "" && c.Discard) || (c.Commit && c.Discard) {

--- a/builder/docker/step_export.go
+++ b/builder/docker/step_export.go
@@ -2,9 +2,10 @@ package docker
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"os"
 )
 
 // StepExport exports the container to a flat tar file.
@@ -16,6 +17,14 @@ func (s *StepExport) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	containerId := state.Get("container_id").(string)
 	ui := state.Get("ui").(packer.Ui)
+
+	// We should catch this in validation, but guard anyway
+	if config.ExportPath == "" {
+		err := fmt.Errorf("No output file specified, we can't export anything")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	// Open the file that we're going to write to
 	f, err := os.Create(config.ExportPath)

--- a/website/source/docs/builders/docker.html.markdown
+++ b/website/source/docs/builders/docker.html.markdown
@@ -68,11 +68,17 @@ builder.
 
 ### Required:
 
+You must specify (only) one of `commit`, `discard`, or `export_path`.
+
 -   `commit` (boolean) - If true, the container will be committed to an image
-    rather than exported. This cannot be set if `export_path` is set.
+    rather than exported.
+
+-   `discard` (boolean) - Throw away the container when the build is complete.
+    This is useful for the [artifice
+    post-processor](https://packer.io/docs/post-processors/artifice.html).
 
 -   `export_path` (string) - The path where the final container will be exported
-    as a tar file. This cannot be set if `commit` is set to true.
+    as a tar file.
 
 -   `image` (string) - The base image for the Docker container that will
     be started. This image will be pulled from the Docker registry if it doesn't


### PR DESCRIPTION
Currently if you forget to specify either `commit` or `export_path` for the docker builder you get a rather unhelpful error message when the build is complete and packer tries to run docker export:

    Error creating output file: open : no such file or directory

Since you might actually want to skip exporting (e.g. for artifice) I added a `discard` option. This allows us to validate in all three cases. The validator now checks to make sure at least one of these options is specified so you get the error sooner.