### PR TITLE
builder/googlecompute: fix image name defaults

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -81,6 +81,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("Unable to parse image name: %s ", err))
+		} else {
 			c.ImageName = img
 		}
 	}

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -160,6 +160,9 @@ func TestConfigDefaults(t *testing.T) {
 
 func TestImageName(t *testing.T) {
 	c, _, _ := NewConfig(testConfig(t))
+	if !strings.HasPrefix(c.ImageName, "packer-") {
+		t.Fatalf("ImageName should have 'packer-' prefix, found %s", c.ImageName)
+	}
 	if strings.Contains(c.ImageName, "{{timestamp}}") {
 		t.Errorf("ImageName should be interpolated; found %s", c.ImageName)
 	}


### PR DESCRIPTION
Fix default image name for GCE, add test to verify.

Related:
#2408
1c71eaaa91cf43f24eac59d412907c0bcd58cc37