### PR TITLE
Implement WinRM-over-HTTPS

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -26,8 +26,10 @@ type Communicator struct {
 // New creates a new communicator implementation over WinRM.
 func New(config *Config) (*Communicator, error) {
 	endpoint := &winrm.Endpoint{
-		Host: config.Host,
-		Port: config.Port,
+		Host:     config.Host,
+		Port:     config.Port,
+		HTTPS:    config.Https,
+		Insecure: config.Insecure,
 
 		/*
 			TODO
@@ -145,6 +147,8 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 			User:     c.config.Username,
 			Password: c.config.Password,
 		},
+		Https: c.config.Https,
+		Insecure: c.config.Insecure,
 		OperationTimeout:      c.config.Timeout,
 		MaxOperationsPerShell: 15, // lowest common denominator
 	})

--- a/communicator/winrm/config.go
+++ b/communicator/winrm/config.go
@@ -11,4 +11,6 @@ type Config struct {
 	Username string
 	Password string
 	Timeout  time.Duration
+	Https    bool
+	Insecure bool
 }

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	WinRMHost     string        `mapstructure:"winrm_host"`
 	WinRMPort     int           `mapstructure:"winrm_port"`
 	WinRMTimeout  time.Duration `mapstructure:"winrm_timeout"`
+	WinRMUseSSL   bool          `mapstructure:"winrm_use_ssl"`
+	WinRMInsecure bool          `mapstructure:"winrm_insecure"`
 }
 
 // Port returns the port that will be used for access based on config.

--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -129,6 +129,8 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 			Username: user,
 			Password: password,
 			Timeout:  s.Config.WinRMTimeout,
+			Https:    s.Config.WinRMUseSSL,
+			Insecure: s.Config.WinRMInsecure,
 		})
 		if err != nil {
 			log.Printf("[ERROR] WinRM connection err: %s", err)

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -111,3 +111,8 @@ The WinRM communicator has the following options.
   * `winrm_timeout` (string) - The amount of time to wait for WinRM to
     become available. This defaults to "30m" since setting up a Windows
     machine generally takes a long time.
+
+  * `winrm_use_ssl` (boolean) - If true, use HTTPS for WinRM
+
+  * `winrm_insecure` (boolean) - If true, do not check server certificate
+    chain and host name


### PR DESCRIPTION
This is allowing me to select HTTP or HTTPS for my WinRM communication.  See https://gist.github.com/goodwinb99/8f631f261bd62567b15d for setting up the Windows host for WinRM over SSL