### PR TITLE
Feature - Adding a new `options` config parameter to Puppet (masterless) provisionining

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -22,6 +22,9 @@ type Config struct {
 	// The command used to execute Puppet.
 	ExecuteCommand string `mapstructure:"execute_command"`
 
+	// Additional options to pass when executing Puppet
+	Options []string
+
 	// Additional facts to set when executing Puppet
 	Facter map[string]string
 
@@ -62,6 +65,7 @@ type ExecuteTemplate struct {
 	ManifestFile    string
 	ManifestDir     string
 	Sudo            bool
+	Options         string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
@@ -86,6 +90,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
 			"--detailed-exitcodes " +
+			"{{.Options}} " +
 			"{{.ManifestFile}}"
 	}
 
@@ -218,6 +223,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		ModulePath:      strings.Join(modulePaths, ":"),
 		Sudo:            !p.config.PreventSudo,
 		WorkingDir:      p.config.WorkingDir,
+		Options:         strings.Join(p.config.Options, " "),
 	}
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -90,7 +90,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
 			"--detailed-exitcodes " +
-			"{{.ExtraArguments}} " +
+			"{{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}}" +
 			"{{.ManifestFile}}"
 	}
 

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -22,8 +22,8 @@ type Config struct {
 	// The command used to execute Puppet.
 	ExecuteCommand string `mapstructure:"execute_command"`
 
-	// Additional options to pass when executing Puppet
-	Options []string
+	// Additional arguments to pass when executing Puppet
+	ExtraArguments []string `mapstructure:"extra_arguments"`
 
 	// Additional facts to set when executing Puppet
 	Facter map[string]string
@@ -65,7 +65,7 @@ type ExecuteTemplate struct {
 	ManifestFile    string
 	ManifestDir     string
 	Sudo            bool
-	Options         string
+	ExtraArguments  string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
@@ -90,7 +90,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
 			"--detailed-exitcodes " +
-			"{{.Options}} " +
+			"{{.ExtraArguments}} " +
 			"{{.ManifestFile}}"
 	}
 
@@ -223,7 +223,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		ModulePath:      strings.Join(modulePaths, ":"),
 		Sudo:            !p.config.PreventSudo,
 		WorkingDir:      p.config.WorkingDir,
-		Options:         strings.Join(p.config.Options, " "),
+		ExtraArguments:  strings.Join(p.config.ExtraArguments, " "),
 	}
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -183,6 +183,7 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 func TestProvisionerPrepare_extraArguments(t *testing.T) {
 	config := testConfig()
 
+	// Test with missing parameter
 	delete(config, "extra_arguments")
 	p := new(Provisioner)
 	err := p.Prepare(config)
@@ -190,7 +191,7 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Test with malformed fact
+	// Test with malformed value
 	config["extra_arguments"] = "{{}}"
 	p = new(Provisioner)
 	err = p.Prepare(config)
@@ -198,6 +199,7 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 		t.Fatal("should be an error")
 	}
 
+	// Test with valid values
 	config["extra_arguments"] = []string{
 		"arg",
 	}
@@ -222,6 +224,7 @@ func TestProvisionerProvision_extraArguments(t *testing.T) {
 	}
 	config["extra_arguments"] = extraArguments
 
+	// Test with valid values
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
@@ -237,5 +240,25 @@ func TestProvisionerProvision_extraArguments(t *testing.T) {
 
 	if !strings.Contains(comm.StartCmd.Command, expectedArgs) {
 		t.Fatalf("Command %q doesn't contain the expected arguments %q", comm.StartCmd.Command, expectedArgs)
+	}
+
+	// Test with missing parameter
+	delete(config, "extra_arguments")
+
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = p.Provision(ui, comm)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Check the expected `extra_arguments` position for an empty value
+	splitCommand := strings.Split(comm.StartCmd.Command, " ")
+	if "" == splitCommand[len(splitCommand)-2] {
+		t.Fatalf("Command %q contains an extra-space which may cause arg parsing issues", comm.StartCmd.Command)
 	}
 }

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -180,10 +180,10 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 	}
 }
 
-func TestProvisionerPrepare_options(t *testing.T) {
+func TestProvisionerPrepare_extraArguments(t *testing.T) {
 	config := testConfig()
 
-	delete(config, "options")
+	delete(config, "extra_arguments")
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
@@ -191,14 +191,14 @@ func TestProvisionerPrepare_options(t *testing.T) {
 	}
 
 	// Test with malformed fact
-	config["options"] = "{{}}"
+	config["extra_arguments"] = "{{}}"
 	p = new(Provisioner)
 	err = p.Prepare(config)
 	if err == nil {
 		t.Fatal("should be an error")
 	}
 
-	config["options"] = []string{
+	config["extra_arguments"] = []string{
 		"arg",
 	}
 
@@ -209,18 +209,18 @@ func TestProvisionerPrepare_options(t *testing.T) {
 	}
 }
 
-func TestProvisionerProvision_options(t *testing.T) {
+func TestProvisionerProvision_extraArguments(t *testing.T) {
 	config := testConfig()
 	ui := &packer.MachineReadableUi{
 		Writer: ioutil.Discard,
 	}
 	comm := new(packer.MockCommunicator)
 
-	options := []string{
+	extraArguments := []string{
 		"--some-arg=yup",
 		"--some-other-arg",
 	}
-	config["options"] = options
+	config["extra_arguments"] = extraArguments
 
 	p := new(Provisioner)
 	err := p.Prepare(config)
@@ -233,7 +233,7 @@ func TestProvisionerProvision_options(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	expectedArgs := strings.Join(options, " ")
+	expectedArgs := strings.Join(extraArguments, " ")
 
 	if !strings.Contains(comm.StartCmd.Command, expectedArgs) {
 		t.Fatalf("Command %q doesn't contain the expected arguments %q", comm.StartCmd.Command, expectedArgs)

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -1,10 +1,11 @@
 package puppetmasterless
 
 import (
-	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/packer/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -175,5 +176,34 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 	err = p.Prepare(config)
 	if p.config.Facter == nil {
 		t.Fatalf("err: Default facts are not set in the Puppet provisioner!")
+	}
+}
+
+func TestProvisionerPrepare_options(t *testing.T) {
+	config := testConfig()
+
+	delete(config, "options")
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Test with malformed fact
+	config["options"] = "{{}}"
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should be an error")
+	}
+
+	config["options"] = []string{
+		"arg",
+	}
+
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 }

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -3,6 +3,7 @@ package puppetmasterless
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/packer/packer"
@@ -205,5 +206,36 @@ func TestProvisionerPrepare_options(t *testing.T) {
 	err = p.Prepare(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvisionerProvision_options(t *testing.T) {
+	config := testConfig()
+	ui := &packer.MachineReadableUi{
+		Writer: ioutil.Discard,
+	}
+	comm := new(packer.MockCommunicator)
+
+	options := []string{
+		"--some-arg=yup",
+		"--some-other-arg",
+	}
+	config["options"] = options
+
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = p.Provision(ui, comm)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expectedArgs := strings.Join(options, " ")
+
+	if !strings.Contains(comm.StartCmd.Command, expectedArgs) {
+		t.Fatalf("Command %q doesn't contain the expected arguments %q", comm.StartCmd.Command, expectedArgs)
 	}
 }

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -59,6 +59,12 @@ Optional parameters:
     variables](/docs/templates/configuration-templates.html) available. See
     below for more information.
 
+-   `options` (array of strings) - This is an array of additional options to
+    pass to the puppet command when executing puppet. This allows for
+    customization of the `execute_command` without having to completely replace
+    or include it's contents, making forward-compatible customizations much
+    easier.
+
 -   `facter` (object of key/value strings) - Additional
     [facts](http://puppetlabs.com/puppet/related-projects/facter) to make
     available when Puppet is running.

--- a/website/source/docs/provisioners/puppet-masterless.html.markdown
+++ b/website/source/docs/provisioners/puppet-masterless.html.markdown
@@ -59,7 +59,7 @@ Optional parameters:
     variables](/docs/templates/configuration-templates.html) available. See
     below for more information.
 
--   `options` (array of strings) - This is an array of additional options to
+-   `extra_arguments` (array of strings) - This is an array of additional options to
     pass to the puppet command when executing puppet. This allows for
     customization of the `execute_command` without having to completely replace
     or include it's contents, making forward-compatible customizations much


### PR DESCRIPTION
This PR implements #2635.

After a few months had passed after opening the original issue, I figured I'd give it a try. Luckily, the Packer codebase is well modularized, so digging into this specific bit was actually really quite easy! :smiley: 

Anyway, this PR adds a new `options` configuration parameter to the **"puppet-masterless"** provisioner, as initially described in #2635. The intent of this is to allow for the customization of the execution command without having to replace the entire command string (which changes every version and circumvents most of the benefits that Packer provides).

This feature works in the same style as Vagrant's "puppet apply" provisioner. So this PR will bring the Packer puppet provisioning configuration more in line with Vagrants. Consistency is good here.

### Naming

**I'm not a huge fan of the name "options"** for the parameter. I think a more semantic/self-documenting name would be `execute_arguments`, `execute_parameters`, or `execute_options`, however I decided to leave it as `options` for this PR in order for it to keep consistency with Vagrant's configuration.

If consistency there is not a desired trait, then I suggest we change the name. I'll leave that decision up to the **Packer** team, though.