### PR TITLE
Make DigitalOcean artifact ID match AWS format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ default: test dev
 
 ci: deps test
 
-release: updatedeps test bin
+release: updatedeps test releasebin
 
 bin: deps
+	@sh -c "$(CURDIR)/scripts/build.sh"
+
+releasebin: deps
 	@grep 'const VersionPrerelease = ""' version.go > /dev/null ; if [ $$? -ne 0 ]; then \
 		echo "ERROR: You must remove prerelease tags from version.go prior to release."; \
 		exit 1; \
@@ -77,4 +80,4 @@ updatedeps:
 	fi
 	@echo "INFO: Currently on $(GITBRANCH) ($(GITSHA))"
 
-.PHONY: bin checkversion ci default deps generate test testacc testrace updatedeps
+.PHONY: bin checkversion ci default deps generate releasebin test testacc testrace updatedeps

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ci: deps test
 release: updatedeps test releasebin
 
 bin: deps
+	@echo "WARN: `make bin` is for debug / test builds only. Use `make release` for release builds."
 	@sh -c "$(CURDIR)/scripts/build.sh"
 
 releasebin: deps

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ci: deps test
 release: updatedeps test releasebin
 
 bin: deps
-	@echo "WARN: `make bin` is for debug / test builds only. Use `make release` for release builds."
+	@echo "WARN: 'make bin' is for debug / test builds only. Use 'make release' for release builds."
 	@sh -c "$(CURDIR)/scripts/build.sh"
 
 releasebin: deps

--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -56,7 +56,7 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 		VolumeType:       rootDevice.Ebs.VolumeType,
 		Iops:             rootDevice.Ebs.Iops,
 	}
-	log.Printf("Create args: %s", createVolume)
+	log.Printf("Create args: %+v", createVolume)
 
 	createVolumeResp, err := ec2conn.CreateVolume(createVolume)
 	if err != nil {

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -91,12 +91,12 @@ func TestBlockDevice(t *testing.T) {
 		expected := []*ec2.BlockDeviceMapping{tc.Result}
 		got := blockDevices.BuildAMIDevices()
 		if !reflect.DeepEqual(expected, got) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s",
+			t.Fatalf("Bad block device, \nexpected: %#v\n\ngot: %#v",
 				expected, got)
 		}
 
 		if !reflect.DeepEqual(expected, blockDevices.BuildLaunchDevices()) {
-			t.Fatalf("Bad block device, \nexpected: %s\n\ngot: %s",
+			t.Fatalf("Bad block device, \nexpected: %#v\n\ngot: %#v",
 				expected,
 				blockDevices.BuildLaunchDevices())
 		}

--- a/builder/digitalocean/artifact.go
+++ b/builder/digitalocean/artifact.go
@@ -32,7 +32,7 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return strconv.FormatUint(uint64(a.snapshotId), 10)
+	return fmt.Sprintf("%s:%s", a.regionName, strconv.FormatUint(uint64(a.snapshotId), 10))
 }
 
 func (a *Artifact) String() string {

--- a/builder/digitalocean/artifact_test.go
+++ b/builder/digitalocean/artifact_test.go
@@ -16,7 +16,7 @@ func TestArtifact_Impl(t *testing.T) {
 
 func TestArtifactId(t *testing.T) {
 	a := &Artifact{"packer-foobar", 42, "San Francisco", nil}
-	expected := "42"
+	expected := "San Francisco:42"
 
 	if a.Id() != expected {
 		t.Fatalf("artifact ID should match: %v", expected)

--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -180,20 +180,20 @@ func TestLargeDownload(t *testing.T) {
 	// bigcake should be 104857600 bytes
 	cupcake, err := os.Stat("cupcake")
 	if err != nil {
-		t.Fatalf("Unable to stat cupcake file")
+		t.Fatalf("Unable to stat cupcake file: %s", err)
 	}
 	cupcakeExpected := int64(2097152)
 	if cupcake.Size() != cupcakeExpected {
-		t.Errorf("Expected cupcake to be %s bytes; found %s", cupcakeExpected, cupcake.Size())
+		t.Errorf("Expected cupcake to be %d bytes; found %d", cupcakeExpected, cupcake.Size())
 	}
 
 	bigcake, err := os.Stat("bigcake")
 	if err != nil {
-		t.Fatalf("Unable to stat bigcake file")
+		t.Fatalf("Unable to stat bigcake file: %s", err)
 	}
 	bigcakeExpected := int64(104857600)
 	if bigcake.Size() != bigcakeExpected {
-		t.Errorf("Expected bigcake to be %s bytes; found %s", bigcakeExpected, bigcake.Size())
+		t.Errorf("Expected bigcake to be %d bytes; found %d", bigcakeExpected, bigcake.Size())
 	}
 
 	// TODO if we can, calculate a sha inside the container and compare to the

--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 // StepTempDir creates a temporary directory that we use in order to
@@ -18,7 +19,19 @@ func (s *StepTempDir) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating a temporary directory for sharing data...")
-	td, err := ioutil.TempDir("", "packer-docker")
+	// Create the docker temp files in the current working directory
+	// to work around an issue when running with docker-machine
+	// using vm's needing access to shared folder content. This assumes
+	// the current working directory is mapped as a share folder.
+	// Allow TMPDIR to override this location.
+	path := ""
+	if tmpdir := os.Getenv("TMPDIR"); tmpdir == "" {
+		abspath, err := filepath.Abs(".")
+		if err == nil {
+			path = abspath
+		}
+	}
+	td, err := ioutil.TempDir(path, "packer-docker")
 	if err != nil {
 		err := fmt.Errorf("Error making temp dir: %s", err)
 		state.Put("error", err)

--- a/builder/docker/step_temp_dir_test.go
+++ b/builder/docker/step_temp_dir_test.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"github.com/mitchellh/multistep"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -10,7 +12,7 @@ func TestStepTempDir_impl(t *testing.T) {
 	var _ multistep.Step = new(StepTempDir)
 }
 
-func TestStepTempDir(t *testing.T) {
+func testStepTempDir_impl(t *testing.T) string {
 	state := testState(t)
 	step := new(StepTempDir)
 	defer step.Cleanup(state)
@@ -40,5 +42,37 @@ func TestStepTempDir(t *testing.T) {
 	step.Cleanup(state)
 	if _, err := os.Stat(dir); err == nil {
 		t.Fatalf("dir should be gone")
+	}
+
+	return dir
+}
+
+func TestStepTempDir(t *testing.T) {
+	testStepTempDir_impl(t)
+}
+
+func TestStepTempDir_notmpdir(t *testing.T) {
+	tempenv := "TMPDIR"
+	if runtime.GOOS == "windows" {
+		tempenv = "TMP"
+	}
+	// Verify empty TMPDIR maps to current working directory
+	oldenv := os.Getenv(tempenv)
+	os.Setenv(tempenv, "")
+	defer os.Setenv(tempenv, oldenv)
+
+	dir1 := testStepTempDir_impl(t)
+
+	// Now set TMPDIR to current directory
+	abspath, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("could not get current working directory")
+	}
+	os.Setenv(tempenv, abspath)
+
+	dir2 := testStepTempDir_impl(t)
+
+	if filepath.Dir(dir1) != filepath.Dir(dir2) {
+		t.Fatalf("temp base directories do not match: %s %s", filepath.Dir(dir1), filepath.Dir(dir2))
 	}
 }

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -131,9 +131,8 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c.stateTimeout = stateTimeout
 
 	if c.AccountFile != "" {
-		if err := loadJSON(&c.account, c.AccountFile); err != nil {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Failed parsing account file: %s", err))
+		if err := processAccountFile(&c.account, c.AccountFile); err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
 		}
 	}
 

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/going/toolkit/xmlpath"
+	"gopkg.in/xmlpath.v2"
 )
 
 type Parallels9Driver struct {

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -54,9 +54,10 @@ var netDevice = map[string]bool{
 }
 
 var diskInterface = map[string]bool{
-	"ide":    true,
-	"scsi":   true,
-	"virtio": true,
+	"ide":         true,
+	"scsi":        true,
+	"virtio":      true,
+	"virtio-scsi": true,
 }
 
 var diskCache = map[string]bool{

--- a/builder/qemu/driver.go
+++ b/builder/qemu/driver.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/mitchellh/multistep"
 	"io"
 	"log"
 	"os/exec"
@@ -14,6 +13,8 @@ import (
 	"syscall"
 	"time"
 	"unicode"
+
+	"github.com/mitchellh/multistep"
 )
 
 type DriverCancelCallback func(state multistep.StateBag) bool
@@ -188,8 +189,8 @@ func (d *QemuDriver) Version() (string, error) {
 
 	versionOutput := strings.TrimSpace(stdout.String())
 	log.Printf("Qemu --version output: %s", versionOutput)
-	versionRe := regexp.MustCompile("qemu-kvm-[0-9]\\.[0-9]")
-	matches := versionRe.Split(versionOutput, 2)
+	versionRe := regexp.MustCompile("[0-9]\\.[0-9]\\.[0-9]")
+	matches := versionRe.FindStringSubmatch(versionOutput)
 	if len(matches) == 0 {
 		return "", fmt.Errorf("No version found: %s", versionOutput)
 	}

--- a/builder/qemu/driver.go
+++ b/builder/qemu/driver.go
@@ -189,7 +189,7 @@ func (d *QemuDriver) Version() (string, error) {
 
 	versionOutput := strings.TrimSpace(stdout.String())
 	log.Printf("Qemu --version output: %s", versionOutput)
-	versionRe := regexp.MustCompile("[0-9]\\.[0-9]\\.[0-9]")
+	versionRe := regexp.MustCompile("[\\.[0-9]+]*")
 	matches := versionRe.FindStringSubmatch(versionOutput)
 	if len(matches) == 0 {
 		return "", fmt.Errorf("No version found: %s", versionOutput)

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -69,30 +69,51 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	vmName := config.VMName
 	imgPath := filepath.Join(config.OutputDir, vmName)
 
-	defaultArgs := make(map[string]string)
+	defaultArgs := make(map[string]interface{})
+	var deviceArgs []string
+	var driveArgs []string
+
+	defaultArgs["-name"] = vmName
+	defaultArgs["-machine"] = fmt.Sprintf("type=%s", config.MachineType)
+	defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:%d", sshHostPort, config.Comm.Port())
+
+	qemuVersion, err := driver.Version()
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(qemuVersion, ".")
+	qemuMajor, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	if qemuMajor >= 2 {
+		if config.DiskInterface == "virtio-scsi" {
+			deviceArgs = append(deviceArgs, "virtio-scsi-pci,id=scsi0", "scsi-hd,bus=scsi0.0,drive=drive0")
+			driveArgs = append(driveArgs, fmt.Sprintf("if=none,file=%s,id=drive0,cache=%s,discard=%s", imgPath, config.DiskCache, config.DiskDiscard))
+		} else {
+			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard))
+		}
+	} else {
+		defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s", imgPath, config.DiskInterface, config.DiskCache)
+	}
+	deviceArgs = append(deviceArgs, fmt.Sprintf("%s,netdev=user.0", config.NetDevice))
 
 	if config.Headless == true {
 		ui.Message("WARNING: The VM will be started in headless mode, as configured.\n" +
 			"In headless mode, errors during the boot sequence or OS setup\n" +
 			"won't be easily visible. Use at your own discretion.")
 	} else {
-		defaultArgs["-display"] = "sdl"
+		if qemuMajor >= 2 {
+			defaultArgs["-display"] = "sdl"
+		} else {
+			ui.Message("WARNING: The version of qemu  on your host doesn't support display mode.\n" +
+				"The display parameter will be ignored.")
+		}
 	}
 
-	defaultArgs["-name"] = vmName
-	defaultArgs["-machine"] = fmt.Sprintf("type=%s", config.MachineType)
-	defaultArgs["-netdev"] = fmt.Sprintf(
-		"user,id=user.0,hostfwd=tcp::%v-:%d", sshHostPort, config.Comm.Port())
-	defaultArgs["-device"] = fmt.Sprintf("%s,netdev=user.0", config.NetDevice)
-	qemuVersion, err := driver.Version()
-	if err == nil {
-		parts := strings.Split(qemuVersion, ".")
-		if strconv.Atoi(parts[0]) >= 2 {
-			defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard)
-		}
-	} else {
-		defaultArgs["-drive"] = fmt.Sprintf("file=%s,if=%s,cache=%s", imgPath, config.DiskInterface, config.DiskCache)
-	}
+	defaultArgs["-device"] = deviceArgs
+	defaultArgs["-drive"] = driveArgs
+
 	if !config.DiskImage {
 		defaultArgs["-cdrom"] = isoPath
 	}
@@ -102,7 +123,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 
 	// Append the accelerator to the machine type if it is specified
 	if config.Accelerator != "none" {
-		defaultArgs["-machine"] += fmt.Sprintf(",accel=%s", config.Accelerator)
+		defaultArgs["-machine"] = fmt.Sprintf("%s,accel=%s", defaultArgs["-machine"], config.Accelerator)
 	} else {
 		ui.Message("WARNING: The VM will be started with no hardware acceleration.\n" +
 			"The installation may take considerably longer to finish.\n")
@@ -152,7 +173,12 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	for key := range defaultArgs {
 		if _, ok := inArgs[key]; !ok {
 			arg := make([]string, 1)
-			arg[0] = defaultArgs[key]
+			switch defaultArgs[key].(type) {
+			case string:
+				arg[0] = defaultArgs[key].(string)
+			case []string:
+				arg = defaultArgs[key].([]string)
+			}
 			inArgs[key] = arg
 		}
 	}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -4,9 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/mitchellh/multistep"
 	vboxcommon "github.com/mitchellh/packer/builder/virtualbox/common"
@@ -211,9 +209,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 }
 
 func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
-	// Seed the random number generator
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	// Create the driver that we'll use to communicate with VirtualBox
 	driver, err := vboxcommon.NewDriver()
 	if err != nil {

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
-	"time"
 
 	"github.com/mitchellh/multistep"
 	vboxcommon "github.com/mitchellh/packer/builder/virtualbox/common"
@@ -35,9 +33,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 // Run executes a Packer build and returns a packer.Artifact representing
 // a VirtualBox appliance.
 func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
-	// Seed the random number generator
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	// Create the driver that we'll use to communicate with VirtualBox
 	driver, err := vboxcommon.NewDriver()
 	if err != nil {

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -245,9 +244,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put("driver", driver)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-
-	// Seed the random number generator
-	rand.Seed(time.Now().UTC().UnixNano())
 
 	steps := []multistep.Step{
 		&vmwcommon.StepPrepareTools{

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -65,6 +65,10 @@ func (c *Config) Prepare(ctx *interpolate.Context) []error {
 		if es := c.prepareWinRM(ctx); len(es) > 0 {
 			errs = append(errs, es...)
 		}
+	case "none":
+		break
+	default:
+		return []error{fmt.Errorf("Communicator type %s is invalid", c.Type)}
 	}
 
 	return errs

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -65,7 +65,7 @@ func (c *Config) Prepare(ctx *interpolate.Context) []error {
 		if es := c.prepareWinRM(ctx); len(es) > 0 {
 			errs = append(errs, es...)
 		}
-	case "none":
+	case "docker", "none":
 		break
 	default:
 		return []error{fmt.Errorf("Communicator type %s is invalid", c.Type)}

--- a/helper/communicator/config_test.go
+++ b/helper/communicator/config_test.go
@@ -30,6 +30,23 @@ func TestConfig_none(t *testing.T) {
 	}
 }
 
+func TestConfig_badtype(t *testing.T) {
+	c := &Config{Type: "foo"}
+	if err := c.Prepare(testContext(t)); len(err) != 1 {
+		t.Fatalf("bad: %#v", err)
+	}
+}
+
+func TestConfig_winrm(t *testing.T) {
+	c := &Config{
+		Type:      "winrm",
+		WinRMUser: "admin",
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+}
+
 func testContext(t *testing.T) *interpolate.Context {
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/packer/command"
@@ -291,4 +293,9 @@ func copyOutput(r io.Reader, doneCh chan<- struct{}) {
 	}()
 
 	wg.Wait()
+}
+
+func init() {
+	// Seed the random number generator
+	rand.Seed(time.Now().UTC().UnixNano())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
 )
@@ -31,5 +32,11 @@ func TestExtractMachineReadable(t *testing.T) {
 
 	if !mr {
 		t.Fatal("should be mr")
+	}
+}
+
+func TestRandom(t *testing.T) {
+	if rand.Intn(9999999) == 8498210 {
+		t.Fatal("math.rand is not seeded properly")
 	}
 }

--- a/packer/plugin/server.go
+++ b/packer/plugin/server.go
@@ -13,12 +13,14 @@ import (
 	packrpc "github.com/mitchellh/packer/packer/rpc"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net"
 	"os"
 	"os/signal"
 	"runtime"
 	"strconv"
 	"sync/atomic"
+	"time"
 )
 
 // This is a count of the number of interrupts the process has received.
@@ -137,4 +139,9 @@ func serverListener_unix() (net.Listener, error) {
 	}
 
 	return net.Listen("unix", path)
+}
+
+func init() {
+	// Seed the random number generator
+	rand.Seed(time.Now().UTC().UnixNano())
 }

--- a/packer/plugin/server_test.go
+++ b/packer/plugin/server_test.go
@@ -1,0 +1,12 @@
+package plugin
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestPluginServerRandom(t *testing.T) {
+	if rand.Intn(9999999) == 8498210 {
+		t.Fatal("math.rand is not seeded properly")
+	}
+}

--- a/packer/rpc/client.go
+++ b/packer/rpc/client.go
@@ -1,11 +1,12 @@
 package rpc
 
 import (
-	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/mitchellh/packer/packer"
 	"io"
 	"log"
 	"net/rpc"
+
+	"github.com/mitchellh/packer/packer"
+	"github.com/ugorji/go/codec"
 )
 
 // Client is the client end that communicates with a Packer RPC server.

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -140,7 +140,6 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 	streamId := c.mux.NextId()
 
 	waitServer := make(chan bool)
-
 	go func() {
 		serveSingleCopy("downloadWriter", c.mux, streamId, w, nil)
 		waitServer <- true
@@ -151,8 +150,10 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 		WriterStreamId: streamId,
 	}
 
+	// Start sending data to the RPC server
 	err = c.client.Call("Communicator.Download", &args, new(interface{}))
 
+	// Wait for the RPC server to finish receiving the data before we return
 	<-waitServer
 
 	return

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -139,10 +139,10 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 	// Serve a single connection and a single copy
 	streamId := c.mux.NextId()
 
-	waitServer := make(chan bool)
+	waitServer := make(chan struct{})
 	go func() {
 		serveSingleCopy("downloadWriter", c.mux, streamId, w, nil)
-		waitServer <- true
+		close(waitServer)
 	}()
 
 	args := CommunicatorDownloadArgs{

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -6,8 +6,8 @@ import (
 	"net/rpc"
 	"sync/atomic"
 
-	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/mitchellh/packer/packer"
+	"github.com/ugorji/go/codec"
 )
 
 var endpointId uint64

--- a/provisioner/windows-restart/provisioner_test.go
+++ b/provisioner/windows-restart/provisioner_test.go
@@ -193,12 +193,14 @@ func TestProvision_waitForRestartTimeout(t *testing.T) {
 	p.Prepare(config)
 	waitForCommunicatorOld := waitForCommunicator
 	waitDone := make(chan bool)
+	waitContinue := make(chan bool)
 
 	// Block until cancel comes through
 	waitForCommunicator = func(p *Provisioner) error {
 		for {
 			select {
 			case <-waitDone:
+				waitContinue <- true
 			}
 		}
 	}
@@ -207,7 +209,7 @@ func TestProvision_waitForRestartTimeout(t *testing.T) {
 		err = p.Provision(ui, comm)
 		waitDone <- true
 	}()
-	<-waitDone
+	<-waitContinue
 
 	if err == nil {
 		t.Fatal("should not have error")

--- a/scripts/website_push.sh
+++ b/scripts/website_push.sh
@@ -1,12 +1,40 @@
 #!/bin/bash
 
+# Set the tmpdir
+if [ -z "$TMPDIR" ]; then
+  TMPDIR="/tmp"
+fi
+
+# Create a temporary build dir and make sure we clean it up. For
+# debugging, comment out the trap line.
+DEPLOY=`mktemp -d $TMPDIR/packer-www-XXXXXX`
+trap "rm -rf $DEPLOY" INT TERM EXIT
+
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
-# Change into that directory
-cd $DIR
+# Copy into tmpdir
+shopt -s dotglob
+cp -r $DIR/website/* $DEPLOY/
 
-# Push the subtree (force)
-git push heroku `git subtree split --prefix website master`:master --force
+# Change into that directory
+pushd $DEPLOY &>/dev/null
+
+# Ignore some stuff
+touch .gitignore
+echo ".sass-cache" >> .gitignore
+echo "build" >> .gitignore
+echo "vendor" >> .gitignore
+
+# Add everything
+git init -q .
+git add .
+git commit -q -m "Deploy by $USER"
+
+git remote add heroku git@heroku.com:packer-www.git
+git push -f heroku master
+
+# Go back to our root
+popd &>/dev/null

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -93,14 +93,14 @@ func funcGenEnv(ctx *Context) interface{} {
 func funcGenIsotime(ctx *Context) interface{} {
 	return func(format ...string) (string, error) {
 		if len(format) == 0 {
-			return time.Now().UTC().Format(time.RFC3339), nil
+			return InitTime.Format(time.RFC3339), nil
 		}
 
 		if len(format) > 1 {
 			return "", fmt.Errorf("too many values, 1 needed: %v", format)
 		}
 
-		return time.Now().UTC().Format(format[0]), nil
+		return InitTime.Format(format[0]), nil
 	}
 }
 

--- a/website/source/docs/builders/googlecompute.html.markdown
+++ b/website/source/docs/builders/googlecompute.html.markdown
@@ -77,7 +77,9 @@ straightforwarded, it is documented here.
 
 Below is a fully functioning example. It doesn't do anything useful, since no
 provisioners are defined, but it will effectively repackage an existing GCE
-image. The account file is obtained in the previous section.
+image. The account_file is obtained in the previous section.  If it parses as
+JSON it is assumed to be the file itself, otherwise it is assumed to be
+the path to the file containing the JSON.
 
 ``` {.javascript}
 {

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -58,9 +58,10 @@ you can also use `token` configuration option.
     You must have access to the organization—hashicorp in this example—in order
     to add an artifact to the organization in Atlas.
 
--   `artifact_type` (string) - For uploading AMIs to Atlas, `artifact_type` will
-    always be `amazon.ami`. This field must be defined because Atlas can host
-    other artifact types, such as Vagrant boxes.
+-   `artifact_type` (string) - For uploading artifacts to Atlas. `artifact_type`
+    can be set to any unique identifier, however, we recommend using the
+    following for consistency - `amazon.ami`, `vagrant.box`, `google.image`,
+    and `docker.image`.
 
 ### Optional:
 

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -60,7 +60,8 @@ you can also use `token` configuration option.
 
 -   `artifact_type` (string) - For uploading artifacts to Atlas. `artifact_type`
     can be set to any unique identifier, however, the following are recommended
-    for consistency - `vagrant.box`, `amazon.ami`, `google.image`, and `docker.image`.
+    for consistency - `vagrant.box`, `amazon.ami`, `google.image`, `docker.image`,
+    `vmware.image`, and `virtualbox.image`.
 
 ### Optional:
 

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -59,9 +59,8 @@ you can also use `token` configuration option.
     to add an artifact to the organization in Atlas.
 
 -   `artifact_type` (string) - For uploading artifacts to Atlas. `artifact_type`
-    can be set to any unique identifier, however, we recommend using the
-    following for consistency - `amazon.ami`, `vagrant.box`, `google.image`,
-    and `docker.image`.
+    can be set to any unique identifier, however, the following are recommended
+    for consistency - `vagrant.box`, `amazon.ami`, `google.image`, and `docker.image`.
 
 ### Optional:
 

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -60,8 +60,9 @@ you can also use `token` configuration option.
 
 -   `artifact_type` (string) - For uploading artifacts to Atlas. `artifact_type`
     can be set to any unique identifier, however, the following are recommended
-    for consistency - `vagrant.box`, `amazon.ami`, `google.image`, `docker.image`,
-    `vmware.image`, and `virtualbox.image`.
+    for consistency - `amazon.image`, `digitalocean.image`, `docker.image`,
+    `googlecompute.image`, `openstack.image`, `parallels.image`, `qemu.image`,
+    `virtualbox.image`, `vmware.image`, `custom.image`, and `vagrant.box`.
 
 ### Optional:
 

--- a/website/source/docs/post-processors/compress.html.markdown
+++ b/website/source/docs/post-processors/compress.html.markdown
@@ -66,6 +66,6 @@ configuration:
 {
   "type": "compress",
   "output": "log_{{.BuildName}}.gz",
-  "compression": 9
+  "compression_level": 9
 }
 ```

--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -165,7 +165,7 @@ storing images at the end of this getting started guide.
 
 After running the above example, your AWS account now has an AMI associated with
 it. AMIs are stored in S3 by Amazon, so unless you want to be charged about
-\$0.01 per month, you'll probably want to remove it. Remove the AMI by first
+$0.01 per month, you'll probably want to remove it. Remove the AMI by first
 deregistering it on the [AWS AMI management
 page](https://console.aws.amazon.com/ec2/home?region=us-east-1#s=Images). Next,
 delete the associated snapshot on the [AWS snapshot management


### PR DESCRIPTION
The Vagrant post processor expects the DO artifact ID to look like an
AWS artifact ID (region_id:snapshot_id). This commit makes the DO
artifact Id() function output this format. Addresses Issue #2491.