### PR TITLE
Made the output of the AWS builder a little more readable

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -51,7 +51,7 @@ func (a *Artifact) String() string {
 	}
 
 	sort.Strings(amiStrings)
-	return fmt.Sprintf("AMIs were created:\n\n%s", strings.Join(amiStrings, "\n"))
+	return fmt.Sprintf("\nAMIs were created:\n%s", strings.Join(amiStrings, "\n"))
 }
 
 func (a *Artifact) State(name string) interface{} {


### PR DESCRIPTION
I didn't like the output of the AWS builder so I changed it a little. It will now output a newline after the last item, and just one newline instead of two after the item.