### PR TITLE
Make DigitalOcean artifact ID match AWS format (fixed)

### DIFF
--- a/builder/digitalocean/artifact.go
+++ b/builder/digitalocean/artifact.go
@@ -32,7 +32,7 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return strconv.FormatUint(uint64(a.snapshotId), 10)
+	return fmt.Sprintf("%s:%s", a.regionName, strconv.FormatUint(uint64(a.snapshotId), 10))
 }
 
 func (a *Artifact) String() string {

--- a/builder/digitalocean/artifact_test.go
+++ b/builder/digitalocean/artifact_test.go
@@ -16,7 +16,7 @@ func TestArtifact_Impl(t *testing.T) {
 
 func TestArtifactId(t *testing.T) {
 	a := &Artifact{"packer-foobar", 42, "San Francisco", nil}
-	expected := "42"
+	expected := "San Francisco:42"
 
 	if a.Id() != expected {
 		t.Fatalf("artifact ID should match: %v", expected)


### PR DESCRIPTION
:smile_cat: *This is just a git fixup of #2805 from @lolindrath — it even preserves his authorship!*

This fixes #2491, which is breaking digital ocean provider.

The Vagrant post processor expects the DO artifact ID to look like an
AWS artifact ID (region_id:snapshot_id). This commit makes the DO
artifact Id() function output this format.