### PR TITLE
Update website/Vagrantfile to re-enable vagrant

### DIFF
--- a/website/Vagrantfile
+++ b/website/Vagrantfile
@@ -20,7 +20,7 @@ make dev
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-14.04"
   config.vm.network "private_network", ip: "33.33.30.10"
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.synced_folder ".", "/vagrant", type: "rsync"

--- a/website/Vagrantfile
+++ b/website/Vagrantfile
@@ -5,22 +5,22 @@ $script = <<SCRIPT
 sudo apt-get -y update
 
 # RVM/Ruby
-sudo apt-get -y install curl
-sudo apt-get -y install git
+sudo apt-get -qy install curl git libgmp3-dev
 gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+# Install rvm and the latest version of ruby
 curl -sSL https://get.rvm.io | bash -s stable
 . ~/.bashrc
 . ~/.bash_profile
-rvm install 2.0.0
-rvm --default use 2.0.0
+rvm install ruby-2.2.2
+gem install bundler
 
 # Middleman deps
 cd /vagrant
-bundle
+make dev
 SCRIPT
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "chef/ubuntu-12.04"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.network "private_network", ip: "33.33.30.10"
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.synced_folder ".", "/vagrant", type: "rsync"


### PR DESCRIPTION
Fixes #2940.

Changed the box from "chef/ubuntu-12.04" to "ubuntu/trusty64".
Changed the ruby version to 2.2.2 to accommodate the latest middleman.
Changed initialization from "bundle" to "make dev".