### PR TITLE
Add "skip_clean" boolean to shell provisioner.

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -58,6 +58,9 @@ type Config struct {
 	// This can be set high to allow for reboots.
 	RawStartRetryTimeout string `mapstructure:"start_retry_timeout"`
 
+	// Whether to clean scripts up
+	NoClean bool
+
 	startRetryTimeout time.Duration
 	ctx               interpolate.Context
 }
@@ -271,29 +274,32 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Script exited with non-zero exit status: %d", cmd.ExitStatus)
 		}
 
-		// Delete the temporary file we created. We retry this a few times
-		// since if the above rebooted we have to wait until the reboot
-		// completes.
-		err = p.retryable(func() error {
-			cmd = &packer.RemoteCmd{
-				Command: fmt.Sprintf("rm -f %s", p.config.RemotePath),
-			}
-			if err := comm.Start(cmd); err != nil {
-				return fmt.Errorf(
-					"Error removing temporary script at %s: %s",
-					p.config.RemotePath, err)
-			}
-			cmd.Wait()
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		if !p.config.NoClean {
 
-		if cmd.ExitStatus != 0 {
-			return fmt.Errorf(
-				"Error removing temporary script at %s!",
-				p.config.RemotePath)
+			// Delete the temporary file we created. We retry this a few times
+			// since if the above rebooted we have to wait until the reboot
+			// completes.
+			err = p.retryable(func() error {
+				cmd = &packer.RemoteCmd{
+					Command: fmt.Sprintf("rm -f %s", p.config.RemotePath),
+				}
+				if err := comm.Start(cmd); err != nil {
+					return fmt.Errorf(
+						"Error removing temporary script at %s: %s",
+						p.config.RemotePath, err)
+				}
+				cmd.Wait()
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			if cmd.ExitStatus != 0 {
+				return fmt.Errorf(
+					"Error removing temporary script at %s!",
+					p.config.RemotePath)
+			}
 		}
 	}
 

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -59,7 +59,7 @@ type Config struct {
 	RawStartRetryTimeout string `mapstructure:"start_retry_timeout"`
 
 	// Whether to clean scripts up
-	NoClean bool
+	SkipClean bool `mapstructure:"skip_clean"`
 
 	startRetryTimeout time.Duration
 	ctx               interpolate.Context
@@ -274,7 +274,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Script exited with non-zero exit status: %d", cmd.ExitStatus)
 		}
 
-		if !p.config.NoClean {
+		if !p.config.SkipClean {
 
 			// Delete the temporary file we created. We retry this a few times
 			// since if the above rebooted we have to wait until the reboot

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -88,6 +88,10 @@ Optional parameters:
     system reboot. Set this to a higher value if reboots take a longer amount
     of time.
 
+-   `noclean` (boolean) - If true, specifies that the helper scripts uploaded
+    to the system will not be removed by Packer. This defaults to false
+    (clean scripts from the system).
+
 ## Execute Command Example
 
 To many new users, the `execute_command` is puzzling. However, it provides an

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -88,9 +88,9 @@ Optional parameters:
     system reboot. Set this to a higher value if reboots take a longer amount
     of time.
 
--   `noclean` (boolean) - If true, specifies that the helper scripts uploaded
-    to the system will not be removed by Packer. This defaults to false
-    (clean scripts from the system).
+-   `skip_clean` (boolean) - If true, specifies that the helper scripts 
+    uploaded to the system will not be removed by Packer. This defaults to 
+    false (clean scripts from the system).
 
 ## Execute Command Example
 


### PR DESCRIPTION
This stops the provisioner from attempting to remove helper scripts it creates. As noted on #2803 this can be useful when deleting the build user from an AMI or other template.

(Despite how noisy the patch is, the only part actually changed is wrapping the lines that call the delete in an if checking a bool..)