### PR TITLE
Workaround docker-machine shared folder mapping issue

### DIFF
--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 // StepTempDir creates a temporary directory that we use in order to
@@ -18,7 +19,19 @@ func (s *StepTempDir) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating a temporary directory for sharing data...")
-	td, err := ioutil.TempDir("", "packer-docker")
+	// Create the docker temp files in the current working directory
+	// to work around an issue when running with docker-machine
+	// using vm's needing access to shared folder content. This assumes
+	// the current working directory is mapped as a share folder.
+	// Allow TMPDIR to override this location.
+	path := ""
+	if tmpdir := os.Getenv("TMPDIR"); tmpdir == "" {
+		abspath, err := filepath.Abs(".")
+		if err == nil {
+			path = abspath
+		}
+	}
+	td, err := ioutil.TempDir(path, "packer-docker")
 	if err != nil {
 		err := fmt.Errorf("Error making temp dir: %s", err)
 		state.Put("error", err)

--- a/builder/docker/step_temp_dir_test.go
+++ b/builder/docker/step_temp_dir_test.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"github.com/mitchellh/multistep"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -10,7 +12,7 @@ func TestStepTempDir_impl(t *testing.T) {
 	var _ multistep.Step = new(StepTempDir)
 }
 
-func TestStepTempDir(t *testing.T) {
+func testStepTempDir_impl(t *testing.T) string {
 	state := testState(t)
 	step := new(StepTempDir)
 	defer step.Cleanup(state)
@@ -40,5 +42,37 @@ func TestStepTempDir(t *testing.T) {
 	step.Cleanup(state)
 	if _, err := os.Stat(dir); err == nil {
 		t.Fatalf("dir should be gone")
+	}
+
+	return dir
+}
+
+func TestStepTempDir(t *testing.T) {
+	testStepTempDir_impl(t)
+}
+
+func TestStepTempDir_notmpdir(t *testing.T) {
+	tempenv := "TMPDIR"
+	if runtime.GOOS == "windows" {
+		tempenv = "TMP"
+	}
+	// Verify empty TMPDIR maps to current working directory
+	oldenv := os.Getenv(tempenv)
+	os.Setenv(tempenv, "")
+	defer os.Setenv(tempenv, oldenv)
+
+	dir1 := testStepTempDir_impl(t)
+
+	// Now set TMPDIR to current directory
+	abspath, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("could not get current working directory")
+	}
+	os.Setenv(tempenv, abspath)
+
+	dir2 := testStepTempDir_impl(t)
+
+	if filepath.Dir(dir1) != filepath.Dir(dir2) {
+		t.Fatalf("temp base directories do not match: %s %s", filepath.Dir(dir1), filepath.Dir(dir2))
 	}
 }


### PR DESCRIPTION
When using docker-machine on a Mac only the /Users folder is shared with
the VM. Uploads fail since the normal tmpdir is not shared. This change
uses the local packer directory (usually when run in the users home
folders) allowing it to work without setting TMPDIR explicitly. A better
fix would be to use the docker API directly but that would force users
to use docker API version 20+.
This fixes #901, fixes #1752, fixes #2436, fixes #2675, fixes #2697.