### PR TITLE
Update dependency to an SSL-enabled path; this was migrated from launchpad to github

### DIFF
--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/going/toolkit/xmlpath"
+	"gopkg.in/xmlpath.v2"
 )
 
 type Parallels9Driver struct {


### PR DESCRIPTION
This dependency causes go get to break in go 1.5 because it is not retrieved over HTTPS. I've added `-insecure` in the mean time.

"github.com/going/toolkit/xmlpath" is actually some weird embedded bazaar repo that `go get` redirects to launchpad. Gustavo Niemeyer (the original author) has since copied this library to github.

The new copy on github also has some updates. I was not able to test parallels so I have left this open for now.