### PR TITLE
Fixes #2743: Change log messages for step_forward_ssh

### DIFF
--- a/builder/qemu/step_forward_ssh.go
+++ b/builder/qemu/step_forward_ssh.go
@@ -22,7 +22,7 @@ func (s *stepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
-	log.Printf("Looking for available SSH port between %d and %d", config.SSHHostPortMin, config.SSHHostPortMax)
+	log.Printf("Looking for available communicator (SSH, WinRM, etc) port between %d and %d", config.SSHHostPortMin, config.SSHHostPortMax)
 	var sshHostPort uint
 	var offset uint = 0
 
@@ -46,7 +46,7 @@ func (s *stepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 		}
 		offset++
 	}
-	ui.Say(fmt.Sprintf("Found port for SSH: %d.", sshHostPort))
+	ui.Say(fmt.Sprintf("Found port for communicator (SSH, WinRM, etc): %d.", sshHostPort))
 
 	// Save the port we're using so that future steps can use it
 	state.Put("sshHostPort", sshHostPort)

--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -36,9 +36,9 @@ func (s *StepExport) Run(state multistep.StateBag) multistep.StepAction {
 	// Clear out the Packer-created forwarding rule
 	if !s.SkipNatMapping {
 		ui.Message(fmt.Sprintf(
-			"Deleting forwarded port mapping for SSH (host port %d)",
+			"Deleting forwarded port mapping for the communicator (SSH, WinRM, etc) (host port %d)",
 			state.Get("sshHostPort")))
-		command := []string{"modifyvm", vmName, "--natpf1", "delete", "packerssh"}
+		command := []string{"modifyvm", vmName, "--natpf1", "delete", "packercomm"}
 		if err := driver.VBoxManage(command...); err != nil {
 			err := fmt.Errorf("Error deleting port forwarding rule: %s", err)
 			state.Put("error", err)

--- a/builder/virtualbox/common/step_forward_ssh.go
+++ b/builder/virtualbox/common/step_forward_ssh.go
@@ -35,7 +35,7 @@ func (s *StepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 	guestPort := s.CommConfig.Port()
 	sshHostPort := guestPort
 	if !s.SkipNatMapping {
-		log.Printf("Looking for available SSH port between %d and %d",
+		log.Printf("Looking for available communicator (SSH, WinRM, etc) port between %d and %d",
 			s.HostPortMin, s.HostPortMax)
 		offset := 0
 
@@ -61,11 +61,11 @@ func (s *StepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 		}
 
 		// Create a forwarded port mapping to the VM
-		ui.Say(fmt.Sprintf("Creating forwarded port mapping for SSH (host port %d)", sshHostPort))
+		ui.Say(fmt.Sprintf("Creating forwarded port mapping for communicator (SSH, WinRM, etc) (host port %d)", sshHostPort))
 		command := []string{
 			"modifyvm", vmName,
 			"--natpf1",
-			fmt.Sprintf("packerssh,tcp,127.0.0.1,%d,,%d", sshHostPort, guestPort),
+			fmt.Sprintf("packercomm,tcp,127.0.0.1,%d,,%d", sshHostPort, guestPort),
 		}
 		if err := driver.VBoxManage(command...); err != nil {
 			err := fmt.Errorf("Error creating port forwarding rule: %s", err)


### PR DESCRIPTION
Changed the log messages and changed the m name of the
VirtualBox builder NAT rule name from packerssh to
packercomm.