### PR TITLE
Return DigitalOcean image ID in output.

### DIFF
--- a/builder/digitalocean/artifact.go
+++ b/builder/digitalocean/artifact.go
@@ -36,7 +36,7 @@ func (a *Artifact) Id() string {
 }
 
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A snapshot was created: '%v' in region '%v'", a.snapshotName, a.regionName)
+	return fmt.Sprintf("A snapshot was created: '%v' (ID: %v) in region '%v'", a.snapshotName, a.snapshotId, a.regionName)
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/builder/digitalocean/artifact_test.go
+++ b/builder/digitalocean/artifact_test.go
@@ -25,7 +25,7 @@ func TestArtifactId(t *testing.T) {
 
 func TestArtifactString(t *testing.T) {
 	a := &Artifact{"packer-foobar", 42, "San Francisco", nil}
-	expected := "A snapshot was created: 'packer-foobar' in region 'San Francisco'"
+	expected := "A snapshot was created: 'packer-foobar' (ID: 42) in region 'San Francisco'"
 
 	if a.String() != expected {
 		t.Fatalf("artifact string should match: %v", expected)


### PR DESCRIPTION
In most instances, a user-generated DigitalOcean image needs to be referenced by its ID. With the DO API, there is no guarantee that an image's "name" is unique. This PR adds the image's ID to the output of successful builds. https://github.com/hashicorp/terraform/issues/4309 is an example of where this would be useful.