### PR TITLE
vsphere post-processor.go - support for spaces

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -122,11 +122,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	args := []string{
 		fmt.Sprintf("--noSSLVerify=%t", p.config.Insecure),
 		"--acceptAllEulas",
-		fmt.Sprintf("--name=%s", p.config.VMName),
-		fmt.Sprintf("--datastore=%s", p.config.Datastore),
-		fmt.Sprintf("--diskMode=%s", p.config.DiskMode),
-		fmt.Sprintf("--network=%s", p.config.VMNetwork),
-		fmt.Sprintf("--vmFolder=%s", p.config.VMFolder),
+		fmt.Sprintf("--name=\"%s\"", p.config.VMName),
+		fmt.Sprintf("--datastore=\"%s\"", p.config.Datastore),
+		fmt.Sprintf("--diskMode=\"%s\"", p.config.DiskMode),
+		fmt.Sprintf("--network=\"%s\"", p.config.VMNetwork),
+		fmt.Sprintf("--vmFolder=\"%s\"", p.config.VMFolder),
 		fmt.Sprintf("%s", source),
 		fmt.Sprintf("%s", ovftool_uri),
 	}


### PR DESCRIPTION
Added support for spaces in vm folders, datastore names etc. in the ovftool command line arguments.