### PR TITLE
Add AMI Product Codes modification for amazon-ebs & amazon-chroot

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -189,9 +189,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Name:         b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
-			Description: b.config.AMIDescription,
-			Users:       b.config.AMIUsers,
-			Groups:      b.config.AMIGroups,
+			Description:  b.config.AMIDescription,
+			Users:        b.config.AMIUsers,
+			Groups:       b.config.AMIGroups,
+			ProductCodes: b.config.AMIProductCodes,
 		},
 		&awscommon.StepCreateTags{
 			Tags: b.config.AMITags,

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -149,9 +149,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Name:         b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
-			Description: b.config.AMIDescription,
-			Users:       b.config.AMIUsers,
-			Groups:      b.config.AMIGroups,
+			Description:  b.config.AMIDescription,
+			Users:        b.config.AMIUsers,
+			Groups:       b.config.AMIGroups,
+			ProductCodes: b.config.AMIProductCodes,
 		},
 		&awscommon.StepCreateTags{
 			Tags: b.config.AMITags,


### PR DESCRIPTION
According to [documents](https://www.packer.io/docs/builders/amazon.html), `amazon-ebs` and `amazon-chroot` builders have a `ami_product_codes` option. But actually it is only supported with a `amazon-instance` builder.

(see: https://github.com/mitchellh/packer/blob/master/builder/amazon/instance/builder.go#L246)

So add `ami_product_codes` to `amazon-ebs` and `amazon-chroot` builders to modify ami product code attribute when building.