### PR TITLE
Salt provisioner updates

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -49,6 +49,9 @@ type Config struct {
 	// Don't exit packer if salt-call returns an error code
 	NoExitOnFailure bool `mapstructure:"no_exit_on_failure"`
 
+	// Set the logging level for the salt highstate run
+	LogLevel string `mapstructure:"log_level"`
+
 	// Command line args passed onto salt-call
 	CmdArgs string ""
 
@@ -121,6 +124,13 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if !p.config.NoExitOnFailure {
 		cmd_args.WriteString(" --retcode-passthrough")
+	}
+
+	if p.config.LogLevel == "" {
+		cmd_args.WriteString(" -l info")
+	} else {
+		cmd_args.WriteString(" -l ")
+		cmd_args.WriteString(p.config.LogLevel)
 	}
 
 	p.config.CmdArgs = cmd_args.String()
@@ -224,7 +234,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	}
 
 	ui.Message("Running highstate")
-	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("salt-call --local state.highstate -l info %s", p.config.CmdArgs))}
+	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("salt-call --local state.highstate %s", p.config.CmdArgs))}
 	if err = cmd.StartWithUi(comm, ui); err != nil || cmd.ExitStatus != 0 {
 		if err == nil {
 			err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus)

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -237,3 +237,27 @@ func TestProvisionerPrepare_NoExitOnFailure(t *testing.T) {
 		t.Fatal("--retcode-passthrough should not be set in CmdArgs")
 	}
 }
+
+func TestProvisionerPrepare_LogLevel(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "-l info") {
+		t.Fatal("-l info should be set in CmdArgs")
+	}
+
+	config["log_level"] = "debug"
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "-l debug") {
+		t.Fatal("-l debug should be set in CmdArgs")
+	}
+}

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +71,30 @@ func TestProvisionerPrepare_MinionConfig(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_MinionConfig_RemoteStateTree(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["minion_config"] = "/i/dont/exist/i/think"
+	config["remote_state_tree"] = "/i/dont/exist/remote_state_tree"
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("minion_config and remote_state_tree should cause error")
+	}
+}
+
+func TestProvisionerPrepare_MinionConfig_RemotePillarRoots(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["minion_config"] = "/i/dont/exist/i/think"
+	config["remote_pillar_roots"] = "/i/dont/exist/remote_pillar_roots"
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("minion_config and remote_pillar_roots should cause error")
+	}
+}
+
 func TestProvisionerPrepare_LocalStateTree(t *testing.T) {
 	var p Provisioner
 	config := testConfig()
@@ -126,5 +151,65 @@ func TestProvisionerSudo(t *testing.T) {
 	withoutSudo := p.sudo("echo hello")
 	if withoutSudo != "echo hello" {
 		t.Fatalf("sudo-less command not generated correctly")
+	}
+}
+
+func TestProvisionerPrepare_RemoteStateTree(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["remote_state_tree"] = "/remote_state_tree"
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "--file-root=/remote_state_tree") {
+		t.Fatal("--file-root should be set in CmdArgs")
+	}
+}
+
+func TestProvisionerPrepare_RemotePillarRoots(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["remote_pillar_roots"] = "/remote_pillar_roots"
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "--pillar-root=/remote_pillar_roots") {
+		t.Fatal("--pillar-root should be set in CmdArgs")
+	}
+}
+
+func TestProvisionerPrepare_RemoteStateTree_Default(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	// no minion_config, no remote_state_tree
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "--file-root=/srv/salt") {
+		t.Fatal("--file-root should be set in CmdArgs")
+	}
+}
+
+func TestProvisionerPrepare_RemotePillarRoots_Default(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	// no minion_config, no remote_pillar_roots
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "--pillar-root=/srv/pillar") {
+		t.Fatal("--pillar-root should be set in CmdArgs")
 	}
 }

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -213,3 +213,27 @@ func TestProvisionerPrepare_RemotePillarRoots_Default(t *testing.T) {
 		t.Fatal("--pillar-root should be set in CmdArgs")
 	}
 }
+
+func TestProvisionerPrepare_NoExitOnFailure(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "--retcode-passthrough") {
+		t.Fatal("--retcode-passthrough should be set in CmdArgs")
+	}
+
+	config["no_exit_on_failure"] = true
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if strings.Contains(p.config.CmdArgs, "--retcode-passthrough") {
+		t.Fatal("--retcode-passthrough should not be set in CmdArgs")
+	}
+}

--- a/website/source/docs/provisioners/salt-masterless.html.markdown
+++ b/website/source/docs/provisioners/salt-masterless.html.markdown
@@ -71,3 +71,5 @@ Optional:
 
 -   `no_exit_on_failure` (boolean) - Packer will exit if the Salt highstate command
     fails. Set this option to true to ignore Salt failures.
+
+-   `log_level` (string) - Set the logging level for the Salt highstate run.

--- a/website/source/docs/provisioners/salt-masterless.html.markdown
+++ b/website/source/docs/provisioners/salt-masterless.html.markdown
@@ -68,3 +68,6 @@ Optional:
 
 -   `temp_config_dir` (string) - Where your local state tree will be copied
     before moving to the `/srv/salt` directory. Default is `/tmp/salt`.
+
+-   `no_exit_on_failure` (boolean) - Packer will exit if the Salt highstate command
+    fails. Set this option to true to ignore Salt failures.

--- a/website/source/docs/provisioners/salt-masterless.html.markdown
+++ b/website/source/docs/provisioners/salt-masterless.html.markdown
@@ -43,11 +43,11 @@ Optional:
 
 -   `remote_pillar_roots` (string) - The path to your remote [pillar
     roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
-    default: `/srv/pillar`.
+    default: `/srv/pillar`. This option cannot be used with `minion_config`.
 
 -   `remote_state_tree` (string) - The path to your remote [state
     tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
-    default: `/srv/salt`.
+    default: `/srv/salt`. This option cannot be used with `minion_config`.
 
 -   `local_pillar_roots` (string) - The path to your local [pillar
     roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
@@ -59,7 +59,8 @@ Optional:
 
 -   `minion_config` (string) - The path to your local [minion config
     file](http://docs.saltstack.com/ref/configuration/minion.html). This will be
-    uploaded to the `/etc/salt` on the remote.
+    uploaded to the `/etc/salt` on the remote. This option overrides the
+    `remote_state_tree` or `remote_pillar_roots` options.
 
 -   `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt
     bootstrap](https://github.com/saltstack/salt-bootstrap) to install salt. Set


### PR DESCRIPTION
A few things in this p/r:

- Better path validation
- Dynamic construction of command line args to `highstate`, as discussed in #2652
- The changes I made to fix #2652 are not compatible with #2488 (which fixes #2486) - so I fixed that in a different way - comments please!
- Included another option to set the Salt logging level
- Added tests for most options