### PR TITLE
Case sensitive VMX keys, SSD disk emulation

### DIFF
--- a/builder/vmware/common/vmx_test.go
+++ b/builder/vmware/common/vmx_test.go
@@ -6,10 +6,11 @@ func TestParseVMX(t *testing.T) {
 	contents := `
 .encoding = "UTF-8"
 config.version = "8"
+scsi0:0.virtualSSD = 1
 `
 
 	results := ParseVMX(contents)
-	if len(results) != 2 {
+	if len(results) != 3 {
 		t.Fatalf("not correct number of results: %d", len(results))
 	}
 
@@ -20,16 +21,22 @@ config.version = "8"
 	if results["config.version"] != "8" {
 		t.Errorf("invalid config.version: %s", results["config.version"])
 	}
+
+	if results["scsi0:0.virtualssd"] != "1" {
+		t.Errorf("invalid scsi0:0.virtualssd: %s", results["scsi0:0.virtualssd"])
+	}
 }
 
 func TestEncodeVMX(t *testing.T) {
 	contents := map[string]string{
-		".encoding":      "UTF-8",
-		"config.version": "8",
+		".encoding":          "UTF-8",
+		"config.version":     "8",
+		"scsi0:0.virtualssd": "1",
 	}
 
 	expected := `.encoding = "UTF-8"
 config.version = "8"
+scsi0:0.virtualSSD = 1
 `
 
 	result := EncodeVMX(contents)


### PR DESCRIPTION
Enabling support for a vmx config file key which is
case sensitive and must not be quoted: scsi0:0.virtualSSD = 1

Can be used in vmware builders vmx_data section:

    "vmx_data": {
        "scsi0:0.virtualssd": "1"
    }

Which gets written to vmx.file as

    scsi0:0.virtualSSD = 1

For now, we transform casing for keys ending with ".virtualssd"
to ".virtualSSD" since the parser destroys casing and this
cannot be changed without breaking backwards compatibility.

I've prepared a list of regular expressions and their correct
casing which can be extended, but these values are also treated
as if they are not to be quoted. If there are case-insensitive
keys which need quoting, those can be added in the future.