### PR TITLE
Add chmod to chef-solo provisioner

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -422,6 +422,15 @@ func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir stri
 		return fmt.Errorf("Non-zero exit status. See output above for more info.")
 	}
 
+	// Chmod the directory to 0777 just so that we can access it as our user
+	cmd = &packer.RemoteCmd{Command: p.guestCommands.Chmod(dir, "0777")}
+	if err := cmd.StartWithUi(comm, ui); err != nil {
+		return err
+	}
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf("Non-zero exit status. See output above for more info.")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
I'm using chef-client without chef-server. (`chef-client -z`)

Current master branch, An error has become to occur in the following configuration that has been used until now.
But there was no problem in v0.8.6.

```json
{
	"provisioners": [
		{
			"type":              "chef-solo",
			"chef_environment":  "{{user `chef_environment`}}",
			"config_template":   "{{user `chef_config_template`}}",
			"environments_path": "{{user `chef_environments_path`}}",
			"roles_path":        "{{user `chef_roles_path`}}",
			"execute_command":   "{{if .Sudo}}sudo {{end}}chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
			"cookbook_paths": [
				"..."
			],
			"run_list": [
				"..."
			]
		}
	]
}
```

```
    amazon-ebs: Installing chef
    amazon-ebs: installing with rpm...
    amazon-ebs: warning: /tmp/install.sh.2455/chef-12.6.0-1.el6.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
    amazon-ebs: warning: waiting for transaction lock on /var/lib/rpm/.rpm.lock
    amazon-ebs: Preparing...                          ################################# [100%]
    amazon-ebs: Updating / installing...
    amazon-ebs: 1:chef-12.6.0-1.el6                ################################# [100%]
    amazon-ebs: Thank you for installing Chef!
    amazon-ebs: Creating directory: /tmp/packer-chef-client
    amazon-ebs: Creating directory: /tmp/packer-chef-client/cookbooks-0
==> amazon-ebs: Cancelling the spot request...
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: No AMIs to cleanup
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Error uploading cookbooks: scp: /tmp/packer-chef-client/cookbooks-0/apt: Permission denied

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error uploading cookbooks: scp: /tmp/packer-chef-client/cookbooks-0/apt: Permission denied

==> Builds finished but no artifacts were created.
```

This pull request is the same as that performed in the chef-client provisioner.
https://github.com/mitchellh/packer/blob/a36a9bf53d9dc9f3dad751779c1ba449c9d85f85/provisioner/chef-client/provisioner.go#L448-L455
