### PR TITLE
spot_price of "0" to mean on demand

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -135,7 +135,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 
 	var instanceId string
 
-	if spotPrice == "" {
+	if spotPrice == "" || spotPrice == "0" {
 		runOpts := &ec2.RunInstancesInput{
 			KeyName:             &keyName,
 			ImageId:             &s.SourceAMI,

--- a/builder/amazon/ebs/step_stop_instance.go
+++ b/builder/amazon/ebs/step_stop_instance.go
@@ -19,7 +19,7 @@ func (s *stepStopInstance) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	// Skip when it is a spot instance
-	if s.SpotPrice != "" {
+	if s.SpotPrice != "" && s.SpotPrice != "0" {
 		return multistep.ActionContinue
 	}
 

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -150,7 +150,8 @@ builder.
     when the current spot price is less than the maximum price you specify. Spot
     price will be updated based on available spot instance capacity and current
     spot instance requests. It may save you some costs. You can set this to
-    "auto" for Packer to automatically discover the best spot price.
+    "auto" for Packer to automatically discover the best spot price or to "0"
+    to use an on demand instance (default).
 
 -   `spot_price_auto_product` (string) - Required if `spot_price` is set
     to "auto". This tells Packer what sort of AMI you're launching to find the

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -191,7 +191,8 @@ builder.
     maximum price that you specify exceeds the current spot price. Spot price
     will be updated based on available spot instance capacity and current spot
     Instance requests. It may save you some costs. You can set this to "auto"
-    for Packer to automatically discover the best spot price.
+    for Packer to automatically discover the best spot price or to "0" to use
+    an on demand instance (default).
 
 -   `spot_price_auto_product` (string) - Required if `spot_price` is set
     to "auto". This tells Packer what sort of AMI you're launching to find the


### PR DESCRIPTION
This means that you can have a single packer template and alter one option to select spot/non-spot instances (which can be a bit easier than providing/omitting it as it can be done via environment variables rather than needing two templates)