### PR TITLE
Overhaul the Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,15 @@ language: go
 
 go:
   - 1.4
+  - 1.5
   - tip
 
-install: make updatedeps
-
 script:
-  - GOMAXPROCS=2 make test
-  #- go test -race ./...
+  - GOMAXPROCS=2 make ci
 
 branches:
   only:
     - master
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#packer-tool"
-    skip_join: true
-    use_notice: true
 
 matrix:
   fast_finish: true

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 
 default: test dev
 
-ci: deps test testrace
+ci: deps test
 
 release: updatedeps test bin
 
@@ -29,10 +29,10 @@ dev: deps
 
 # generate runs `go generate` to build the dynamically generated
 # source files.
-generate:
+generate: deps
 	go generate ./...
 
-test:
+test: deps
 	go test $(TEST) $(TESTARGS) -timeout=15s
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
@@ -43,11 +43,11 @@ test:
 	fi
 
 # testacc runs acceptance tests
-testacc: generate
+testacc: deps generate
 	@echo "WARN: Acceptance tests will take a long time to run and may cost money. Ctrl-C if you want to cancel."
 	PACKER_ACC=1 go test -v $(TEST) $(TESTARGS) -timeout=45m
 
-testrace:
+testrace: deps
 	go test -race $(TEST) $(TESTARGS) -timeout=15s
 
 # `go get -u` causes git to revert packer to the master branch. This causes all

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,31 @@
 TEST?=./...
+# Get the current full sha from git
+GITSHA:=$(shell git rev-parse HEAD)
+# Get the current local branch name from git (if we can, this may be blank)
+GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 
-default: test vet dev
+default: test dev
 
-bin:
+ci: deps test testrace
+
+release: updatedeps test bin
+
+bin: deps
+	@grep 'const VersionPrerelease = ""' version.go > /dev/null ; if [ $$? -ne 0 ]; then \
+		echo "ERROR: You must remove prerelease tags from version.go prior to release."; \
+		exit 1; \
+	fi
 	@sh -c "$(CURDIR)/scripts/build.sh"
 
-dev:
-	@TF_DEV=1 sh -c "$(CURDIR)/scripts/build.sh"
+deps:
+	go get -v -d ./...
+
+dev: deps
+	@grep 'const VersionPrerelease = ""' version.go > /dev/null ; if [ $$? -eq 0 ]; then \
+		echo "ERROR: You must add prerelease tags to version.go prior to making a dev build."; \
+		exit 1; \
+	fi
+	@PACKER_DEV=1 sh -c "$(CURDIR)/scripts/build.sh"
 
 # generate runs `go generate` to build the dynamically generated
 # source files.
@@ -14,23 +33,33 @@ generate:
 	go generate ./...
 
 test:
-	@echo "Running tests on:"; git symbolic-ref HEAD; git rev-parse HEAD
-	go test $(TEST) $(TESTARGS) -timeout=10s
-	@$(MAKE) vet
+	go test $(TEST) $(TESTARGS) -timeout=15s
+	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
+		go get golang.org/x/tools/cmd/vet; \
+	fi
+	@go vet $(TEST) ; if [ $$? -eq 1 ]; then \
+		echo "ERROR: Vet found problems in the code."; \
+		exit 1; \
+	fi
 
 # testacc runs acceptance tests
 testacc: generate
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package"; \
-		exit 1; \
-	fi
-	PACKER_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 45m
+	@echo "WARN: Acceptance tests will take a long time to run and may cost money. Ctrl-C if you want to cancel."
+	PACKER_ACC=1 go test -v $(TEST) $(TESTARGS) -timeout=45m
 
 testrace:
-	go test -race $(TEST) $(TESTARGS)
+	go test -race $(TEST) $(TESTARGS) -timeout=15s
 
+# `go get -u` causes git to revert packer to the master branch. This causes all
+# kinds of headaches. We record the git sha when make starts try to correct it
+# if we detect dift. DO NOT use `git checkout -f` for this because it will wipe
+# out your changes without asking.
 updatedeps:
-	@echo "Updating deps on:"; git symbolic-ref HEAD; git rev-parse HEAD
+	@echo "INFO: Currently on $(GITBRANCH) ($(GITSHA))"
+	@git diff-index --quiet HEAD ; if [ $$? -ne 0 ]; then \
+		echo "ERROR: Your git working tree has uncommitted changes. updatedeps will fail. Please stash or commit your changes first."; \
+		exit 1; \
+	fi
 	go get -u github.com/mitchellh/gox
 	go get -u golang.org/x/tools/cmd/stringer
 	go list ./... \
@@ -38,19 +67,14 @@ updatedeps:
 		| grep -v github.com/mitchellh/packer \
 		| grep -v '/internal/' \
 		| sort -u \
-		| xargs go get -f -u -v
-	@echo "Finished updating deps, now on:"; git symbolic-ref HEAD; git rev-parse HEAD
-
-vet:
-	@echo "Running go vet on:"; git symbolic-ref HEAD; git rev-parse HEAD
-	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
-		go get golang.org/x/tools/cmd/vet; \
+		| xargs go get -f -u -v -d ; if [ $$? -eq 0 ]; then \
+		echo "ERROR: go get failed. Your git branch may have changed; you were on $(GITBRANCH) ($(GITSHA))."; \
 	fi
-	@go vet ./... ; if [ $$? -eq 1 ]; then \
-		echo ""; \
-		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for reviewal."; \
+	@if [ "$(GITBRANCH)" != "" ]; then git checkout -q $(GITBRANCH); else git checkout -q $(GITSHA); fi
+	@if [ `git rev-parse HEAD` != "$(GITSHA)" ]; then \
+		echo "ERROR: git checkout has drifted and we weren't able to correct it. Was $(GITBRANCH) ($(GITSHA))"; \
 		exit 1; \
 	fi
+	@echo "INFO: Currently on $(GITBRANCH) ($(GITSHA))"
 
-.PHONY: bin default generate test testacc updatedeps vet
+.PHONY: bin checkversion ci default deps generate test testacc testrace updatedeps

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ GIT_COMMIT=$(git rev-parse HEAD)
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 
 # If its dev mode, only build for ourself
-if [ "${TF_DEV}x" != "x" ]; then
+if [ "${PACKER_DEV}x" != "x" ]; then
     XC_OS=${XC_OS:-$(go env GOOS)}
     XC_ARCH=${XC_ARCH:-$(go env GOARCH)}
 fi
@@ -27,7 +27,7 @@ XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
 
 # Install dependencies
 echo "==> Getting dependencies..."
-go get ./...
+go get -d ./...
 
 # Delete the old dir
 echo "==> Removing old directory..."


### PR DESCRIPTION
- Fix updatedeps reverting to master, which causes Travis CI to produce
  invalid results for pull-request builds. The makefile attempts to detect
  this change and checkout the correct branch / commit if it happens.
- Clean up the code style and failure messaging.
- Add / update proxy targets for common workflows: default, deps, ci,
  release