### PR TITLE
Added alternative floppy boot command syntax

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -422,7 +422,7 @@ file by attaching a floppy disk. An example below, based on RHEL:
 }
 ```
 
-It's also worth noting that `ks=floppy` has been deprecated in the latest versions of Anaconda.  Later versions of Linux may require a different syntax to source a kickstart file from a mounted floppy image.
+It's also worth noting that `ks=floppy` has been deprecated.  Later versions of the Anaconda installer (used in RHEL/CentOS 7 and Fedora) may require a different syntax to source a kickstart file from a mounted floppy image.
 
 ``` {.javascript}
 {

--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -421,3 +421,19 @@ file by attaching a floppy disk. An example below, based on RHEL:
   ]
 }
 ```
+
+It's also worth noting that `ks=floppy` has been deprecated in the latest versions of Anaconda.  Later versions of Linux may require a different syntax to source a kickstart file from a mounted floppy image.
+
+``` {.javascript}
+{
+  "builders": [
+    {
+      "type":"vmware-iso",
+      "floppy_files": [
+        "folder/ks.cfg"
+      ],
+      "boot_command": "<tab> inst.text inst.ks=hd:fd0:/ks.cfg <enter><wait>"
+    }
+  ]
+}
+```


### PR DESCRIPTION
The vmware-iso example configuration to load a Kickstart configuration file off of a mounted floppy image is not valid for recent versions of Linux including RHEL7.  The version of Anaconda used no longer supports ks=floppy.

This commit adds an alternative syntax that users can use with more recent version of Linux to source a Kickstart file from a mounted floppy image.