### PR TITLE
Docs: Examples of templates need more assistance about AMI IDs

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -204,7 +204,7 @@ builder.
 
 ## Basic Example
 
-Here is a basic example. It is completely valid except for the access keys:
+Here is a basic example. You will need to provide access keys, and may need to change the AMI IDs according to what images exist at the time the template is run:
 
 ``` {.javascript}
 {
@@ -223,6 +223,8 @@ Here is a basic example. It is completely valid except for the access keys:
 environmental variables. See the configuration reference in the section above
 for more information on what environmental variables Packer will look for.
 
+Further information on locating AMI IDs and their relationship to instance types and regions can be found in the AWS EC2 Documentation [for Linux](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html) or [for Windows](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/finding-an-ami.html).  
+
 ## Accessing the Instance to Debug
 
 If you need to access the instance to debug for some reason, run the builder
@@ -233,7 +235,7 @@ You can use this information to access the instance as it is running.
 ## AMI Block Device Mappings Example
 
 Here is an example using the optional AMI block device mappings. This will add
-the /dev/sdb and /dev/sdc block device mappings to the finished AMI.
+the /dev/sdb and /dev/sdc block device mappings to the finished AMI. As with the basic example, you will need to provide access keys and may need to change the source AMI ID based on what images exist when this template is run:
 
 ``` {.javascript}
 {
@@ -261,7 +263,7 @@ the /dev/sdb and /dev/sdc block device mappings to the finished AMI.
 ## Tag Example
 
 Here is an example using the optional AMI tags. This will add the tags
-"OS\_Version" and "Release" to the finished AMI.
+"OS\_Version" and "Release" to the finished AMI. As before, your will need to provide your access keys, and may need to change the source AMI ID based on what images exist when this template is run:
 
 ``` {.javascript}
 {

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -263,7 +263,7 @@ the /dev/sdb and /dev/sdc block device mappings to the finished AMI. As with the
 ## Tag Example
 
 Here is an example using the optional AMI tags. This will add the tags
-"OS\_Version" and "Release" to the finished AMI. As before, your will need to provide your access keys, and may need to change the source AMI ID based on what images exist when this template is run:
+"OS\_Version" and "Release" to the finished AMI. As before, you will need to provide your access keys, and may need to change the source AMI ID based on what images exist when this template is run:
 
 ``` {.javascript}
 {

--- a/website/source/docs/post-processors/atlas.html.markdown
+++ b/website/source/docs/post-processors/atlas.html.markdown
@@ -115,3 +115,5 @@ you can also use `token` configuration option.
     ]
 }
 ```
+
+More information on the correct configuration of the `amazon-ebs` builder in this example can be found in the [amazon-ebs builder documentation](/docs/builders/amazon-ebs.html).

--- a/website/source/docs/templates/configuration-templates.html.markdown
+++ b/website/source/docs/templates/configuration-templates.html.markdown
@@ -188,7 +188,7 @@ isotime = June 7, 7:22:43pm 2014
 {{isotime "Hour15Year200603"}} = Hour19Year201407
 ```
 
-Please note that double quote characters need escaping inside of templates:
+Please note that double quote characters need escaping inside of templates (in this case, on the `ami_name` value):
 
 ``` {.javascript}
 {
@@ -206,6 +206,8 @@ Please note that double quote characters need escaping inside of templates:
   ]
 }
 ```
+
+-&gt; **Note:** See the [Amazon builder](/docs/builders/amazon.html) documentation for more information on how to correctly configure the Amazon builder in this example.
 
 ## Amazon Specific Functions
 

--- a/website/source/docs/templates/introduction.html.markdown
+++ b/website/source/docs/templates/introduction.html.markdown
@@ -81,9 +81,9 @@ builders, provisioners, etc. will still result in validation errors.
 
 ## Example Template
 
-Below is an example of a basic template that is nearly fully functional. It is
-just missing valid AWS access keys. Otherwise, it would work properly with
-`packer build`.
+Below is an example of a basic template that could be invoked with `packer build`. It would create an instance in AWS, and once running copy a script to it and run that script using SSH.
+
+-&gt; **Note:** This example requires an account with Amazon Web Services. There are a number of parameters which need to be provided for a functional build to take place. See the [Amazon builder](/docs/builders/amazon.html) documentation for more information.
 
 ``` {.javascript}
 {


### PR DESCRIPTION
 * Several places where AMI IDs are used now have more explanation about
   where to find information about them, or links to the builder docs
 * IDs present in examples have not been changed to valid ones, since
   this would be an on-going problem to maintain a current valid ID
 * See github.com issue #3132

Signed-off-by: David Zanetti <dave2@wetstring.net>