### PR TITLE
provisioner/file: Use go-getter to allow for remote files

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -115,19 +115,19 @@ func (p *Provisioner) ProvisionUpload(ui packer.Ui, comm packer.Communicator) er
 	}
 
 	if len(det) == 0 {
-		return fmt.Errorf("Didn't recognise the source type")
+		return errors.New("Don't recognise the source type")
 	}
 
 	dir, err := ioutil.TempDir("", "packer")
 	if err != nil {
-		return fmt.Errorf("Unable to create temp dir")
+		return errors.New("Unable to create temp dir")
 	}
 
 	defer os.RemoveAll(dir)
 
 	source := filepath.Join(dir, filepath.Base(p.config.Source))
 	if err := gg.GetFile(source, p.config.Source); err != nil {
-		return fmt.Errorf("Some error: %v", err)
+		return fmt.Errorf("There was a problem getting the file: %v", err)
 	}
 
 	// We're uploading a file...

--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -57,13 +57,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			errors.New("Direction must be one of: download, upload."))
 	}
 
-	// if p.config.Direction == "upload" {
-	// 	if _, err := os.Stat(p.config.Source); err != nil {
-	// 		errs = packer.MultiErrorAppend(errs,
-	// 			fmt.Errorf("Bad source '%s': %s", p.config.Source, err))
-	// 	}
-	// }
-
 	if p.config.Destination == "" {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Destination must be specified."))

--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -34,17 +34,6 @@ func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	}
 }
 
-func TestProvisionerPrepare_InvalidSource(t *testing.T) {
-	var p Provisioner
-	config := testConfig()
-	config["source"] = "/this/should/not/exist"
-
-	err := p.Prepare(config)
-	if err == nil {
-		t.Fatalf("should require existing file")
-	}
-}
-
 func TestProvisionerPrepare_ValidSource(t *testing.T) {
 	var p Provisioner
 


### PR DESCRIPTION
I've replaced parts of provisioner/file to allow go-getter to be used. 

This allows users to specify remote files to be sent to builds.