### PR TITLE
Pass the vmName as hostname to qemu

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -75,7 +75,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 
 	defaultArgs["-name"] = vmName
 	defaultArgs["-machine"] = fmt.Sprintf("type=%s", config.MachineType)
-	defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:%d", sshHostPort, config.Comm.Port())
+	defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:%d,hostname=%s", sshHostPort, config.Comm.Port(), vmName)
 
 	qemuVersion, err := driver.Version()
 	if err != nil {


### PR DESCRIPTION
Pass the vmName as hostname to qemu, so that qemu's DHCP server will pass it to the VM

This fixes Solaris10's hostname being determined to be "unknown"