### PR TITLE
command/push: Fix variable pushes to Atlas

### DIFF
--- a/command/push_test.go
+++ b/command/push_test.go
@@ -204,8 +204,10 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	args := []string{
+		"-var-file", filepath.Join(testFixture("push-vars"), "vars.json"),
 		"-var", "name=foo/bar",
 		"-var", "one=two",
+		"-var", "overridden=yes",
 		filepath.Join(testFixture("push-vars"), "template.json"),
 	}
 	if code := c.Run(args); code != 0 {
@@ -217,8 +219,11 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"name": "foo/bar",
-		"one":  "two",
+		"bar":        "baz",
+		"name":       "foo/bar",
+		"null":       "",
+		"one":        "two",
+		"overridden": "yes",
 	}
 	if !reflect.DeepEqual(actualOpts.Vars, expected) {
 		t.Fatalf("bad: %#v", actualOpts.Vars)

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -205,15 +205,23 @@ func TestPush_vars(t *testing.T) {
 
 	args := []string{
 		"-var", "name=foo/bar",
+		"-var", "one=two",
 		filepath.Join(testFixture("push-vars"), "template.json"),
 	}
 	if code := c.Run(args); code != 0 {
 		fatalCommand(t, c.Meta)
 	}
 
-	expected := "foo/bar"
-	if actualOpts.Slug != expected {
+	if actualOpts.Slug != "foo/bar" {
 		t.Fatalf("bad: %#v", actualOpts.Slug)
+	}
+
+	expected := map[string]string{
+		"name": "foo/bar",
+		"one":  "two",
+	}
+	if !reflect.DeepEqual(actualOpts.Vars, expected) {
+		t.Fatalf("bad: %#v", actualOpts.Vars)
 	}
 }
 

--- a/command/test-fixtures/push-vars/vars.json
+++ b/command/test-fixtures/push-vars/vars.json
@@ -1,0 +1,5 @@
+{
+  "null": null,
+  "bar": "baz",
+  "overridden": "no"
+}

--- a/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
@@ -126,7 +126,7 @@ func (c *Client) CreateBuildConfig(user, name string) (*BuildConfig, error) {
 //
 // Actual API: "Create Build Config Version"
 func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[string]interface{},
-	data io.Reader, size int64) error {
+	vars map[string]string, data io.Reader, size int64) error {
 
 	log.Printf("[INFO] uploading build configuration version %s (%d bytes), with metadata %q",
 		v.Slug(), size, metadata)
@@ -137,6 +137,7 @@ func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[st
 	var bodyData bcCreateWrapper
 	bodyData.Version.Builds = v.Builds
 	bodyData.Version.Metadata = metadata
+	bodyData.Version.Vars = vars
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return err
@@ -179,5 +180,6 @@ type bcCreateWrapper struct {
 	Version struct {
 		Metadata map[string]interface{} `json:"metadata,omitempty"`
 		Builds   []BuildConfigBuild     `json:"builds"`
+		Vars     map[string]string      `json:"vars,omitempty"`
 	} `json:"version"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -342,15 +342,15 @@
 			"checksumSHA1": "FUiF2WLrih0JdHsUTMMDz3DRokw=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/archive",
-			"revision": "a32da833807becb5b150e125c859e01b707e74ca",
-			"revisionTime": "2016-10-12T21:43:57Z"
+			"revision": "c1efcbcec751e3dd01d7078099451db31cbf0d24",
+			"revisionTime": "2016-10-31T14:24:30Z"
 		},
 		{
-			"checksumSHA1": "aD7uHoVmfg2T9mpnVZ5dWe6rGtY=",
+			"checksumSHA1": "sgpnQTQ+dITho0EmAoBukxw7eG4=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/v1",
-			"revision": "a32da833807becb5b150e125c859e01b707e74ca",
-			"revisionTime": "2016-10-12T21:43:57Z"
+			"revision": "c1efcbcec751e3dd01d7078099451db31cbf0d24",
+			"revisionTime": "2016-10-31T14:24:30Z"
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",


### PR DESCRIPTION
This parses `-var` and `-var-file` CLI arguments when using `packer push`. The behavior is the same as `packer build`.

These will be ignored in Atlas until implemented there as well (but should not break pushes in the meantime).

Requires https://github.com/hashicorp/atlas-go/pull/48
