### PR TITLE
Ansible: don't use deprecated ssh options when ver above 2.0

### DIFF
--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -6,13 +6,28 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/mitchellh/packer/packer"
 )
 
-func testConfig() map[string]interface{} {
+// Be sure to remove the Ansible stub file in each test with:
+//   defer os.Remove(config["command"].(string))
+func testConfig(t *testing.T) map[string]interface{} {
 	m := make(map[string]interface{})
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	ansible_stub := path.Join(wd, "packer-ansible-stub.sh")
+
+	err = ioutil.WriteFile(ansible_stub, []byte("#!/usr/bin/env bash\necho ansible 1.6.0"), 0777)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	m["command"] = ansible_stub
+
 	return m
 }
 
@@ -26,7 +41,8 @@ func TestProvisioner_Impl(t *testing.T) {
 
 func TestProvisionerPrepare_Defaults(t *testing.T) {
 	var p Provisioner
-	config := testConfig()
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
 
 	err := p.Prepare(config)
 	if err == nil {
@@ -62,7 +78,8 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 
 func TestProvisionerPrepare_PlaybookFile(t *testing.T) {
 	var p Provisioner
-	config := testConfig()
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
 
 	hostkey_file, err := ioutil.TempFile("", "hostkey")
 	if err != nil {
@@ -99,7 +116,8 @@ func TestProvisionerPrepare_PlaybookFile(t *testing.T) {
 
 func TestProvisionerPrepare_HostKeyFile(t *testing.T) {
 	var p Provisioner
-	config := testConfig()
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
 
 	publickey_file, err := ioutil.TempFile("", "publickey")
 	if err != nil {
@@ -143,7 +161,8 @@ func TestProvisionerPrepare_HostKeyFile(t *testing.T) {
 
 func TestProvisionerPrepare_AuthorizedKeyFile(t *testing.T) {
 	var p Provisioner
-	config := testConfig()
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
 
 	hostkey_file, err := ioutil.TempFile("", "hostkey")
 	if err != nil {
@@ -187,7 +206,8 @@ func TestProvisionerPrepare_AuthorizedKeyFile(t *testing.T) {
 
 func TestProvisionerPrepare_LocalPort(t *testing.T) {
 	var p Provisioner
-	config := testConfig()
+	config := testConfig(t)
+	defer os.Remove(config["command"].(string))
 
 	hostkey_file, err := ioutil.TempFile("", "hostkey")
 	if err != nil {


### PR DESCRIPTION
Ansible 2.0 deprecated ```ansible_ssh_user```, ```ansible_ssh_port```, ```ansible_ssh_host```
instead use ```ansible_user```, ```ansible_port```, and ```ansible_host``` in the
inventory file.

Closes #3275