### PR TITLE
Add IAM policy for copying images

### DIFF
--- a/website/source/docs/builders/amazon.html.markdown
+++ b/website/source/docs/builders/amazon.html.markdown
@@ -101,6 +101,7 @@ Packer to work:
         "ec2:DeleteSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CreateImage",
+        "ec2:CopyImage",
         "ec2:RunInstances",
         "ec2:TerminateInstances",
         "ec2:StopInstances",


### PR DESCRIPTION
The ec2:CopyImage privilege is required in order to make a cross-region AMI when using the  `ami_regions` option for the amazon-ebs builder.