### PR TITLE
OpenStack: Update documentation, fixes GH-2701

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -43,6 +43,10 @@ builder.
 
 -   `image_name` (string) - The name of the resulting image.
 
+-   `identity_endpoint` (string) - The URL to the OpenStack Identity service.
+    If not specified, Packer will use the environment variables `OS_AUTH_URL`,
+    if set.
+
 -   `source_image` (string) - The ID or full URL to the base image to use. This
     is the image that will be used to launch a new server and provision it.
     Unless you specify completely custom SSH settings, the source image must
@@ -52,9 +56,9 @@ builder.
     is an alternative way of providing `source_image` and only either of them
     can be specified.
 
--   `username` (string) - The username used to connect to the OpenStack service.
-    If not specified, Packer will use the environment variable `OS_USERNAME`,
-    if set.
+-   `username` or `user_id` (string) - The username or id used to connect to
+    the OpenStack service. If not specified, Packer will use the environment
+    variable `OS_USERNAME` or `OS_USERID`, if set.
 
 -   `password` (string) - The password used to connect to the OpenStack service.
     If not specified, Packer will use the environment variables `OS_PASSWORD`,
@@ -69,12 +73,14 @@ builder.
     server in. If this isn't specified, the default enforced by your OpenStack
     cluster will be used. This may be required for some OpenStack clusters.
 
+-   `endpoint_type` (string) - The endpoint type to use. Can be any of "internal",
+    "internalURL", "admin", "adminURL", "public", and "publicURL". By default
+    this is "public".
+
 -   `floating_ip` (string) - A specific floating IP to assign to this instance.
-    `use_floating_ip` must also be set to true for this to have an affect.
 
 -   `floating_ip_pool` (string) - The name of the floating IP pool to use to
-    allocate a floating IP. `use_floating_ip` must also be set to true for this
-    to have an affect.
+    allocate a floating IP.
 
 -   `insecure` (boolean) - Whether or not the connection to OpenStack can be
     done over an insecure connection. By default this is false.
@@ -84,9 +90,10 @@ builder.
 
 -   `tenant_id` or `tenant_name` (string) - The tenant ID or name to boot the
     instance into. Some OpenStack installations require this. If not specified,
-    Packer will use the environment variable `OS_TENANT_NAME`, if set.
+    Packer will use the environment variable `OS_TENANT_NAME`, if set. Tenant
+    is also called Project in later versions of OpenStack.
 
--   `domain_name` or `domain_id` (string) - The Domain name or ID you are 
+-   `domain_name` or `domain_id` (string) - The Domain name or ID you are
     authenticating with. OpenStack installations require this if identity v3 is used.
     Packer will use the environment variable `OS_DOMAIN_NAME` or `OS_DOMAIN_ID`, if set.
 
@@ -101,8 +108,14 @@ builder.
     useful for Rackspace are "public" or "private", and the default behavior is
     to connect via whichever is returned first from the OpenStack API.
 
--   `use_floating_ip` (boolean) - Whether or not to use a floating IP for
-    the instance. Defaults to false.
+-   `ssh_keypair_name` (string) - If specified, this is the key that will be
+    used for SSH with the machine. By default, this is blank, and Packer will
+    generate a temporary keypair.
+    [`ssh_private_key_file`](docs/templates/communicator.html#ssh_private_key_file)
+    must be specified with this.
+
+-   `use_floating_ip` (boolean) - _Deprecated_ use `floating_ip` or `floating_ip_pool`
+    instead.
 
 -   `rackconnect_wait` (boolean) - For rackspace, whether or not to wait for
     Rackconnect to assign the machine an IP address before connecting via SSH.
@@ -111,8 +124,37 @@ builder.
 -   `metadata` (object of key/value strings) - Glance metadata that will be
     applied to the image.
 
+-   `user_data` (string) - User data to apply when launching the instance. Note
+    that you need to be careful about escaping characters due to the templates
+    being JSON. It is often more convenient to use `user_data_file`, instead.
+
+-   `user_data_file` (string) - Path to a file that will be used for the user
+    data when launching the instance.
+
 -   `config_drive` (boolean) - Whether or not nova should use ConfigDrive for
      cloud-init metadata.
+
+## Basic Example: DevStack
+
+Here is a basic example. This is a example to build on DevStack running in a VM.
+
+``` {.javascript}
+{
+  "type": "openstack",
+  "identity_endpoint": "http://<destack-ip>:5000/v3",
+  "tenant_name": "admin",
+  "domain_name": "Default",
+  "username": "admin",
+  "password": "<your admin password>",
+  "region": "RegionOne",
+  "ssh_username": "root",
+  "image_name": "Test image",
+  "source_image": "<image id>",
+  "flavor": "m1.tiny",
+  "insecure": "true"
+}
+
+```
 
 ## Basic Example: Rackspace public cloud
 
@@ -165,9 +207,9 @@ This is slightly different when identity v3 is used:
 -   `OS_DOMAIN_NAME`
 -   `OS_TENANT_NAME`
 
-This will authenticate the user on the domain and scope you to the project. 
-A tenant is the same as a project. It's optional to use names or IDs in v3. 
-This means you can use `OS_USERNAME` or `OS_USERID`,  `OS_TENANT_ID` or 
+This will authenticate the user on the domain and scope you to the project.
+A tenant is the same as a project. It's optional to use names or IDs in v3.
+This means you can use `OS_USERNAME` or `OS_USERID`,  `OS_TENANT_ID` or
 `OS_TENANT_NAME` and `OS_DOMAIN_ID` or `OS_DOMAIN_NAME`.
 
 The above example would be equivalent to an RC file looking like this :
@@ -177,3 +219,18 @@ The above example would be equivalent to an RC file looking like this :
     export OS_PASSWORD="password"
     export OS_USER_DOMAIN_NAME="mydomain"
     export OS_PROJECT_DOMAIN_NAME="mydomain"
+
+## Notes on OpenStack Authorization
+
+The simplest way to get all settings for authorization agains OpenStack is to
+go into the OpenStack Dashboard (Horizon) select your _Project_ and navigate
+_Project, Access & Security_, select _API Access_ and _Download OpenStack RC
+File v3_. Source the file, and select your wanted region by setting
+environment variable `OS_REGION_NAME` or `OS_REGION_ID` and `export
+OS_TENANT_NAME=$OS_PROJECT_NAME` or `export OS_TENANT_ID=$OS_PROJECT_ID`.
+
+\~&gt; `OS_TENANT_NAME` or `OS_TENANT_ID` must be used even with Identity v3,
+`OS_PROJECT_NAME` and `OS_PROJECT_ID` has no effect in Packer.
+
+To troubleshoot authorization issues test you environment variables with the
+OpenStack cli. It can be installed with ```pip install --user openstack```.


### PR DESCRIPTION
Added documentation for:
 - identity_endpoint
 - user_id
 - OS_USERID
 - endpoint_type
 - ssh_keypair_name
 - user_data
 - user_data_file

Improved documentation for:
 - floating_ip
 - OS_TENANT_NAME
 - use_floating_ip

Added a DevStack exmaple and some notes about OpenStack authorization
and how to get started with a correct setup.