### PR TITLE
Docs: add Ansible Remote to index

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -56,7 +56,8 @@
       <li><a href="/docs/provisioners/file.html">File Uploads</a></li>
       <li><a href="/docs/provisioners/powershell.html">PowerShell</a></li>
       <li><a href="/docs/provisioners/windows-shell.html">Windows Shell</a></li>
-      <li><a href="/docs/provisioners/ansible-local.html">Ansible</a></li>
+      <li><a href="/docs/provisioners/ansible-local.html">Ansible Local</a></li>
+      <li><a href="/docs/provisioners/ansible.html">Ansible Remote</a></li>
       <li><a href="/docs/provisioners/chef-client.html">Chef Client</a></li>
       <li><a href="/docs/provisioners/chef-solo.html">Chef Solo</a></li>
       <li><a href="/docs/provisioners/puppet-masterless.html">Puppet Masterless</a></li>


### PR DESCRIPTION
Add Ansible Remote to website documentation and appropriately rename Ansible Local link.