### PR TITLE
Change log file behaviour from create to append

### DIFF
--- a/log.go
+++ b/log.go
@@ -18,7 +18,7 @@ func logOutput() (logOutput io.Writer, err error) {
 
 		if logPath := os.Getenv(EnvLogFile); logPath != "" {
 			var err error
-			logOutput, err = os.Create(logPath)
+			logOutput, err = os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
So far packer creates (and truncates) the log file on each run. But its often desirable to have some global packer log file across different packer runs. Especially in the scenario when triggering packer via some kind of automatism. Therefore we need to change the log file open behaviour from open/truncate to append.