### PR TITLE
Fix travis builds for go 1.4 and go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
   - 1.4.3
   - 1.6
 
+install:
+  - make deps
+
 script:
   - GOMAXPROCS=2 make ci
 


### PR DESCRIPTION
There's extra logic in the makefile to install and use godeps if running go 1.4