### PR TITLE
Update documentation of shell remote_path variable

### DIFF
--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -78,9 +78,10 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
--   `remote_path` (string) - The path where the script will be uploaded to in
-    the machine. This defaults to "/tmp/script.sh". This value must be a
-    writable location and any parent directories must already exist.
+-   `remote_path` (string) - The filename where the script will be uploaded
+    to in the machine. This defaults to "/tmp/script_nnn.sh" where "nnn" is
+    a randomly generated number. This value must be a writable location and
+    any parent directories must already exist.
 
 -   `start_retry_timeout` (string) - The amount of time to attempt to *start*
     the remote process. By default this is "5m" or 5 minutes. This setting


### PR DESCRIPTION
It is not a path as implied by docs, but a specific filename.
Update default to currently implemented default.
Fixes #2945 