### PR TITLE
vmware/iso: force iso extension for downloads

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -260,6 +260,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Description:  "ISO",
 			ResultKey:    "iso_path",
 			Url:          b.config.ISOUrls,
+			Extension:    "iso",
 		},
 		&vmwcommon.StepOutputDir{
 			Force: b.config.PackerForce,


### PR DESCRIPTION

Add extension to VMware ISO builder to bring in sync with Virtualbox ISO builder.  This should prevent duplicate ISO download for multi-builder builds

This should resolve issue https://github.com/mitchellh/packer/issues/2695

Extension for Virtualbox was introduced with https://github.com/mitchellh/packer/commit/9ea34d4ea85d469272a12dc0ab6fe6837128e382