### PR TITLE
Fix and refactor block device mapping builder

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -30,35 +30,40 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 	var blockDevices []*ec2.BlockDeviceMapping
 
 	for _, blockDevice := range b {
-		ebsBlockDevice := &ec2.EbsBlockDevice{
-			VolumeType:          aws.String(blockDevice.VolumeType),
-			VolumeSize:          aws.Int64(blockDevice.VolumeSize),
-			DeleteOnTermination: aws.Bool(blockDevice.DeleteOnTermination),
-		}
-
-		// IOPS is only valid for SSD Volumes
-		if blockDevice.VolumeType != "" && blockDevice.VolumeType != "standard" && blockDevice.VolumeType != "gp2" {
-			ebsBlockDevice.Iops = aws.Int64(blockDevice.IOPS)
-		}
-
-		// You cannot specify Encrypted if you specify a Snapshot ID
-		if blockDevice.SnapshotId != "" {
-			ebsBlockDevice.SnapshotId = aws.String(blockDevice.SnapshotId)
-		} else if blockDevice.Encrypted {
-			ebsBlockDevice.Encrypted = aws.Bool(blockDevice.Encrypted)
-		}
-
-		mapping := &ec2.BlockDeviceMapping{
-			DeviceName:  aws.String(blockDevice.DeviceName),
-			VirtualName: aws.String(blockDevice.VirtualName),
-		}
-
-		if !strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
-			mapping.Ebs = ebsBlockDevice
+		mapping := &ec2.BlockDeviceMapping {
+			DeviceName: aws.String(blockDevice.DeviceName),
 		}
 
 		if blockDevice.NoDevice {
 			mapping.NoDevice = aws.String("")
+		} else if strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
+			mapping.VirtualName = aws.String(blockDevice.VirtualName)
+		} else {
+			ebsBlockDevice := &ec2.EbsBlockDevice{
+				DeleteOnTermination: aws.Bool(blockDevice.DeleteOnTermination),
+			}
+
+			if blockDevice.VolumeType != "" {
+				ebsBlockDevice.VolumeType = aws.String(blockDevice.VolumeType)
+			}
+
+			if blockDevice.VolumeSize > 0 {
+				ebsBlockDevice.VolumeSize = aws.Int64(blockDevice.VolumeSize)
+			}
+
+			// IOPS is only valid for io1 type
+			if blockDevice.VolumeType == "io1" {
+				ebsBlockDevice.Iops = aws.Int64(blockDevice.IOPS)
+			}
+
+			// You cannot specify Encrypted if you specify a Snapshot ID
+			if blockDevice.SnapshotId != "" {
+				ebsBlockDevice.SnapshotId = aws.String(blockDevice.SnapshotId)
+			} else if blockDevice.Encrypted {
+				ebsBlockDevice.Encrypted = aws.Bool(blockDevice.Encrypted)
+			}
+
+			mapping.Ebs = ebsBlockDevice
 		}
 
 		blockDevices = append(blockDevices, mapping)

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -24,7 +24,6 @@ func TestBlockDevice(t *testing.T) {
 
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
 				Ebs: &ec2.EbsBlockDevice{
 					SnapshotId:          aws.String("snap-1234"),
 					VolumeType:          aws.String("standard"),
@@ -41,9 +40,7 @@ func TestBlockDevice(t *testing.T) {
 
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
 				Ebs: &ec2.EbsBlockDevice{
-					VolumeType:          aws.String(""),
 					VolumeSize:          aws.Int64(8),
 					DeleteOnTermination: aws.Bool(false),
 				},
@@ -60,12 +57,30 @@ func TestBlockDevice(t *testing.T) {
 
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
 				Ebs: &ec2.EbsBlockDevice{
 					VolumeType:          aws.String("io1"),
 					VolumeSize:          aws.Int64(8),
 					DeleteOnTermination: aws.Bool(true),
 					Iops:                aws.Int64(1000),
+				},
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName:          "/dev/sdb",
+				VolumeType:          "gp2",
+				VolumeSize:          8,
+				DeleteOnTermination: true,
+				Encrypted:           true,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/sdb"),
+				Ebs: &ec2.EbsBlockDevice{
+					VolumeType:          aws.String("gp2"),
+					VolumeSize:          aws.Int64(8),
+					DeleteOnTermination: aws.Bool(true),
+					Encrypted:           aws.Bool(true),
 				},
 			},
 		},
@@ -78,6 +93,17 @@ func TestBlockDevice(t *testing.T) {
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
 				VirtualName: aws.String("ephemeral0"),
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName: "/dev/sdb",
+				NoDevice:   true,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/sdb"),
+				NoDevice:    aws.String(""),
 			},
 		},
 	}


### PR DESCRIPTION
Fix NoDevice not properly configured #2398.
Refactor the mapping builder to match BlockDeviceMapping from AWS SDK:

* If NoDevice is specified, include NoDevice only.
* If VirtualName starts with ephemeral, don't create Ebs (they are mutually
  exclusive anyway)
* Otherwise, assume Ebs and create it with the exact specified attributes by
  the user.

Change/add tests to reflect these changes.