### PR TITLE
Tag EBS volumes with volume_tags in EBS builder

### DIFF
--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -28,6 +28,7 @@ type Config struct {
 	awscommon.AMIConfig    `mapstructure:",squash"`
 	awscommon.BlockDevices `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
+	VolumeRunTags          map[string]string `mapstructure:"run_volume_tags"`
 
 	ctx interpolate.Context
 }
@@ -117,6 +118,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
+		},
+		&stepTagEBSVolumes{
+			VolumeRunTags: b.config.VolumeRunTags,
 		},
 		&awscommon.StepGetPassword{
 			Debug:   b.config.PackerDebug,

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -1,0 +1,58 @@
+package ebs
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+type stepTagEBSVolumes struct {
+	VolumeRunTags map[string]string
+}
+
+func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	instance := state.Get("instance").(*ec2.Instance)
+	ui := state.Get("ui").(packer.Ui)
+
+	if len(s.VolumeRunTags) > 0 {
+		ui.Say("Tagging source EBS volumes...")
+
+		volumeIds := make([]*string, 0)
+		for _, v := range instance.BlockDeviceMappings {
+			if ebs := v.Ebs; ebs != nil {
+				volumeIds = append(volumeIds, ebs.VolumeId)
+			}
+		}
+
+		if len(volumeIds) == 0 {
+			return multistep.ActionContinue
+		}
+
+		tags := make([]*ec2.Tag, len(s.VolumeRunTags))
+		for key, value := range s.VolumeRunTags {
+			tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
+		}
+
+		_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{
+				instance.BlockDeviceMappings[0].Ebs.VolumeId,
+			},
+			Tags: tags,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepTagEBSVolumes) Cleanup(state multistep.StateBag) {
+	// No cleanup...
+}

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -134,6 +134,9 @@ builder.
 -   `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`.
+-   `volume_run_tags` (object of key/value strings) - Tags to apply to the volumes
+    that are *launched* to create the AMI. These tags are *not* applied to the
+    resulting AMI unless they're duplicated in `tags`.
 
 -   `security_group_id` (string) - The ID (*not* the name) of the security group
     to assign to the instance. By default this is not set and Packer will


### PR DESCRIPTION
This change allows specification of a new "volume_tags" array in the amazon-ebs builder in order to allow tagging of volumes used on the source instance. It is implemented as a new step which is skipped if there are no tags specified.