### PR TITLE
Fixes for windows-restart provisioner tests and google cloud engine compile

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -219,7 +219,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 	for k, v := range c.Metadata {
 		metadata = append(metadata, &compute.MetadataItems{
 			Key:   k,
-			Value: v,
+			Value: &v,
 		})
 	}
 

--- a/provisioner/windows-restart/provisioner_test.go
+++ b/provisioner/windows-restart/provisioner_test.go
@@ -365,3 +365,38 @@ func TestProvision_Cancel(t *testing.T) {
 	}
 	testDone <- true
 }
+
+func TestProvision_CancelBeforeStart(t *testing.T) {
+	config := testConfig()
+
+	// Defaults provided by Packer
+	ui := testUi()
+	p := new(Provisioner)
+
+	var err error
+
+	comm := new(packer.MockCommunicator)
+	p.Prepare(config)
+	waitDone := make(chan bool)
+	cancelled := make(chan bool)
+
+	// Create two go routines to provision and cancel in parallel
+	// Provision will block until cancel happens
+	go func() {
+		<-cancelled // wait before provisioning
+		err = p.Provision(ui, comm)
+		waitDone <- true
+	}()
+
+	go func() {
+		// wait before canceling
+		cancelled <- true
+		p.Cancel()
+	}()
+	<-waitDone
+
+	// Expect interupt error
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}


### PR DESCRIPTION
Disclaimer: I'm just getting familiar with the codebase, so my thinking may be off.

Found out these issues when I've tried to compile it on my machine (Mac OS). Build failed without fixing the google cloud builder, but it may have been something specific to the environment, although I followed  the instructions for setting up.

The windows-restart provisioner tests were failing intermittently only when the full build was run. After adding little more synchronization, they seem stable now. However, realized that there is a corner case of canceling the provisioner before even starting, which I'm not sure is really important, but the tests were hitting it, so I've decided to fix this as well if you think is worth it.