### PR TITLE
qemu: allow to use live iso without cache

### DIFF
--- a/builder/qemu/step_set_iso.go
+++ b/builder/qemu/step_set_iso.go
@@ -1,0 +1,56 @@
+package qemu
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step set iso_patch to available url
+type stepSetISO struct {
+	ResultKey string
+	Url       []string
+}
+
+func (s *stepSetISO) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+
+	iso_path := ""
+
+	for _, url := range s.Url {
+		req, err := http.NewRequest("HEAD", url, nil)
+		if err != nil {
+			continue
+		}
+
+		req.Header.Set("User-Agent", "Packer")
+
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+			},
+		}
+
+		res, err := httpClient.Do(req)
+		if err == nil && (res.StatusCode >= 200 && res.StatusCode < 300) {
+			if res.Header.Get("Accept-Ranges") == "bytes" {
+				iso_path = url
+			}
+		}
+	}
+
+	if iso_path == "" {
+		err := fmt.Errorf("No byte serving support. The HTTP server must support Accept-Ranges=bytes")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	state.Put(s.ResultKey, iso_path)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepSetISO) Cleanup(state multistep.StateBag) {}

--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -173,10 +173,13 @@ builder.
     to force the HTTP server to be on one port, make this minimum and maximum
     port the same. By default the values are 8000 and 9000, respectively.
 
+-   `iso_skip_cache` (boolean) - Use iso from provided url. Qemu must support
+    curl block device.
+
 -   `iso_target_path` (string) - The path where the iso should be saved after
     download. By default will go in the packer cache, with a hash of the
     original filename as its name.
-      
+
 -   `iso_urls` (array of strings) - Multiple URLs for the ISO to download.
     Packer will try these in order. If anything goes wrong attempting to
     download or while downloading a single URL, it will move on to the next. All


### PR DESCRIPTION
qemu allows to use iso via curl, so packer does not need to cache it.
Sometimes this is very useful in case reliable network, because it speedup packer build.
Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>