### PR TITLE
Fix AMI creation - replace not allowed character , and add allowed .

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -19,8 +19,10 @@ func isalphanumeric(b byte) bool {
 }
 
 // Clean up AMI name by replacing invalid characters with "-"
+// For allowed characters see docs for Name parameter
+// at http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateImage.html
 func templateCleanAMIName(s string) string {
-	allowed := []byte{'(', ')', ',', '/', '-', '_', ' '}
+	allowed := []byte{'(', ')', '[', ']', ' ', '.', '/', '-', '\'', '@', '_'}
 	b := []byte(s)
 	newb := make([]byte, len(b))
 	for i, c := range b {

--- a/builder/amazon/common/template_funcs_test.go
+++ b/builder/amazon/common/template_funcs_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestAMITemplatePrepare_clean(t *testing.T) {
-	origName := "AMZamz09(),/-_:&^ $%"
-	expected := "AMZamz09(),/-_--- --"
+	origName := "AMZamz09()./-_:&^ $%[]#'@"
+	expected := "AMZamz09()./-_--- --[]-'@"
 
 	name := templateCleanAMIName(origName)
 


### PR DESCRIPTION
Fixes error:
```
Error creating AMI: InvalidAMIName.Malformed: AMI names must be between 3 and 128 characters long, and may contain letters, numbers, '(', ')', '.', '-', '/' and '_'
	status code: 400, request id: []
```