### PR TITLE
increased DigitalOcean unlock wait timeouts

### DIFF
--- a/builder/digitalocean/step_power_off.go
+++ b/builder/digitalocean/step_power_off.go
@@ -50,7 +50,7 @@ func (s *stepPowerOff) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Wait for the droplet to become unlocked for future steps
-	if err := waitForDropletUnlocked(client, dropletId, 2*time.Minute); err != nil {
+	if err := waitForDropletUnlocked(client, dropletId, 4*time.Minute); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error powering off droplet: %s", err)
 		state.Put("error", err)

--- a/builder/digitalocean/step_shutdown.go
+++ b/builder/digitalocean/step_shutdown.go
@@ -72,7 +72,7 @@ func (s *stepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	if err := waitForDropletUnlocked(client, dropletId, 2*time.Minute); err != nil {
+	if err := waitForDropletUnlocked(client, dropletId, 4*time.Minute); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error shutting down droplet: %s", err)
 		state.Put("error", err)

--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -30,8 +30,8 @@ func (s *stepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Wait for the droplet to become unlocked first. For snapshots
 	// this can end up taking quite a long time, so we hardcode this to
-	// 15 minutes.
-	if err := waitForDropletUnlocked(client, dropletId, 15*time.Minute); err != nil {
+	// 20 minutes.
+	if err := waitForDropletUnlocked(client, dropletId, 20*time.Minute); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error shutting down droplet: %s", err)
 		state.Put("error", err)

--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -30,8 +30,8 @@ func (s *stepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Wait for the droplet to become unlocked first. For snapshots
 	// this can end up taking quite a long time, so we hardcode this to
-	// 10 minutes.
-	if err := waitForDropletUnlocked(client, dropletId, 10*time.Minute); err != nil {
+	// 15 minutes.
+	if err := waitForDropletUnlocked(client, dropletId, 15*time.Minute); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error shutting down droplet: %s", err)
 		state.Put("error", err)


### PR DESCRIPTION
For larger DigitalOcean droplets the hardcoded limits were too low. I believe these limits should be exposed as configuration options instead.