### PR TITLE
Added support for GCE external static IPs

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`
+	Address              string            `mapstructure:"address"`
 	Preemptible          bool              `mapstructure:"preemptible"`
 	SourceImage          string            `mapstructure:"source_image"`
 	SourceImageProjectId string            `mapstructure:"source_image_project_id"`

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -47,6 +47,7 @@ type InstanceConfig struct {
 	Metadata    map[string]string
 	Name        string
 	Network     string
+	Address     string
 	Preemptible bool
 	Tags        []string
 	Zone        string

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -59,6 +59,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Metadata:    config.getInstanceMetadata(sshPublicKey),
 		Name:        name,
 		Network:     config.Network,
+		Address:     config.Address,
 		Preemptible: config.Preemptible,
 		Tags:        config.Tags,
 		Zone:        config.Zone,

--- a/website/source/docs/builders/googlecompute.html.markdown
+++ b/website/source/docs/builders/googlecompute.html.markdown
@@ -118,6 +118,9 @@ builder.
     Not required if you run Packer on a GCE instance with a service account.
     Instructions for creating file or using service accounts are above.
 
+-   `address` (string) - The name of a pre-allocated static external IP address. 
+    Note, must be the name and not the actual IP address. 
+
 -   `disk_size` (integer) - The size of the disk in GB. This defaults to `10`,
     which is 10GB.
 


### PR DESCRIPTION
When working in environments with restricted access to the outside world, you usually have to whitelist allowed external IPs for ssh access. However, when using google compute engine, packer doesnt currently allow you to force it to use a particular IP so google compute engine will auto assign an ephemeral one (which is then blocked by the firewalls).  

In this PR I added support for using a predefined fixed external static IP.  To use the static IP rather than an ephemeral one configure the gce builder like so:
```
"builders": [
    {
    "type": "googlecompute",
    "account_file": "myaccount.json",
    "project_id": "myprojectid",
    "source_image": "debian-7-wheezy-v20150127",
    "zone": "us-central1-a",
    "image_name" : "packer-test",
    "address" : "packerip"
    }
  ],
``` 
where `packerip` is the *name* of the static ip you reserved before hand. Leaving out the "address" field will result in the current behavior. 

First contribution to a golang project, all feedback welcome.