### PR TITLE
Rearranges vmware builders to avoid stomping VMX changes

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -318,6 +318,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 		},
 		&vmwcommon.StepCleanFiles{},
+		&vmwcommon.StepCompactDisk{
+			Skip: b.config.SkipCompaction,
+		},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
 			SkipFloppy: true,
@@ -325,9 +328,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&vmwcommon.StepCleanVMX{},
 		&StepUploadVMX{
 			RemoteType: b.config.RemoteType,
-		},
-		&vmwcommon.StepCompactDisk{
-			Skip: b.config.SkipCompaction,
 		},
 	}
 

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -108,14 +108,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 		},
 		&vmwcommon.StepCleanFiles{},
+		&vmwcommon.StepCompactDisk{
+			Skip: b.config.SkipCompaction,
+		},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
 			SkipFloppy: true,
 		},
 		&vmwcommon.StepCleanVMX{},
-		&vmwcommon.StepCompactDisk{
-			Skip: b.config.SkipCompaction,
-		},
 	}
 
 	// Run the steps.


### PR DESCRIPTION
Fixes #2708.  The disk compaction process was opening the VMX in write mode (for me, for unknown reasons).

![merry christmas, it's a dird](https://cloud.githubusercontent.com/assets/1100234/9689245/07c82e58-52f2-11e5-921e-e1eee4f39389.jpg)
