### PR TITLE
Create docker temp files under packer.d when TMPDIR is not set

### DIFF
--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -18,7 +18,14 @@ func (s *StepTempDir) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating a temporary directory for sharing data...")
-	td, err := ioutil.TempDir("", "packer-docker")
+
+	var err error
+	var tempdir string
+
+	configTmpDir, err := packer.ConfigTmpDir()
+	if err == nil {
+		tempdir, err = ioutil.TempDir(configTmpDir, "packer-docker")
+	}
 	if err != nil {
 		err := fmt.Errorf("Error making temp dir: %s", err)
 		state.Put("error", err)
@@ -26,7 +33,7 @@ func (s *StepTempDir) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	s.tempDir = td
+	s.tempDir = tempdir
 	state.Put("temp_dir", s.tempDir)
 	return multistep.ActionContinue
 }

--- a/builder/docker/step_temp_dir_test.go
+++ b/builder/docker/step_temp_dir_test.go
@@ -1,16 +1,19 @@
 package docker
 
 import (
-	"github.com/mitchellh/multistep"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 func TestStepTempDir_impl(t *testing.T) {
 	var _ multistep.Step = new(StepTempDir)
 }
 
-func TestStepTempDir(t *testing.T) {
+func testStepTempDir_impl(t *testing.T) string {
 	state := testState(t)
 	step := new(StepTempDir)
 	defer step.Cleanup(state)
@@ -40,5 +43,54 @@ func TestStepTempDir(t *testing.T) {
 	step.Cleanup(state)
 	if _, err := os.Stat(dir); err == nil {
 		t.Fatalf("dir should be gone")
+	}
+
+	return dir
+}
+
+func TestStepTempDir(t *testing.T) {
+	testStepTempDir_impl(t)
+}
+
+func TestStepTempDir_notmpdir(t *testing.T) {
+	tempenv := "PACKER_TMP_DIR"
+
+	oldenv := os.Getenv(tempenv)
+	defer os.Setenv(tempenv, oldenv)
+	os.Setenv(tempenv, "")
+
+	dir1 := testStepTempDir_impl(t)
+
+	cd, err := packer.ConfigDir()
+	if err != nil {
+		t.Fatalf("bad ConfigDir")
+	}
+	td := filepath.Join(cd, "tmp")
+	os.Setenv(tempenv, td)
+
+	dir2 := testStepTempDir_impl(t)
+
+	if filepath.Dir(dir1) != filepath.Dir(dir2) {
+		t.Fatalf("temp base directories do not match: %s %s", filepath.Dir(dir1), filepath.Dir(dir2))
+	}
+}
+
+func TestStepTempDir_packertmpdir(t *testing.T) {
+	tempenv := "PACKER_TMP_DIR"
+
+	oldenv := os.Getenv(tempenv)
+	defer os.Setenv(tempenv, oldenv)
+	os.Setenv(tempenv, ".")
+
+	dir1 := testStepTempDir_impl(t)
+
+	abspath, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("bad absolute path")
+	}
+	dir2 := filepath.Join(abspath, "tmp")
+
+	if filepath.Dir(dir1) != filepath.Dir(dir2) {
+		t.Fatalf("temp base directories do not match: %s %s", filepath.Dir(dir1), filepath.Dir(dir2))
 	}
 }

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-checkpoint"
 	"github.com/mitchellh/packer/command"
+	"github.com/mitchellh/packer/packer"
 )
 
 func init() {
@@ -25,7 +26,7 @@ func runCheckpoint(c *config) {
 		return
 	}
 
-	configDir, err := ConfigDir()
+	configDir, err := packer.ConfigDir()
 	if err != nil {
 		log.Printf("[ERR] Checkpoint setup error: %s", err)
 		checkpointResult <- nil

--- a/config.go
+++ b/config.go
@@ -25,19 +25,6 @@ type config struct {
 	Provisioners   map[string]string
 }
 
-// ConfigFile returns the default path to the configuration file. On
-// Unix-like systems this is the ".packerconfig" file in the home directory.
-// On Windows, this is the "packer.config" file in the application data
-// directory.
-func ConfigFile() (string, error) {
-	return configFile()
-}
-
-// ConfigDir returns the configuration directory for Packer.
-func ConfigDir() (string, error) {
-	return configDir()
-}
-
 // Decodes configuration in JSON format from the given io.Reader into
 // the config object pointed to.
 func decodeConfig(r io.Reader, c *config) error {
@@ -64,7 +51,7 @@ func (c *config) Discover() error {
 	}
 
 	// Next, look in the plugins directory.
-	dir, err := ConfigDir()
+	dir, err := packer.ConfigDir()
 	if err != nil {
 		log.Printf("[ERR] Error loading config directory: %s", err)
 	} else {

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func loadConfig() (*config, error) {
 	configFilePath := os.Getenv("PACKER_CONFIG")
 	if configFilePath == "" {
 		var err error
-		configFilePath, err = configFile()
+		configFilePath, err = packer.ConfigFile()
 
 		if err != nil {
 			log.Printf("Error detecting default config file path: %s", err)

--- a/packer/config_file.go
+++ b/packer/config_file.go
@@ -1,5 +1,10 @@
 package packer
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // ConfigFile returns the default path to the configuration file. On
 // Unix-like systems this is the ".packerconfig" file in the home directory.
 // On Windows, this is the "packer.config" file in the application data
@@ -11,4 +16,25 @@ func ConfigFile() (string, error) {
 // ConfigDir returns the configuration directory for Packer.
 func ConfigDir() (string, error) {
 	return configDir()
+}
+
+// ConfigTmpDir returns the configuration tmp directory for Packer
+func ConfigTmpDir() (string, error) {
+	if tmpdir := os.Getenv("PACKER_TMP_DIR"); tmpdir != "" {
+		return filepath.Abs(tmpdir)
+	}
+	configdir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	td := filepath.Join(configdir, "tmp")
+	_, err = os.Stat(td)
+	if os.IsNotExist(err) {
+		if err = os.MkdirAll(td, 0755); err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		return "", err
+	}
+	return td, nil
 }

--- a/packer/config_file.go
+++ b/packer/config_file.go
@@ -1,0 +1,14 @@
+package packer
+
+// ConfigFile returns the default path to the configuration file. On
+// Unix-like systems this is the ".packerconfig" file in the home directory.
+// On Windows, this is the "packer.config" file in the application data
+// directory.
+func ConfigFile() (string, error) {
+	return configFile()
+}
+
+// ConfigDir returns the configuration directory for Packer.
+func ConfigDir() (string, error) {
+	return configDir()
+}

--- a/packer/config_file_unix.go
+++ b/packer/config_file_unix.go
@@ -1,6 +1,6 @@
 // +build darwin freebsd linux netbsd openbsd
 
-package main
+package packer
 
 import (
 	"bytes"

--- a/packer/config_file_windows.go
+++ b/packer/config_file_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package main
+package packer
 
 import (
 	"path/filepath"


### PR DESCRIPTION
Packer uses a docker bind mount to upload files into the docker image via a temp directory. When run on a Mac with docker-machine (using vmware/virtualbox) the VM will only mount the /Users directory by default. This causes mounts using the temp directory to silently fail and cause packer to hang waiting for the Upload to finish which can't succeed.

A previous PR #2807 attempted to fix this by creating the temp dir in the CWD of the packer invocation. This caused an issue when a provisioner tried uploading "." and it recursively tried to copy up the intermediate upload directory.

This PR now creates the intermediate upload directory under the packer configuration directory (~/.packer.d/tmp). The ConfigDir()/ConfigFile() code has been moved from package main to package packer to allow the docker code to call it.

Note: the real fix for this issue is to switch to using the latest docker API directly suck as through [go-dockerclient](https://github.com/fsouza/go-dockerclient). However, this would require upgrading the minimum requirement for docker to version 1.8 which would need consensus before moving forward.