### PR TITLE
Clarify remote_path shell option

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -58,6 +58,9 @@ type Config struct {
 	// This can be set high to allow for reboots.
 	RawStartRetryTimeout string `mapstructure:"start_retry_timeout"`
 
+	// Whether to clean scripts up
+	NoClean bool
+
 	startRetryTimeout time.Duration
 	ctx               interpolate.Context
 }
@@ -271,29 +274,32 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Script exited with non-zero exit status: %d", cmd.ExitStatus)
 		}
 
-		// Delete the temporary file we created. We retry this a few times
-		// since if the above rebooted we have to wait until the reboot
-		// completes.
-		err = p.retryable(func() error {
-			cmd = &packer.RemoteCmd{
-				Command: fmt.Sprintf("rm -f %s", p.config.RemotePath),
-			}
-			if err := comm.Start(cmd); err != nil {
-				return fmt.Errorf(
-					"Error removing temporary script at %s: %s",
-					p.config.RemotePath, err)
-			}
-			cmd.Wait()
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		if !p.config.NoClean {
 
-		if cmd.ExitStatus != 0 {
-			return fmt.Errorf(
-				"Error removing temporary script at %s!",
-				p.config.RemotePath)
+			// Delete the temporary file we created. We retry this a few times
+			// since if the above rebooted we have to wait until the reboot
+			// completes.
+			err = p.retryable(func() error {
+				cmd = &packer.RemoteCmd{
+					Command: fmt.Sprintf("rm -f %s", p.config.RemotePath),
+				}
+				if err := comm.Start(cmd); err != nil {
+					return fmt.Errorf(
+						"Error removing temporary script at %s: %s",
+						p.config.RemotePath, err)
+				}
+				cmd.Wait()
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			if cmd.ExitStatus != 0 {
+				return fmt.Errorf(
+					"Error removing temporary script at %s!",
+					p.config.RemotePath)
+			}
 		}
 	}
 

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -78,9 +78,10 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
--   `remote_path` (string) - The path where the script will be uploaded to in
-    the machine. This defaults to "/tmp/script.sh". This value must be a
-    writable location and any parent directories must already exist.
+-   `remote_path` (string) - The filename where the script will be uploaded
+    to in the machine. This defaults to "/tmp/script_nnn.sh" where "nnn" is
+    a randomly generated number. This value must be a writable location and
+    any parent directories must already exist.
 
 -   `start_retry_timeout` (string) - The amount of time to attempt to *start*
     the remote process. By default this is "5m" or 5 minutes. This setting

--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -88,6 +88,10 @@ Optional parameters:
     system reboot. Set this to a higher value if reboots take a longer amount
     of time.
 
+-   `noclean` (boolean) - If true, specifies that the helper scripts uploaded
+    to the system will not be removed by Packer. This defaults to false
+    (clean scripts from the system).
+
 ## Execute Command Example
 
 To many new users, the `execute_command` is puzzling. However, it provides an


### PR DESCRIPTION
Fixes up documentation to match how remote_path is actually used by shell provisioner, and current default.