### PR TITLE
Fix #2742: Include template line numbers on error

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -39,11 +39,7 @@ func (c BuildCommand) Run(args []string) int {
 	// Parse the template
 	var tpl *template.Template
 	var err error
-	if args[0] == "-" {
-		tpl, err = template.Parse(os.Stdin)
-	} else {
-		tpl, err = template.ParseFile(args[0])
-	}
+	tpl, err = template.ParseFile(args[0])
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to parse template: %s", err))
 		return 1

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -350,3 +350,23 @@ func TestParse_contents(t *testing.T) {
 		t.Fatalf("bad: %s\n\n%s", actual, expected)
 	}
 }
+
+func TestParse_bad(t *testing.T) {
+	cases := []struct {
+		File     string
+		Expected string
+	}{
+		{"error-beginning.json", "line 1, char 1"},
+		{"error-middle.json", "line 5, char 5"},
+		{"error-end.json", "line 1, char 30"},
+	}
+	for _, tc := range cases {
+		_, err := ParseFile(fixtureDir(tc.File))
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), tc.Expected) {
+			t.Fatalf("file: %s\nExpected: %s\n%s\n", tc.File, tc.Expected, err.Error())
+		}
+	}
+}

--- a/template/test-fixtures/error-beginning.json
+++ b/template/test-fixtures/error-beginning.json
@@ -1,0 +1,1 @@
+*"builders": [ { "type":"test", }]}

--- a/template/test-fixtures/error-end.json
+++ b/template/test-fixtures/error-end.json
@@ -1,0 +1,1 @@
+{"builders":[{"type":"test"}]*

--- a/template/test-fixtures/error-middle.json
+++ b/template/test-fixtures/error-middle.json
@@ -1,0 +1,7 @@
+{
+  "builders": [
+    {
+      "type":"test",
+    }
+  ]
+}


### PR DESCRIPTION
Template errors will now show line number and character position of the error. This also adds as a side-effect piping stdin for non-build commands (like validate). Note: the below example is due to the trailing comma from the line before it.

```
$ cat template/test-fixtures/error-middle.json
{
  "builders": [
    {
      "type":"test",
    }
  ]
}
$ cat template/test-fixtures/error-middle.json | packer validate -
Failed to parse template: Error in line 5, char 5: invalid character '}' looking for beginning of object key string
    }
```