### PR TITLE
Implement a null-object communicator for 'none'

### DIFF
--- a/communicator/none/communicator.go
+++ b/communicator/none/communicator.go
@@ -1,0 +1,40 @@
+package none
+
+import (
+	"errors"
+	"io"
+	"os"
+	"github.com/mitchellh/packer/packer"
+)
+
+type comm struct {
+	config  string
+}
+
+// Creates a null packer.Communicator implementation. This takes
+// an already existing configuration.
+func New(config string) (result *comm, err error) {
+	// Establish an initial connection and connect
+	result = &comm{
+		config:  config,
+	}
+
+	return
+}
+
+func (c *comm) Start(cmd *packer.RemoteCmd) (err error) {
+	cmd.SetExited(0)
+	return
+}
+
+func (c *comm) Upload(path string, input io.Reader, fi *os.FileInfo) error {
+	return errors.New("Upload is not implemented when communicator = 'none'")
+}
+
+func (c *comm) UploadDir(dst string, src string, excl []string) error {
+	return errors.New("UploadDir is not implemented when communicator = 'none'")
+}
+
+func (c *comm) Download(path string, output io.Writer) error {
+	return errors.New("Download is not implemented when communicator = 'none'")
+}

--- a/helper/communicator/step_connect.go
+++ b/helper/communicator/step_connect.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/multistep"
 	gossh "golang.org/x/crypto/ssh"
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/communicator/none"
 )
 
 // StepConnect is a multistep Step implementation that connects to
@@ -67,6 +69,15 @@ func (s *StepConnect) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if step == nil {
+		comm, err := none.New("none")
+		if err != nil {
+			err := fmt.Errorf("Failed to set communicator 'none': %s", err)
+			state.Put("error", err)
+			ui := state.Get("ui").(packer.Ui)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		state.Put("communicator",  comm)
 		log.Printf("[INFO] communicator disabled, will not connect")
 		return multistep.ActionContinue
 	}


### PR DESCRIPTION
Fixes #2736 

I am able to successfully build my VM with no network access using this changed version of Packer. I have not tested it significantly outside this use case.