### PR TITLE
Ansible: os.Environ() should always be passed to the ansible command.

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -262,8 +262,8 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 
 	cmd := exec.Command(p.config.Command, args...)
 
+	cmd.Env = os.Environ()
 	if len(envvars) > 0 {
-		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, envvars...)
 	} else if !checkHostKey {
 		cmd.Env = append(cmd.Env, "ANSIBLE_HOST_KEY_CHECKING=False")


### PR DESCRIPTION
Closes #3271

Regression introduced in #3203