### PR TITLE
Updated Documentation - Now use t2.micro instead of t1.micro size

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -209,7 +209,7 @@ Here is a basic example. It is completely valid except for the access keys:
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
   "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}"
 }
@@ -238,7 +238,7 @@ the /dev/sdb and /dev/sdc block device mappings to the finished AMI.
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
   "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}",
   "ami_block_device_mappings": [
@@ -266,7 +266,7 @@ Here is an example using the optional AMI tags. This will add the tags
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
   "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}",
   "tags": {

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -89,7 +89,7 @@ you can also use `token` configuration option.
         "secret_key": "{{user `aws_secret_key`}}",
         "region": "us-east-1",
         "source_ami": "ami-de0d9eb7",
-        "instance_type": "t1.micro",
+        "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "atlas-example {{timestamp}}"
     }],

--- a/website/source/docs/templates/configuration-templates.html.markdown
+++ b/website/source/docs/templates/configuration-templates.html.markdown
@@ -199,7 +199,7 @@ Please note that double quote characters need escaping inside of templates:
       "secret_key": "...",
       "region": "us-east-1",
       "source_ami": "ami-de0d9eb7",
-      "instance_type": "t1.micro",
+      "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "packer {{isotime \"2006-01-02\"}}"
     }

--- a/website/source/docs/templates/introduction.html.markdown
+++ b/website/source/docs/templates/introduction.html.markdown
@@ -94,7 +94,7 @@ just missing valid AWS access keys. Otherwise, it would work properly with
       "secret_key": "...",
       "region": "us-east-1",
       "source_ami": "ami-de0d9eb7",
-      "instance_type": "t1.micro",
+      "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "packer {{timestamp}}"
     }

--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -58,7 +58,7 @@ briefly. Create a file `example.json` and fill it with the following contents:
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
     "source_ami": "ami-de0d9eb7",
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   }]

--- a/website/source/intro/getting-started/parallel-builds.html.markdown
+++ b/website/source/intro/getting-started/parallel-builds.html.markdown
@@ -96,7 +96,7 @@ The entire template should now look like this:
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
     "source_ami": "ami-de0d9eb7",
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   },{


### PR DESCRIPTION
Updated the documentation to reference using the t2.micro instance size instead of the t1.micro size. Per AWS, t1.micro size has been replaced by the t2.micro. The pricing is the same (i.g. still qualifies for the free tier). See: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts_micro_instances.html