### PR TITLE
amazon chroot_mounts should append instead of replace per docs

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -66,23 +66,21 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
-	// Defaults
 	if b.config.ChrootMounts == nil {
 		b.config.ChrootMounts = make([][]string, 0)
 	}
 
+	// Add Defaults
+	b.config.ChrootMounts = append(b.config.ChrootMounts,
+		[]string{"proc", "proc", "/proc"},
+		[]string{"sysfs", "sysfs", "/sys"},
+		[]string{"bind", "/dev", "/dev"},
+		[]string{"devpts", "devpts", "/dev/pts"},
+		[]string{"binfmt_misc", "binfmt_misc", "/proc/sys/fs/binfmt_misc"},
+	)
+
 	if b.config.CopyFiles == nil {
 		b.config.CopyFiles = make([]string, 0)
-	}
-
-	if len(b.config.ChrootMounts) == 0 {
-		b.config.ChrootMounts = [][]string{
-			[]string{"proc", "proc", "/proc"},
-			[]string{"sysfs", "sysfs", "/sys"},
-			[]string{"bind", "/dev", "/dev"},
-			[]string{"devpts", "devpts", "/dev/pts"},
-			[]string{"binfmt_misc", "binfmt_misc", "/proc/sys/fs/binfmt_misc"},
-		}
 	}
 
 	if len(b.config.CopyFiles) == 0 {

--- a/builder/amazon/chroot/builder_test.go
+++ b/builder/amazon/chroot/builder_test.go
@@ -80,7 +80,22 @@ func TestBuilderPrepare_ChrootMounts(t *testing.T) {
 	if err == nil {
 		t.Fatal("should have error")
 	}
+
+	config["chroot_mounts"] = [][]string{
+		[]string{"tmpfs", "tmpfs", "/dev/shm"},
+	}
+	warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Errorf("err: %s", err)
+	}
+	if len(b.config.ChrootMounts) != 6 {
+		t.Errorf("defaults not added to chroot_mounts")
+	}
 }
+
 func TestBuilderPrepare_SourceAmi(t *testing.T) {
 	b := &Builder{}
 	config := testConfig()


### PR DESCRIPTION
Per the Packer docs (https://www.packer.io/docs/builders/amazon-chroot.html): 
> chroot_mounts (array of array of strings) - This is a list of additional devices to mount into the chroot environment. 

Passing in chroot_mounts overrides all defaults, so this PR changes the code to match the docs. 

I can see the flexibility argument of keeping the packer code as-is, but in that case the docs should be updated to reflect the behavior of ```chroot_mounts```.