### PR TITLE
Make communicator's WinRM defaults more intuitive when using SSL.

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -137,7 +137,9 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 }
 
 func (c *Config) prepareWinRM(ctx *interpolate.Context) []error {
-	if c.WinRMPort == 0 {
+	if c.WinRMPort == 0 && c.WinRMUseSSL {
+		c.WinRMPort = 5986
+	} else if c.WinRMPort == 0 {
 		c.WinRMPort = 5985
 	}
 

--- a/helper/communicator/config_test.go
+++ b/helper/communicator/config_test.go
@@ -37,6 +37,70 @@ func TestConfig_badtype(t *testing.T) {
 	}
 }
 
+func TestConfig_winrm_noport(t *testing.T) {
+	c := &Config{
+		Type:      "winrm",
+		WinRMUser: "admin",
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMPort != 5985 {
+		t.Fatalf("WinRMPort doesn't match default port 5985 when SSL is not enabled and no port is specified.")
+	}
+
+}
+
+func TestConfig_winrm_noport_ssl(t *testing.T) {
+	c := &Config{
+		Type:        "winrm",
+		WinRMUser:   "admin",
+		WinRMUseSSL: true,
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMPort != 5986 {
+		t.Fatalf("WinRMPort doesn't match default port 5986 when SSL is enabled and no port is specified.")
+	}
+
+}
+
+func TestConfig_winrm_port(t *testing.T) {
+	c := &Config{
+		Type:      "winrm",
+		WinRMUser: "admin",
+		WinRMPort: 5509,
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMPort != 5509 {
+		t.Fatalf("WinRMPort doesn't match custom port 5509 when SSL is not enabled.")
+	}
+
+}
+
+func TestConfig_winrm_port_ssl(t *testing.T) {
+	c := &Config{
+		Type:        "winrm",
+		WinRMUser:   "admin",
+		WinRMPort:   5510,
+		WinRMUseSSL: true,
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMPort != 5510 {
+		t.Fatalf("WinRMPort doesn't match custom port 5510 when SSL is enabled.")
+	}
+
+}
+
 func TestConfig_winrm(t *testing.T) {
 	c := &Config{
 		Type:      "winrm",

--- a/website/source/docs/templates/communicator.html.markdown
+++ b/website/source/docs/templates/communicator.html.markdown
@@ -105,7 +105,7 @@ The WinRM communicator has the following options.
   * `winrm_host` (string) - The address for WinRM to connect to.
 
   * `winrm_port` (integer) - The WinRM port to connect to. This defaults to
-    5985.
+    5985 for plain unencrypted connection and 5896 for SSL when `winrm_use_ssl` is set to true.
 
   * `winrm_username` (string) - The username to use to connect to WinRM.
 


### PR DESCRIPTION
Hello,

I just made a very small improvement to the recently added WinRM communicator feature of using SSL. I made the default port match the expected Windows default one when `winrm_use_ssl` is set to true and no port is explicitly specified.

