### PR TITLE
Fixed GCE builder after dependency change.

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -219,7 +219,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 	for k, v := range c.Metadata {
 		metadata = append(metadata, &compute.MetadataItems{
 			Key:   k,
-			Value: v,
+			Value: &v,
 		})
 	}
 


### PR DESCRIPTION
See
https://github.com/google/google-api-go-client/commit/4af91da60108e4a6d2547bb4adce3f611c4d1f20