### PR TITLE
Make ssh_host_port_max an inclusive bound to agree with documentation

### DIFF
--- a/builder/qemu/step_forward_ssh.go
+++ b/builder/qemu/step_forward_ssh.go
@@ -24,20 +24,12 @@ func (s *stepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 
 	log.Printf("Looking for available SSH port between %d and %d", config.SSHHostPortMin, config.SSHHostPortMax)
 	var sshHostPort uint
-	var offset uint = 0
 
-	portRange := int(config.SSHHostPortMax - config.SSHHostPortMin)
-	if portRange > 0 {
-		// Have to check if > 0 to avoid a panic
-		offset = uint(rand.Intn(portRange))
-	}
+	portRange := config.SSHHostPortMax - config.SSHHostPortMin + 1
+	offset := uint(rand.Intn(int(portRange)))
 
 	for {
 		sshHostPort = offset + config.SSHHostPortMin
-		if sshHostPort >= config.SSHHostPortMax {
-			offset = 0
-			sshHostPort = config.SSHHostPortMin
-		}
 		log.Printf("Trying port: %d", sshHostPort)
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", sshHostPort))
 		if err == nil {
@@ -45,6 +37,9 @@ func (s *stepForwardSSH) Run(state multistep.StateBag) multistep.StepAction {
 			break
 		}
 		offset++
+		if offset == portRange {
+			offset = 0
+		}
 	}
 	ui.Say(fmt.Sprintf("Found port for SSH: %d.", sshHostPort))
 


### PR DESCRIPTION
Documentation says that `ssh_host_port_max` is a maximum port to use for the SSH port, but previously this port was skipped, unless `ssh_host_port_max` was equal to `ssh_host_port_min`.