### PR TITLE
openstack: Allow customizing poll delay

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -89,6 +89,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
 			ConfigDrive:      b.config.ConfigDrive,
+			PollDelay:        b.config.PollDelay,
 		},
 		&StepWaitForRackConnect{
 			Wait: b.config.RackconnectWait,
@@ -105,7 +106,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHConfig: SSHConfig(b.config.RunConfig.Comm.SSHUsername),
 		},
 		&common.StepProvision{},
-		&StepStopServer{},
+		&StepStopServer{
+			PollDelay: b.config.PollDelay,
+		},
 		&stepCreateImage{},
 	}
 

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"errors"
+	"time"
 
 	"github.com/mitchellh/packer/helper/communicator"
 	"github.com/mitchellh/packer/template/interpolate"
@@ -14,16 +15,17 @@ type RunConfig struct {
 	SSHKeyPairName string              `mapstructure:"ssh_keypair_name"`
 	SSHInterface   string              `mapstructure:"ssh_interface"`
 
-	SourceImage      string   `mapstructure:"source_image"`
-	Flavor           string   `mapstructure:"flavor"`
-	AvailabilityZone string   `mapstructure:"availability_zone"`
-	RackconnectWait  bool     `mapstructure:"rackconnect_wait"`
-	FloatingIpPool   string   `mapstructure:"floating_ip_pool"`
-	FloatingIp       string   `mapstructure:"floating_ip"`
-	SecurityGroups   []string `mapstructure:"security_groups"`
-	Networks         []string `mapstructure:"networks"`
-	UserData         string   `mapstructure:"user_data"`
-	UserDataFile     string   `mapstructure:"user_data_file"`
+	SourceImage      string        `mapstructure:"source_image"`
+	Flavor           string        `mapstructure:"flavor"`
+	AvailabilityZone string        `mapstructure:"availability_zone"`
+	RackconnectWait  bool          `mapstructure:"rackconnect_wait"`
+	FloatingIpPool   string        `mapstructure:"floating_ip_pool"`
+	FloatingIp       string        `mapstructure:"floating_ip"`
+	SecurityGroups   []string      `mapstructure:"security_groups"`
+	Networks         []string      `mapstructure:"networks"`
+	UserData         string        `mapstructure:"user_data"`
+	UserDataFile     string        `mapstructure:"user_data_file"`
+	PollDelay        time.Duration `mapstructure:"poll_delay"`
 
 	ConfigDrive bool `mapstructure:"config_drive"`
 
@@ -40,6 +42,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.UseFloatingIp && c.FloatingIpPool == "" {
 		c.FloatingIpPool = "public"
+	}
+
+	if c.PollDelay == 0 {
+		c.PollDelay = 2 * time.Second
 	}
 
 	// Validation

--- a/builder/openstack/server.go
+++ b/builder/openstack/server.go
@@ -54,7 +54,7 @@ func ServerStateRefreshFunc(
 
 // WaitForState watches an object and waits for it to achieve a certain
 // state.
-func WaitForState(conf *StateChangeConf) (i interface{}, err error) {
+func WaitForState(conf *StateChangeConf, sleepDuration time.Duration) (i interface{}, err error) {
 	log.Printf("Waiting for state to become: %s", conf.Target)
 
 	for {
@@ -90,6 +90,6 @@ func WaitForState(conf *StateChangeConf) (i interface{}, err error) {
 		}
 
 		log.Printf("Waiting for state to become: %s currently %s (%d%%)", conf.Target, currentState, currentProgress)
-		time.Sleep(2 * time.Second)
+		time.Sleep(sleepDuration)
 	}
 }

--- a/builder/openstack/step_stop_server.go
+++ b/builder/openstack/step_stop_server.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
@@ -9,7 +10,9 @@ import (
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 )
 
-type StepStopServer struct{}
+type StepStopServer struct {
+	PollDelay time.Duration
+}
 
 func (s *StepStopServer) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
@@ -45,7 +48,7 @@ func (s *StepStopServer) Run(state multistep.StateBag) multistep.StepAction {
 		Refresh:   ServerStateRefreshFunc(client, server),
 		StepState: state,
 	}
-	if _, err := WaitForState(&stateChange); err != nil {
+	if _, err := WaitForState(&stateChange, s.PollDelay); err != nil {
 		err := fmt.Errorf("Error waiting for server (%s) to stop: %s", server.ID, err)
 		state.Put("error", err)
 		ui.Error(err.Error())


### PR DESCRIPTION
Allows customizing the polling delay - the delay between iterations of checking the status of the server.

e.g.:

    "poll_delay": "4s"

instead of hard-coding to 2 seconds.

I wanted this because I often hit a problem with one of our OpenStack clouds where the server status request succeeds a bunch of times and then there is a request that never gets a response. I want to test the theory that maybe this is because the repeated requests are somehow triggering the problem. E.g.: see https://github.com/mitchellh/packer/issues/3010 -- I would do this by setting the `poll_delay` larger so that packer does less status requests to Nova -- my hope is that might not fail if less status checks are done.

```
$ packer build -var flavor=default -var source_image=153f96dc-62b4-4a91-b49b-22079aa6bf6d packer.json
openstack output will be in this color.

==> openstack: Discovering enabled extensions...
==> openstack: Loading flavor: default
    openstack: Verified flavor. ID: e3e6120f-3297-468f-9232-d46e5d92f67d
==> openstack: Creating temporary keypair: packer 56a1c7b7-aef3-127a-08eb-88eff8c8b8fd ...
==> openstack: Created temporary keypair: packer 56a1c7b7-aef3-127a-08eb-88eff8c8b8fd
==> openstack: Launching server...
    openstack: Server ID: bda1c893-0036-4db9-a6c2-44ca2e6d11d9
==> openstack: Waiting for server to become ready (PollDelay = 4s)...
...
```

Note `PollDelay = 4s` in output above.