### PR TITLE
Doc change only: misspelling of 'termination'

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -278,7 +278,7 @@ Here is an example using the optional AMI tags. This will add the tags
 
 -&gt; **Note:** Packer uses pre-built AMIs as the source for building images.
 These source AMIs may include volumes that are not flagged to be destroyed on
-termiation of the instance building the new image. Packer will attempt to clean
+termination of the instance building the new image. Packer will attempt to clean
 up all residual volumes that are not designated by the user to remain after
 termination. If you need to preserve those source volumes, you can overwrite the
 termination setting by specifying `delete_on_termination=false` in the


### PR DESCRIPTION
Just a wee documentation change to a footnote.