### PR TITLE
Fix zsh-completion

### DIFF
--- a/contrib/zsh-completion/_packer
+++ b/contrib/zsh-completion/_packer
@@ -30,8 +30,10 @@ __inspect() {
 
 __push() {
   _arguments \
-    '-create[Create the build configuration if it does not exist].' \
-    '-token=[(<token>) Access token to use to upload.]'
+    '-name=[(<name>) The destination build in Atlas.]' \
+    '-token=[(<token>) Access token to use to upload.]' \
+    '-var[("key=value") Variable for templates, can be used multiple times.]' \
+    '-var-file=[(path) JSON file containing user variables.]'
 }
 
 __validate() {


### PR DESCRIPTION
The `-create` option looks like a default option, so it is not longer used. I remove the option and add some options for `push` subcommand.

* output

```bash
$ packer push -<tab>
-message   -m  -- (<detail>) A message to identify the purpose or changes in this Packer template.
-name          -- (<name>) The destination build in Atlas.
-token         -- (<token>) Access token to use to upload.
-var           -- ("key=value") Variable for templates, can be used multiple times.
-var-file      -- (path) JSON file containing user variables.
```

* My test machine

```bash
$ packer -version
0.8.6
$ zsh --version
zsh 5.2 (x86_64-apple-darwin15.0.0)
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.11.3
BuildVersion:   15D21
```