### PR TITLE
Remove deprecated parallels_tools_host_path and guest_os_distribution

### DIFF
--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -43,10 +43,6 @@ type Config struct {
 	SkipCompaction     bool     `mapstructure:"skip_compaction"`
 	VMName             string   `mapstructure:"vm_name"`
 
-	// Deprecated parameters
-	GuestOSDistribution    string `mapstructure:"guest_os_distribution"`
-	ParallelsToolsHostPath string `mapstructure:"parallels_tools_host_path"`
-
 	ctx interpolate.Context
 }
 
@@ -99,16 +95,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		b.config.GuestOSType = "other"
 	}
 
-	if b.config.GuestOSDistribution != "" {
-		// Compatibility with older templates:
-		// Use value of 'guest_os_distribution' if it is defined.
-		b.config.GuestOSType = b.config.GuestOSDistribution
-		warnings = append(warnings,
-			"A 'guest_os_distribution' has been completely replaced with 'guest_os_type'\n"+
-				"It is recommended to remove it and assign the previous value to 'guest_os_type'.\n"+
-				"Run it to see all available values: `prlctl create x -d list` ")
-	}
-
 	if len(b.config.HostInterfaces) == 0 {
 		b.config.HostInterfaces = []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7",
 			"en8", "en9", "ppp0", "ppp1", "ppp2"}
@@ -128,12 +114,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		warnings = append(warnings,
 			"A shutdown_command was not specified. Without a shutdown command, Packer\n"+
 				"will forcibly halt the virtual machine, which may result in data loss.")
-	}
-
-	if b.config.ParallelsToolsHostPath != "" {
-		warnings = append(warnings,
-			"A 'parallels_tools_host_path' has been deprecated and not in use anymore\n"+
-				"You can remove it from your Packer template.")
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/parallels/iso/builder_test.go
+++ b/builder/parallels/iso/builder_test.go
@@ -78,25 +78,6 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 	}
 }
 
-func TestBuilderPrepare_GuestOSType(t *testing.T) {
-	var b Builder
-	config := testConfig()
-	delete(config, "guest_os_distribution")
-
-	// Test deprecated parameter
-	config["guest_os_distribution"] = "bolgenos"
-	warns, err := b.Prepare(config)
-	if len(warns) == 0 {
-		t.Fatalf("should have warning")
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-	if b.config.GuestOSType != "bolgenos" {
-		t.Fatalf("bad: %s", b.config.GuestOSType)
-	}
-}
-
 func TestBuilderPrepare_HardDriveInterface(t *testing.T) {
 	var b Builder
 	config := testConfig()
@@ -150,21 +131,5 @@ func TestBuilderPrepare_InvalidKey(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("should have error")
-	}
-}
-
-func TestBuilderPrepare_ParallelsToolsHostPath(t *testing.T) {
-	var b Builder
-	config := testConfig()
-	delete(config, "parallels_tools_host_path")
-
-	// Test that it is deprecated
-	config["parallels_tools_host_path"] = "/path/to/iso"
-	warns, err := b.Prepare(config)
-	if len(warns) == 0 {
-		t.Fatalf("should have warning")
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
 	}
 }

--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -20,13 +20,14 @@ var FixerOrder []string
 
 func init() {
 	Fixers = map[string]Fixer{
-		"iso-md5":             new(FixerISOMD5),
-		"createtime":          new(FixerCreateTime),
-		"pp-vagrant-override": new(FixerVagrantPPOverride),
-		"virtualbox-gaattach": new(FixerVirtualBoxGAAttach),
-		"virtualbox-rename":   new(FixerVirtualBoxRename),
-		"vmware-rename":       new(FixerVMwareRename),
-		"parallels-headless":  new(FixerParallelsHeadless),
+		"iso-md5":                new(FixerISOMD5),
+		"createtime":             new(FixerCreateTime),
+		"pp-vagrant-override":    new(FixerVagrantPPOverride),
+		"virtualbox-gaattach":    new(FixerVirtualBoxGAAttach),
+		"virtualbox-rename":      new(FixerVirtualBoxRename),
+		"vmware-rename":          new(FixerVMwareRename),
+		"parallels-headless":     new(FixerParallelsHeadless),
+		"parallels-deprecations": new(FixerParallelsDeprecations),
 	}
 
 	FixerOrder = []string{
@@ -37,5 +38,6 @@ func init() {
 		"virtualbox-rename",
 		"vmware-rename",
 		"parallels-headless",
+		"parallels-deprecations",
 	}
 }

--- a/fix/fixer_parallels_deprections.go
+++ b/fix/fixer_parallels_deprections.go
@@ -1,0 +1,59 @@
+package fix
+
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
+// FixerParallelsDeprecations removes "parallels_tools_host_path" from a
+// template in a Parallels builder and changes "guest_os_distribution" to
+// "guest_os_type", possibly overwriting any existing "guest_os_type"
+type FixerParallelsDeprecations struct{}
+
+func (FixerParallelsDeprecations) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+	// The type we'll decode into; we only care about builders
+	type template struct {
+		Builders []map[string]interface{}
+	}
+
+	// Decode the input into our structure, if we can
+	var tpl template
+	if err := mapstructure.Decode(input, &tpl); err != nil {
+		return nil, err
+	}
+
+	for _, builder := range tpl.Builders {
+		builderTypeRaw, ok := builder["type"]
+		if !ok {
+			continue
+		}
+
+		builderType, ok := builderTypeRaw.(string)
+		if !ok {
+			continue
+		}
+
+		if builderType != "parallels-iso" && builderType != "parallels-pvm" {
+			continue
+		}
+
+		_, ok = builder["parallels_tools_host_path"]
+		if ok {
+			delete(builder, "parallels_tools_host_path")
+		}
+
+		guestOsDistribution, ok := builder["guest_os_distribution"]
+
+		if ok {
+			builder["guest_os_type"] = guestOsDistribution
+			delete(builder, "guest_os_distribution")
+		}
+	}
+
+	input["builders"] = tpl.Builders
+	return input, nil
+}
+
+func (FixerParallelsDeprecations) Synopsis() string {
+	return `Removes deprecated "parallels_tools_host_path" from Parallels builders
+	and changes "guest_os_distribution" to "guest_os_type".`
+}

--- a/fix/fixer_parallels_deprections_test.go
+++ b/fix/fixer_parallels_deprections_test.go
@@ -1,0 +1,129 @@
+package fix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixerParallelsDeprecations(t *testing.T) {
+	var _ Fixer = new(FixerParallelsDeprecations)
+}
+
+func TestFixerParallelsDeprecations_Fix_parallels_tools_guest_path(t *testing.T) {
+	cases := []struct {
+		Input    map[string]interface{}
+		Expected map[string]interface{}
+	}{
+		// No parallels_tools_host_path field
+		{
+			Input: map[string]interface{}{
+				"type": "parallels-iso",
+			},
+
+			Expected: map[string]interface{}{
+				"type": "parallels-iso",
+			},
+		},
+
+		// parallels_tools_host_path field
+		{
+			Input: map[string]interface{}{
+				"type": "parallels-iso",
+				"parallels_tools_host_path": "/Path...",
+			},
+
+			Expected: map[string]interface{}{
+				"type": "parallels-iso",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var f FixerParallelsDeprecations
+
+		input := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Input},
+		}
+
+		expected := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Expected},
+		}
+
+		output, err := f.Fix(input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(output, expected) {
+			t.Fatalf("unexpected: %#v\nexpected: %#v\n", output, expected)
+		}
+	}
+}
+
+func TestFixerParallelsDeprecations_Fix_guest_os_distribution(t *testing.T) {
+	cases := []struct {
+		Input    map[string]interface{}
+		Expected map[string]interface{}
+	}{
+		// No guest_os_distribution field
+		{
+			Input: map[string]interface{}{
+				"type":          "parallels-iso",
+				"guest_os_type": "ubuntu",
+			},
+
+			Expected: map[string]interface{}{
+				"type":          "parallels-iso",
+				"guest_os_type": "ubuntu",
+			},
+		},
+
+		// guest_os_distribution and guest_os_type field
+		{
+			Input: map[string]interface{}{
+				"type":                  "parallels-iso",
+				"guest_os_type":         "linux",
+				"guest_os_distribution": "ubuntu",
+			},
+
+			Expected: map[string]interface{}{
+				"type":          "parallels-iso",
+				"guest_os_type": "ubuntu",
+			},
+		},
+
+		// guest_os_distribution but no guest_os_type field
+		{
+			Input: map[string]interface{}{
+				"type":                  "parallels-iso",
+				"guest_os_distribution": "ubuntu",
+			},
+
+			Expected: map[string]interface{}{
+				"type":          "parallels-iso",
+				"guest_os_type": "ubuntu",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var f FixerParallelsDeprecations
+
+		input := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Input},
+		}
+
+		expected := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Expected},
+		}
+
+		output, err := f.Fix(input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(output, expected) {
+			t.Fatalf("unexpected: %#v\nexpected: %#v\n", output, expected)
+		}
+	}
+}


### PR DESCRIPTION
Remove deprecated and unused option ```parallels_tools_host_path```.
Remove deprecated ```guest_os_distribution``` changing it to ```guest_os_type```.