### PR TITLE
Add explicit wait after Communicator.Download to make sure serveSingleCopy completes

### DIFF
--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -140,7 +140,6 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 	streamId := c.mux.NextId()
 
 	waitServer := make(chan bool)
-
 	go func() {
 		serveSingleCopy("downloadWriter", c.mux, streamId, w, nil)
 		waitServer <- true
@@ -151,8 +150,10 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 		WriterStreamId: streamId,
 	}
 
+	// Start sending data to the RPC server
 	err = c.client.Call("Communicator.Download", &args, new(interface{}))
 
+	// Wait for the RPC server to finish receiving the data before we return
 	<-waitServer
 
 	return


### PR DESCRIPTION
Fixes #2793 

`serveSingleCopy` uses `io.Copy()` under the hood. @markpeek fixed a bunch of similar issues in other parts of Packer, which clued me into the fix.

I suspect what may be happening at a lower level is that one side of the copy operating has finished sending the data and signals that it is complete (the `client.Call` line in this case). After this the function returns.

However, the go routine running `io.Copy` has not yet completed, so it's trying to finish copying the data while the main go routine has already moved on and started reading data. My guess is that the rest of the data is sitting in the kernel's TCP/IO stack in the mean time.

Now we wait for the server to shut itself down before we continue.

TL;DR: Any time you use `go io.Copy()` you should block until it completes.