### PR TITLE
Add support for using cloud-init via a ConfigDrive

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -88,6 +88,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone: b.config.AvailabilityZone,
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
+			ConfigDrive:      b.config.ConfigDrive,
 		},
 		&StepWaitForRackConnect{
 			Wait: b.config.RackconnectWait,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -25,6 +25,8 @@ type RunConfig struct {
 	UserData         string   `mapstructure:"user_data"`
 	UserDataFile     string   `mapstructure:"user_data_file"`
 
+	ConfigDrive bool `mapstructure:"config_drive"`
+
 	// Not really used, but here for BC
 	OpenstackProvider string `mapstructure:"openstack_provider"`
 	UseFloatingIp     bool   `mapstructure:"use_floating_ip"`

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -19,8 +19,8 @@ type StepRunSourceServer struct {
 	AvailabilityZone string
 	UserData         string
 	UserDataFile     string
-
-	server *servers.Server
+	ConfigDrive      bool
+	server           *servers.Server
 }
 
 func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction {
@@ -62,6 +62,7 @@ func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction
 			Networks:         networks,
 			AvailabilityZone: s.AvailabilityZone,
 			UserData:         userData,
+			ConfigDrive:      s.ConfigDrive,
 		},
 
 		KeyName: keyName,


### PR DESCRIPTION
@cbednarski can you review for me? :)

This adds support for using openstack's configdrive with cloud-init by passing the boolean for configdrive as described by http://docs.openstack.org/user-guide/cli_config_drive.html

Signed-off-by: Ian Duffy <ian@ianduffy.ie>