### PR TITLE
Print slug size before upload in packer's atlas post-processor

### DIFF
--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -204,7 +204,8 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		opts.FileSize = r.Size
 	}
 
-	ui.Message(fmt.Sprintf("Uploading artifact (Size: %v)", opts.FileSize))
+	fileSizeMB := float64(opts.FileSize / 1000000)
+	ui.Message(fmt.Sprintf("Uploading artifact (Size: %.2fMB)", fileSizeMB))
 	var av *atlas.ArtifactVersion
 	doneCh := make(chan struct{})
 	errCh := make(chan error, 1)
@@ -220,7 +221,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	select {
 	case err := <-errCh:
-		return nil, false, fmt.Errorf("Error uploading (Size: %v): %s", opts.FileSize, err)
+		return nil, false, fmt.Errorf("Error uploading (Size: %.2fMB): %s", fileSizeMB, err)
 	case <-doneCh:
 	}
 

--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -204,7 +204,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		opts.FileSize = r.Size
 	}
 
-	ui.Message("Uploading artifact version...")
+	ui.Message(fmt.Sprintf("Uploading artifact (Size: %v)", opts.FileSize))
 	var av *atlas.ArtifactVersion
 	doneCh := make(chan struct{})
 	errCh := make(chan error, 1)
@@ -220,7 +220,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	select {
 	case err := <-errCh:
-		return nil, false, fmt.Errorf("Error uploading: %s", err)
+		return nil, false, fmt.Errorf("Error uploading (Size: %v): %s", opts.FileSize, err)
 	case <-doneCh:
 	}
 


### PR DESCRIPTION
Adds size output to `ui.Message` as well as if the artifact failed to upload to atlas.