### PR TITLE
Add empty_groups param to ansible provisioner

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -43,6 +43,7 @@ type Config struct {
 	// The main playbook file to execute.
 	PlaybookFile         string   `mapstructure:"playbook_file"`
 	Groups               []string `mapstructure:"groups"`
+	EmptyGroups          []string `mapstructure:"empty_groups"`
 	HostAlias            string   `mapstructure:"host_alias"`
 	LocalPort            string   `mapstructure:"local_port"`
 	SSHHostKeyFile       string   `mapstructure:"ssh_host_key_file"`
@@ -211,6 +212,10 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		w.WriteString(host)
 		for _, group := range p.config.Groups {
 			fmt.Fprintf(w, "[%s]\n%s", group, host)
+		}
+
+		for _, group := range p.config.EmptyGroups {
+			fmt.Fprintf(w, "[%s]\n", group)
 		}
 
 		if err := w.Flush(); err != nil {

--- a/website/source/docs/provisioners/ansible.html.markdown
+++ b/website/source/docs/provisioners/ansible.html.markdown
@@ -51,6 +51,9 @@ Optional Parameters:
   should be placed. When unspecified, the host is not associated with any
   groups.
 
+- `empty_groups` (array of strings) - The groups which should be present in
+  inventory file but remain empty.
+
 - `host_alias` (string) - The alias by which the Ansible host should be known.
   Defaults to `default`.
 


### PR DESCRIPTION
If Ansible playbooks are shared between Ansible provisioner and i.e. some other part of infrastructure, it may be necessary to introduce empty groups into inventory to make i.e.  "universal" templates that expect full inventory work in Packer provided environment.