### PR TITLE
Allow specifying environment variables for ansible provisioner

### DIFF
--- a/website/source/docs/provisioners/ansible.html.markdown
+++ b/website/source/docs/provisioners/ansible.html.markdown
@@ -79,6 +79,14 @@ Optional Parameters:
 
 - `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
 
+- `ansible_env_vars` (array of strings) - Environment variables to set before running Ansible.
+  If unset, defaults to `ANSIBLE_HOST_KEY_CHECKING=False`.
+  Usage example:
+
+```
+"ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
+```
+
 ## Limitations
 
 The `ansible` provisioner does not support SCP to transfer files.


### PR DESCRIPTION
This adds a parameter for the Ansible provisioner to set the environment variables for ansible-playbook execution. It's useful if you need to override anything from Ansible config file.

This is my second attempt at sending a PR, the first one was in #3164 and it went bad due to my mistakes during the rebase. 