### PR TITLE
Add suggestion to AWS Instance builder error message

### DIFF
--- a/builder/amazon/instance/step_bundle_volume.go
+++ b/builder/amazon/instance/step_bundle_volume.go
@@ -67,7 +67,9 @@ func (s *StepBundleVolume) Run(state multistep.StateBag) multistep.StepAction {
 	if cmd.ExitStatus != 0 {
 		state.Put("error", fmt.Errorf(
 			"Volume bundling failed. Please see the output above for more\n"+
-				"details on what went wrong."))
+				"details on what went wrong.\n\n"+
+				"One common cause for this error is ec2-bundle-vol not being\n"+
+				"available on the target instance."))
 		ui.Error(state.Get("error").(error).Error())
 		return multistep.ActionHalt
 	}


### PR DESCRIPTION
A common cause of the failure of the bundle volume step is missing the ec2-bundle-vol command on the target instance (as observed in the #hashicorp channel on the HangOps Slack!).

This commit adds a note about this to the error message produced as Packer output if the bundling step fails (it is already in the documentation).