### PR TITLE
Display better error messages on json.SyntaxError

### DIFF
--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -356,9 +356,9 @@ func TestParse_bad(t *testing.T) {
 		File     string
 		Expected string
 	}{
-		{"error-beginning.json", "line 1, char 1"},
-		{"error-middle.json", "line 5, char 5"},
-		{"error-end.json", "line 1, char 30"},
+		{"error-beginning.json", "line 1, column 1 (offset 1)"},
+		{"error-middle.json", "line 5, column 6 (offset 50)"},
+		{"error-end.json", "line 1, column 30 (offset 30)"},
 	}
 	for _, tc := range cases {
 		_, err := ParseFile(fixtureDir(tc.File))


### PR DESCRIPTION
Better display an error message on an encounter of a json.SyntaxError.

Rolls back the file position, to read the entire file, then steps
through the file reading a single byte at a time, populating lines until
encountering the syntax error. Then relays the offending line as well as
the previous line in the file to the user, also placing a `^` that
points the the offending column of the decoder error.

```
➤  packer validate template.json
Failed to parse template: Error parsing JSON: invalid character '"' after object key:value pair
At line 9, column 8 (offset 121):
    8:       "name": "vbox"
    9:       "
             ^
```