### PR TITLE
Fix net virtio default and reorder qemu builder options

### DIFF
--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -120,6 +120,9 @@ builder.
     include any of "writethrough", "writeback", "none", "unsafe"
     or "directsync". By default, this is set to "writeback".
 
+-   `disk_compression` (boolean) - Apply compression to the QCOW2 disk file
+    using `qemu-img convert`. Defaults to `false`.
+
 -   `disk_discard` (string) - The discard mode to use for disk. Allowed values
     include any of "unmap" or "ignore". By default, this is set to "ignore".
 
@@ -135,12 +138,6 @@ builder.
 
 -   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
-
--   `skip_compaction` (boolean) - Packer compacts the QCOW2 image using `qemu-img convert`.
-    Set this option to `true` to disable compacting. Defaults to `false`.
-
--   `disk_compression` (boolean) - Apply compression to the QCOW2 disk file
-    using `qemu-img convert`. Defaults to `false`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
@@ -192,7 +189,7 @@ builder.
 
 -   `net_device` (string) - The driver to use for the network interface. Allowed
     values "ne2k\_pci," "i82551," "i82557b," "i82559er," "rtl8139," "e1000,"
-    "pcnet" or "virtio." The Qemu builder uses "virtio" by default.
+    "pcnet" or "virtio-net." The Qemu builder uses "virtio-net" by default.
 
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
@@ -251,6 +248,9 @@ builder and not otherwise conflicting with the qemuargs):
     `shutdown_command` for the virtual machine to actually shut down. If it
     doesn't shut down in this time, it is an error. By default, the timeout is
     "5m", or five minutes.
+
+-   `skip_compaction` (boolean) - Packer compacts the QCOW2 image using `qemu-img convert`.
+    Set this option to `true` to disable compacting. Defaults to `false`.
 
 -   `ssh_host_port_min` and `ssh_host_port_max` (integer) - The minimum and
     maximum port to use for the SSH port on the host machine which is forwarded


### PR DESCRIPTION
Correct the valid options for net_device.  Also put the qemu builder disk_compression and skip_compaction options in the same order as ```packer fix```.