### PR TITLE
Add a notice that Ansible needs to be already present on the target.

### DIFF
--- a/website/source/docs/provisioners/ansible-local.html.markdown
+++ b/website/source/docs/provisioners/ansible-local.html.markdown
@@ -18,6 +18,12 @@ uploaded from your local machine to the remote machine. Ansible is run in [local
 mode](http://docs.ansible.com/playbooks_delegation.html#local-playbooks) via the
 `ansible-playbook` command.
 
+-&gt; **Note:** Ansible will *not* be installed automatically by this
+provisioner. This provisioner expects that Ansible is already installed on the
+machine. It is common practice to use the [shell
+provisioner](/docs/provisioners/shell.html) before the Ansible provisioner to do
+this.
+
 ## Basic Example
 
 The example below is fully functional.


### PR DESCRIPTION
Like the `puppet-masterless` and `puppet-server` provisioners (and
unlike the `chef-solo` and `chef-client` provisioners), the
`ansible-local` currently requires Ansible to be present on the
provisioned image.

The relevant issue to add an install option to the provisioner is:
https://github.com/mitchellh/packer/issues/2010

Until then, a notice similar to the `puppet-masterless` and
`puppet-server` ones is added.