### PR TITLE
Enable SSH Communicator to download directories

### DIFF
--- a/builder/amazon/chroot/communicator.go
+++ b/builder/amazon/chroot/communicator.go
@@ -3,7 +3,6 @@ package chroot
 import (
 	"bytes"
 	"fmt"
-	"github.com/mitchellh/packer/packer"
 	"io"
 	"io/ioutil"
 	"log"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/mitchellh/packer/packer"
 )
 
 // Communicator is a special communicator that works by executing
@@ -112,6 +113,10 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 	}
 
 	return err
+}
+
+func (c *Communicator) DownloadDir(src string, dst string, exclude []string) error {
+	return fmt.Errorf("DownloadDir is not implemented for amazon-chroot")
 }
 
 func (c *Communicator) Download(src string, w io.Writer) error {

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -233,6 +233,10 @@ func (c *Communicator) Download(src string, dst io.Writer) error {
 	return nil
 }
 
+func (c *Communicator) DownloadDir(src string, dst string, exclude []string) error {
+	return fmt.Errorf("DownloadDir is not implemented for docker")
+}
+
 // canExec tells us whether `docker exec` is supported
 func (c *Communicator) canExec() bool {
 	execConstraint, err := version.NewConstraint(">= 1.4.0")

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -140,6 +140,10 @@ func (c *Communicator) Download(src string, dst io.Writer) error {
 	return fmt.Errorf("WinRM doesn't support download.")
 }
 
+func (c *Communicator) DownloadDir(src string, dst string, exclude []string) error {
+	return fmt.Errorf("WinRM doesn't support download dir.")
+}
+
 func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 	addr := fmt.Sprintf("%s:%d", c.endpoint.Host, c.endpoint.Port)
 	return winrmcp.New(addr, &winrmcp.Config{

--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -75,6 +75,8 @@ type Communicator interface {
 	// with the contents writing to the given writer. This method will
 	// block until it completes.
 	Download(string, io.Writer) error
+
+	DownloadDir(src string, dst string, exclude []string) error
 }
 
 // StartWithUi runs the remote command and streams the output to any

--- a/packer/communicator_mock.go
+++ b/packer/communicator_mock.go
@@ -25,6 +25,10 @@ type MockCommunicator struct {
 	UploadDirSrc     string
 	UploadDirExclude []string
 
+	DownloadDirDst     string
+	DownloadDirSrc     string
+	DownloadDirExclude []string
+
 	DownloadCalled bool
 	DownloadPath   string
 	DownloadData   string
@@ -95,6 +99,14 @@ func (c *MockCommunicator) Download(path string, w io.Writer) error {
 	c.DownloadCalled = true
 	c.DownloadPath = path
 	w.Write([]byte(c.DownloadData))
+
+	return nil
+}
+
+func (c *MockCommunicator) DownloadDir(src string, dst string, excl []string) error {
+	c.DownloadDirDst = dst
+	c.DownloadDirSrc = src
+	c.DownloadDirExclude = excl
 
 	return nil
 }

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -52,6 +52,12 @@ type CommunicatorUploadDirArgs struct {
 	Exclude []string
 }
 
+type CommunicatorDownloadDirArgs struct {
+	Dst     string
+	Src     string
+	Exclude []string
+}
+
 func Communicator(client *rpc.Client) *communicator {
 	return &communicator{client: client}
 }
@@ -128,6 +134,22 @@ func (c *communicator) UploadDir(dst string, src string, exclude []string) error
 
 	var reply error
 	err := c.client.Call("Communicator.UploadDir", args, &reply)
+	if err == nil {
+		err = reply
+	}
+
+	return err
+}
+
+func (c *communicator) DownloadDir(src string, dst string, exclude []string) error {
+	args := &CommunicatorDownloadDirArgs{
+		Dst:     dst,
+		Src:     src,
+		Exclude: exclude,
+	}
+
+	var reply error
+	err := c.client.Call("Communicator.DownloadDir", args, &reply)
 	if err == nil {
 		err = reply
 	}
@@ -251,6 +273,10 @@ func (c *CommunicatorServer) Upload(args *CommunicatorUploadArgs, reply *interfa
 
 func (c *CommunicatorServer) UploadDir(args *CommunicatorUploadDirArgs, reply *error) error {
 	return c.c.UploadDir(args.Dst, args.Src, args.Exclude)
+}
+
+func (c *CommunicatorServer) DownloadDir(args *CommunicatorUploadDirArgs, reply *error) error {
+	return c.c.DownloadDir(args.Src, args.Dst, args.Exclude)
 }
 
 func (c *CommunicatorServer) Download(args *CommunicatorDownloadArgs, reply *interface{}) (err error) {

--- a/post-processor/shell-local/communicator.go
+++ b/post-processor/shell-local/communicator.go
@@ -57,3 +57,7 @@ func (c *Communicator) UploadDir(string, string, []string) error {
 func (c *Communicator) Download(string, io.Writer) error {
 	return fmt.Errorf("download not supported")
 }
+
+func (c *Communicator) DownloadDir(src string, dst string, exclude []string) error {
+	return fmt.Errorf("downloadDir not supported")
+}

--- a/provisioner/ansible/adapter_test.go
+++ b/provisioner/ansible/adapter_test.go
@@ -140,3 +140,7 @@ func (c communicator) UploadDir(dst string, src string, exclude []string) error 
 func (c communicator) Download(string, io.Writer) error {
 	return errors.New("communicator not supported")
 }
+
+func (c communicator) DownloadDir(src string, dst string, exclude []string) error {
+	return errors.New("communicator not supported")
+}

--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/helper/config"
@@ -15,7 +16,8 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	// The local path of the file to upload.
-	Source string
+	Source  string
+	Sources []string
 
 	// The remote path where the local file will be uploaded to.
 	Destination string
@@ -52,12 +54,22 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Direction must be one of: download, upload."))
 	}
+	if p.config.Source != "" {
+		p.config.Sources = append(p.config.Sources, p.config.Source)
+	}
 
 	if p.config.Direction == "upload" {
-		if _, err := os.Stat(p.config.Source); err != nil {
-			errs = packer.MultiErrorAppend(errs,
-				fmt.Errorf("Bad source '%s': %s", p.config.Source, err))
+		for _, src := range p.config.Sources {
+			if _, err := os.Stat(src); err != nil {
+				errs = packer.MultiErrorAppend(errs,
+					fmt.Errorf("Bad source '%s': %s", src, err))
+			}
 		}
+	}
+
+	if len(p.config.Sources) < 1 {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("Source must be specified."))
 	}
 
 	if p.config.Destination == "" {
@@ -81,50 +93,65 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 }
 
 func (p *Provisioner) ProvisionDownload(ui packer.Ui, comm packer.Communicator) error {
-	ui.Say(fmt.Sprintf("Downloading %s => %s", p.config.Source, p.config.Destination))
+	for _, src := range p.config.Sources {
+		ui.Say(fmt.Sprintf("Downloading %s => %s", src, p.config.Destination))
 
-	f, err := os.OpenFile(p.config.Destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+		if strings.HasSuffix(p.config.Destination, "/") {
+			err := os.MkdirAll(p.config.Destination, os.FileMode(0755))
+			if err != nil {
+				return err
+			}
+			return comm.DownloadDir(src, p.config.Destination, nil)
+		}
 
-	err = comm.Download(p.config.Source, f)
-	if err != nil {
-		ui.Error(fmt.Sprintf("Download failed: %s", err))
+		f, err := os.OpenFile(p.config.Destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		err = comm.Download(src, f)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Download failed: %s", err))
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func (p *Provisioner) ProvisionUpload(ui packer.Ui, comm packer.Communicator) error {
-	ui.Say(fmt.Sprintf("Uploading %s => %s", p.config.Source, p.config.Destination))
-	info, err := os.Stat(p.config.Source)
-	if err != nil {
-		return err
-	}
+	for _, src := range p.config.Sources {
+		ui.Say(fmt.Sprintf("Uploading %s => %s", src, p.config.Destination))
 
-	// If we're uploading a directory, short circuit and do that
-	if info.IsDir() {
-		return comm.UploadDir(p.config.Destination, p.config.Source, nil)
-	}
+		info, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
 
-	// We're uploading a file...
-	f, err := os.Open(p.config.Source)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+		// If we're uploading a directory, short circuit and do that
+		if info.IsDir() {
+			return comm.UploadDir(p.config.Destination, src, nil)
+		}
 
-	fi, err := f.Stat()
-	if err != nil {
-		return err
-	}
+		// We're uploading a file...
+		f, err := os.Open(src)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 
-	err = comm.Upload(p.config.Destination, f, &fi)
-	if err != nil {
-		ui.Error(fmt.Sprintf("Upload failed: %s", err))
+		fi, err := f.Stat()
+		if err != nil {
+			return err
+		}
+
+		err = comm.Upload(p.config.Destination, f, &fi)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Upload failed: %s", err))
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func (p *Provisioner) Cancel() {

--- a/provisioner/shell-local/communicator.go
+++ b/provisioner/shell-local/communicator.go
@@ -76,6 +76,10 @@ func (c *Communicator) Download(string, io.Writer) error {
 	return fmt.Errorf("download not supported")
 }
 
+func (c *Communicator) DownloadDir(string, string, []string) error {
+	return fmt.Errorf("downloadDir not supported")
+}
+
 type ExecuteCommandTemplate struct {
 	Command string
 }


### PR DESCRIPTION
I merged this locally to fix a test failure as a result of the new ansible provisioner. Ansible includes a communicator in a test, which I needed to update.

Closes #2618

Thanks @vtolstov!