### PR TITLE
vmware-iso-builder: Corrects logic checking destroy

### DIFF
--- a/builder/vmware/iso/step_register.go
+++ b/builder/vmware/iso/step_register.go
@@ -57,8 +57,8 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 			}
 			// Wait for the machine to actually destroy
 			for {
-				exists, _ := remoteDriver.IsDestroyed()
-				if !exists {
+				destroyed, _ := remoteDriver.IsDestroyed()
+				if destroyed {
 					break
 				}
 				time.Sleep(150 * time.Millisecond)


### PR DESCRIPTION
* I suspect the logic written for checking if the vm has been destroyed is incorrect.  The test will come back from the esx server indicating that the vm is gone as it should, but the logic I believe is reversed so we never hit the break in the if statement
* Feedback is MORE than welcome