### PR TITLE
document optional amazon-ebs virt type behavior

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -109,6 +109,10 @@ builder.
     launch the resulting AMI(s). By default no additional users other than the
     user creating the AMI has permissions to launch it.
 
+-   `ami_virtualization_type` (string) - The type of virtualization for the AMI
+    you are building. This option must match the supported virtualization 
+    type of `source_ami`. Can be "paravirtual" or "hvm".
+
 -   `associate_public_ip_address` (boolean) - If using a non-default VPC, public
     IP addresses are not provided by default. If this is toggled, your new
     instance will get a Public IP.


### PR DESCRIPTION
packer amazon-ebs builder accepts the ami_virtualization_type option which has some undocumented behavior. Feel free to ignore the pull request and reword as desired.