### PR TITLE
Add support for Google subnetworks. Closes #3062. 

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`
+	Subnetwork           string            `mapstructure:"subnetwork"`
 	Address              string            `mapstructure:"address"`
 	Preemptible          bool              `mapstructure:"preemptible"`
 	SourceImage          string            `mapstructure:"source_image"`
@@ -38,6 +39,7 @@ type Config struct {
 	RawStateTimeout      string            `mapstructure:"state_timeout"`
 	Tags                 []string          `mapstructure:"tags"`
 	UseInternalIP        bool              `mapstructure:"use_internal_ip"`
+	Region               string            `mapstructure:"region"`
 	Zone                 string            `mapstructure:"zone"`
 
 	account         accountFile
@@ -124,6 +126,11 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.Zone == "" {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("a zone must be specified"))
+	}
+	if c.Region == "" && len(c.Zone) > 2 {
+		// get region from Zone
+		region := c.Zone[:len(c.Zone)-2]
+		c.Region = region
 	}
 
 	stateTimeout, err := time.ParseDuration(c.RawStateTimeout)

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -168,6 +168,13 @@ func TestImageName(t *testing.T) {
 	}
 }
 
+func TestRegion(t *testing.T) {
+	c, _, _ := NewConfig(testConfig(t))
+	if c.Region != "us-east1" {
+		t.Fatalf("Region should be 'us-east1' given Zone of 'us-east1-a', but is %s", c.Region)
+	}
+}
+
 // Helper stuff below
 
 func testConfig(t *testing.T) map[string]interface{} {
@@ -175,7 +182,7 @@ func testConfig(t *testing.T) map[string]interface{} {
 		"account_file": testAccountFile(t),
 		"project_id":   "hashicorp",
 		"source_image": "foo",
-		"zone":         "us-east-1a",
+		"zone":         "us-east1-a",
 	}
 }
 

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -47,8 +47,10 @@ type InstanceConfig struct {
 	Metadata    map[string]string
 	Name        string
 	Network     string
+	Subnetwork  string
 	Address     string
 	Preemptible bool
 	Tags        []string
+	Region      string
 	Zone        string
 }

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -59,9 +59,11 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Metadata:    config.getInstanceMetadata(sshPublicKey),
 		Name:        name,
 		Network:     config.Network,
+		Subnetwork:  config.Subnetwork,
 		Address:     config.Address,
 		Preemptible: config.Preemptible,
 		Tags:        config.Tags,
+		Region:      config.Region,
 		Zone:        config.Zone,
 	})
 

--- a/website/source/docs/builders/googlecompute.html.markdown
+++ b/website/source/docs/builders/googlecompute.html.markdown
@@ -142,6 +142,10 @@ builder.
 -   `state_timeout` (string) - The time to wait for instance state changes.
     Defaults to `"5m"`.
 
+-   `subnetwork` (string) - The Google Compute subnetwork to use for the launced
+     instance. Only required if the `network` has been created with custom
+     subnetting.
+
 -   `tags` (array of strings)
 
 -   `use_internal_ip` (boolean) - If true, use the instance's internal IP

--- a/website/source/docs/builders/googlecompute.html.markdown
+++ b/website/source/docs/builders/googlecompute.html.markdown
@@ -139,12 +139,17 @@ builder.
 -   `network` (string) - The Google Compute network to use for the
     launched instance. Defaults to `"default"`.
 
+-   `region` (string) - The region in which to launch the instance. Defaults to
+    to the region hosting the specified `zone`.
+
 -   `state_timeout` (string) - The time to wait for instance state changes.
     Defaults to `"5m"`.
 
 -   `subnetwork` (string) - The Google Compute subnetwork to use for the launced
      instance. Only required if the `network` has been created with custom
      subnetting.
+     Note, the region of the subnetwork must match the `region` or `zone` in
+     which the VM is launched.
 
 -   `tags` (array of strings)
 


### PR DESCRIPTION
The new subnetworks feature of Google Cloud platform, allows creation of subnetted networks, where each region must have a unique subnet. This is the default going forward, and it's no longer possible to create "legacy" networks via the Google web UI.
If the Google project uses an [auto subnet network](https://cloud.google.com/compute/docs/subnetworks#auto_subnet_ip_ranges), when instantiating a VM, we do not need to specify the subnet. Meaning, it behaves mostly the same as before and a specific Subnetwork does not need to be specified in the packer config.

However, if the project uses a [custom subnet network](https://cloud.google.com/compute/docs/subnetworks#custom_subnet_ip_ranges), where the subnets are manually specified, it is mandatory when instantiating the google VM instance to specify the subnet.

Also, fixes an issue with how packer populates instances metadata. Closes #3181