### PR TITLE
Added support of preemptible instance in googlecompute builder

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`
+	Preemptible          bool              `mapstructure:"preemptible"`
 	SourceImage          string            `mapstructure:"source_image"`
 	SourceImageProjectId string            `mapstructure:"source_image_project_id"`
 	RawStateTimeout      string            `mapstructure:"state_timeout"`

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -93,6 +93,21 @@ func TestConfigPrepare(t *testing.T) {
 			"SO VERY BAD",
 			true,
 		},
+		{
+			"preemptible",
+			nil,
+			false,
+		},
+		{
+			"preemptible",
+			false,
+			false,
+		},
+		{
+			"preemptible",
+			"SO VERY BAD",
+			true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -47,6 +47,7 @@ type InstanceConfig struct {
 	Metadata    map[string]string
 	Name        string
 	Network     string
+	Preemptible bool
 	Tags        []string
 	Zone        string
 }

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -255,6 +255,9 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 				Network: network.SelfLink,
 			},
 		},
+		Scheduling: &compute.Scheduling{
+			Preemptible: c.Preemptible,
+		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			&compute.ServiceAccount{
 				Email: "default",

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -59,6 +59,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Metadata:    config.getInstanceMetadata(sshPublicKey),
 		Name:        name,
 		Network:     config.Network,
+		Preemptible: config.Preemptible,
 		Tags:        config.Tags,
 		Zone:        config.Zone,
 	})

--- a/website/source/docs/builders/googlecompute.html.markdown
+++ b/website/source/docs/builders/googlecompute.html.markdown
@@ -144,6 +144,8 @@ builder.
 -   `use_internal_ip` (boolean) - If true, use the instance's internal IP
     instead of its external IP during building.
 
+-   `preemptible` (boolean) - If true, launch a preembtible instance.
+
 ## Gotchas
 
 Centos images have root ssh access disabled by default. Set `ssh_username` to


### PR DESCRIPTION
Launch a preemptible VM instance (https://cloud.google.com/compute/docs/instances/preemptible)
when `"preemptible": true` in googlecompute builder:

```
{
  "builders": [{
    "type": "googlecompute",
    ...(snip)...,
    "preemptible": true
  }],
  "provisioners":[{
    ...(snip)...
  }]
}
```

