### PR TITLE
openstack builder: Set image_type to "image"

### DIFF
--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -18,6 +18,17 @@ func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("An image_name must be specified"))
 	}
 
+	// By default, OpenStack seems to create the image with an image_type of
+	// "snapshot", since it came from snapshotting a VM. A "snapshot" looks
+	// slightly different in the OpenStack UI and OpenStack won't show "snapshot"
+	// images as a choice in the list of images to boot from for a new instance.
+	// See https://github.com/mitchellh/packer/issues/3038
+	if c.ImageMetadata == nil {
+		c.ImageMetadata = map[string]string{"image_type": "image"}
+	} else if c.ImageMetadata["image_type"] == "" {
+		c.ImageMetadata["image_type"] = "image"
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}


### PR DESCRIPTION
so that built images are treated as images and not as snapshots.

Fixes: GH-3038

```
$ bin/packer build -var flavor=default -var source_image=153f96dc-62b4-4a91-b49b-22079aa6bf6d packer.json
...
==> Builds finished. The artifacts of successful builds are:
--> openstack: An image was created: 16f98813-8bbc-4fc9-819d-8ec48ccaac4e

$ glance image-show 16f98813-8bbc-4fc9-819d-8ec48ccaac4e | egrep --color=none -- '---|Value|image_type'
+---------------------------------------+--------------------------------------+
| Property                              | Value                                |
+---------------------------------------+--------------------------------------+
| Property 'image_type'                 | image                                |
+---------------------------------------+--------------------------------------+
```