### PR TITLE
remoteValidationKeyPath was being set AFTER client.rb file was written

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -235,6 +235,15 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Error uploading encrypted data bag secret: %s", err)
 		}
 	}
+
+	remoteValidationKeyPath := ""
+	if p.config.ValidationKeyPath != "" {
+		remoteValidationKeyPath = fmt.Sprintf("%s/validation.pem", p.config.StagingDir)
+		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, p.config.ValidationKeyPath); err != nil {
+			return fmt.Errorf("Error copying validation key: %s", err)
+		}
+	}
+
 	configPath, err := p.createConfig(
 		ui,
 		comm,
@@ -248,13 +257,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		p.config.SslVerifyMode)
 	if err != nil {
 		return fmt.Errorf("Error creating Chef config file: %s", err)
-	}
-
-	if p.config.ValidationKeyPath != "" {
-		remoteValidationKeyPath = fmt.Sprintf("%s/validation.pem", p.config.StagingDir)
-		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, p.config.ValidationKeyPath); err != nil {
-			return fmt.Errorf("Error copying validation key: %s", err)
-		}
 	}
 
 	jsonPath, err := p.createJson(ui, comm)

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -208,7 +208,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	if nodeName == "" {
 		nodeName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
 	}
-	remoteValidationKeyPath := ""
 	serverUrl := p.config.ServerUrl
 
 	if !p.config.SkipInstall {


### PR DESCRIPTION
Because remoteValidationKeyPath was not being set before the client.rb file was written, it would never write ValidationKeyPath to the file, causing chef to always look for the file at c:\chef\validation.pem instead of {StagingDir}\validation.pem.