### PR TITLE
Update docs to reflect current AMI IDs and instance sizes

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -208,8 +208,8 @@ Here is a basic example. It is completely valid except for the access keys:
   "access_key": "YOUR KEY HERE",
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
-  "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "source_ami": "ami-72b9e018",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}"
 }
@@ -237,8 +237,8 @@ the /dev/sdb and /dev/sdc block device mappings to the finished AMI.
   "access_key": "YOUR KEY HERE",
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
-  "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "source_ami": "ami-72b9e018",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}",
   "ami_block_device_mappings": [
@@ -265,8 +265,8 @@ Here is an example using the optional AMI tags. This will add the tags
   "access_key": "YOUR KEY HERE",
   "secret_key": "YOUR SECRET KEY HERE",
   "region": "us-east-1",
-  "source_ami": "ami-de0d9eb7",
-  "instance_type": "t1.micro",
+  "source_ami": "ami-72b9e018",
+  "instance_type": "t2.micro",
   "ssh_username": "ubuntu",
   "ami_name": "packer-quick-start {{timestamp}}",
   "tags": {

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -88,8 +88,8 @@ you can also use `token` configuration option.
         "access_key": "{{user `aws_access_key`}}",
         "secret_key": "{{user `aws_secret_key`}}",
         "region": "us-east-1",
-        "source_ami": "ami-de0d9eb7",
-        "instance_type": "t1.micro",
+        "source_ami": "ami-72b9e018",
+        "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "atlas-example {{timestamp}}"
     }],

--- a/website/source/docs/templates/configuration-templates.html.markdown
+++ b/website/source/docs/templates/configuration-templates.html.markdown
@@ -198,8 +198,8 @@ Please note that double quote characters need escaping inside of templates:
       "access_key": "...",
       "secret_key": "...",
       "region": "us-east-1",
-      "source_ami": "ami-de0d9eb7",
-      "instance_type": "t1.micro",
+      "source_ami": "ami-72b9e018",
+      "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "packer {{isotime \"2006-01-02\"}}"
     }

--- a/website/source/docs/templates/introduction.html.markdown
+++ b/website/source/docs/templates/introduction.html.markdown
@@ -93,8 +93,8 @@ just missing valid AWS access keys. Otherwise, it would work properly with
       "access_key": "...",
       "secret_key": "...",
       "region": "us-east-1",
-      "source_ami": "ami-de0d9eb7",
-      "instance_type": "t1.micro",
+      "source_ami": "ami-72b9e018",
+      "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "packer {{timestamp}}"
     }

--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -57,8 +57,8 @@ briefly. Create a file `example.json` and fill it with the following contents:
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-de0d9eb7",
-    "instance_type": "t1.micro",
+    "source_ami": "ami-72b9e018",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   }]

--- a/website/source/intro/getting-started/parallel-builds.html.markdown
+++ b/website/source/intro/getting-started/parallel-builds.html.markdown
@@ -95,8 +95,8 @@ The entire template should now look like this:
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-de0d9eb7",
-    "instance_type": "t1.micro",
+    "source_ami": "ami-72b9e018",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   },{


### PR DESCRIPTION
- Using Ubuntu-supported image, 14.04 LTS current, for us-east-1
- t1.micro no longer exists, t2.micro replaces it
- Raised in issue #3052