### PR TITLE
Make the OpenStack builder more informative

### DIFF
--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -45,7 +45,7 @@ func (s *stepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 	state.Put("image", imageId)
 
 	// Wait for the image to become ready
-	ui.Say("Waiting for image to become ready...")
+	ui.Say(fmt.Sprintf("Waiting for image %s (image id: %s) to become ready...", config.ImageName, imageId))
 	if err := WaitForImage(client, imageId); err != nil {
 		err := fmt.Errorf("Error waiting for image: %s", err)
 		state.Put("error", err)

--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -47,8 +47,8 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	ui.Say("Creating temporary keypair for this instance...")
 	keyName := fmt.Sprintf("packer %s", uuid.TimeOrderedUUID())
+	ui.Say(fmt.Sprintf("Creating temporary keypair: %s ...", keyName))
 	keypair, err := keypairs.Create(computeClient, keypairs.CreateOpts{
 		Name: keyName,
 	}).Extract()
@@ -61,6 +61,8 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 		state.Put("error", fmt.Errorf("The temporary keypair returned was blank"))
 		return multistep.ActionHalt
 	}
+
+	ui.Say(fmt.Sprintf("Created temporary keypair: %s", keyName))
 
 	// If we're in debug mode, output the private key to the working
 	// directory.
@@ -120,7 +122,7 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	ui.Say("Deleting temporary keypair...")
+	ui.Say(fmt.Sprintf("Deleting temporary keypair: %s ...", s.keyName))
 	err = keypairs.Delete(computeClient, s.keyName).ExtractErr()
 	if err != nil {
 		ui.Error(fmt.Sprintf(

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -113,7 +113,7 @@ func (s *StepRunSourceServer) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	ui.Say("Terminating the source server...")
+	ui.Say(fmt.Sprintf("Terminating the source server: %s ...", s.server.ID))
 	if err := servers.Delete(computeClient, s.server.ID).ExtractErr(); err != nil {
 		ui.Error(fmt.Sprintf("Error terminating server, may still be around: %s", err))
 		return

--- a/builder/openstack/step_stop_server.go
+++ b/builder/openstack/step_stop_server.go
@@ -31,14 +31,14 @@ func (s *StepStopServer) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	ui.Say("Stopping server...")
+	ui.Say(fmt.Sprintf("Stopping server: %s ...", server.ID))
 	if err := startstop.Stop(client, server.ID).ExtractErr(); err != nil {
 		err = fmt.Errorf("Error stopping server: %s", err)
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 
-	ui.Message("Waiting for server to stop...")
+	ui.Message(fmt.Sprintf("Waiting for server to stop: %s ...", server.ID))
 	stateChange := StateChangeConf{
 		Pending:   []string{"ACTIVE"},
 		Target:    []string{"SHUTOFF", "STOPPED"},


### PR DESCRIPTION
about the servers, images, and keypairs that it's dealing with.

so troubleshooting is as easy as possible