### PR TITLE
Add required DescribeSubnets IAM permission

### DIFF
--- a/website/source/docs/builders/amazon.html.markdown
+++ b/website/source/docs/builders/amazon.html.markdown
@@ -97,6 +97,7 @@ Packer to work:
         "ec2:DeleteVolume",
         "ec2:CreateKeypair",
         "ec2:DeleteKeypair",
+        "ec2:DescribeSubnets",
         "ec2:CreateSecurityGroup",
         "ec2:DeleteSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",


### PR DESCRIPTION
From https://github.com/mitchellh/packer/pull/3037, building an AMI now requires DescribeSubnets so we should document that.