### PR TITLE
Fix NoDevice on the Amazon AMI builders (fixes #2398)

### DIFF
--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -23,8 +23,7 @@ func TestBlockDevice(t *testing.T) {
 			},
 
 			Result: &ec2.BlockDeviceMapping{
-				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
+				DeviceName: aws.String("/dev/sdb"),
 				Ebs: &ec2.EbsBlockDevice{
 					SnapshotId:          aws.String("snap-1234"),
 					VolumeType:          aws.String("standard"),
@@ -40,8 +39,7 @@ func TestBlockDevice(t *testing.T) {
 			},
 
 			Result: &ec2.BlockDeviceMapping{
-				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
+				DeviceName: aws.String("/dev/sdb"),
 				Ebs: &ec2.EbsBlockDevice{
 					VolumeType:          aws.String(""),
 					VolumeSize:          aws.Int64(8),
@@ -59,8 +57,7 @@ func TestBlockDevice(t *testing.T) {
 			},
 
 			Result: &ec2.BlockDeviceMapping{
-				DeviceName:  aws.String("/dev/sdb"),
-				VirtualName: aws.String(""),
+				DeviceName: aws.String("/dev/sdb"),
 				Ebs: &ec2.EbsBlockDevice{
 					VolumeType:          aws.String("io1"),
 					VolumeSize:          aws.Int64(8),
@@ -78,6 +75,17 @@ func TestBlockDevice(t *testing.T) {
 			Result: &ec2.BlockDeviceMapping{
 				DeviceName:  aws.String("/dev/sdb"),
 				VirtualName: aws.String("ephemeral0"),
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName: "/dev/sdb",
+				NoDevice:   true,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName: aws.String("/dev/sdb"),
+				NoDevice:   aws.String(""),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #2398.

The change to use the upstream aws/aws-sdk-go library introduced a bug
where the `no_device: true` option became useless in block device
mappings for Amazon AMI builders. When `no_device: true` is specified,
the EBS and instance store block mapping sections cannot be included.

The `virtual_name` parameter only makes sense with ephemeral volumes so
there's no point in checking if the string starts with "ephemeral" since
it cannot be used with EBS and will return an AWS error if used
incorrectly anyway.

The `no_device` parameter is not compatible with any other parameter.

This also moves the section that sets up the EBS block device mappings
into a section of the code that only gets run when EBS block mappings
are being setup. There's no point in creating a struct that gets
discarded when `virtual_name` or `no_device` are specified.

For usability, it might be worth catching and throwing an error when
mutually incompatible options are specified, but this change will at
least allow all of them to work when given the correct parameters as
documented by Amazon.