### PR TITLE
Self documenting Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,8 @@ following steps in order to be able to compile and test Packer. These instructio
    `$GOPATH/src/github.com/mitchellh/packer`.
 
 4. When working on packer `cd $GOPATH/src/github.com/mitchellh/packer` so you
-   can run `make` and easily access other files.
+   can run `make` and easily access other files. Run `make help` to get
+   information about make targets.
 
 5. Make your changes to the Packer source. You can run `make` in
    `$GOPATH/src/github.com/mitchellh/packer` to run tests and build the packer


### PR DESCRIPTION
Make the ```Makefile``` self documented allowing a developer to understand the targets by running ```make help```.

Example:
<img width="548" alt="screen shot 2016-03-01 at 18 51 47" src="https://cloud.githubusercontent.com/assets/557699/13436374/2efcd62a-dfdf-11e5-8bbc-382d3f425252.png">

I'll add more documentation if I get a :+1:. 

Optionally we can change to ```.PHONY: help``` if that don't brake anything important. 