### PR TITLE
Resolves vsphere post-processor problems

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -92,8 +92,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ConfigDrive:      b.config.ConfigDrive,
 		},
 		&StepGetPassword{
-			Debug:            b.config.PackerDebug,
-			Comm:             &b.config.RunConfig.Comm,
+			Debug: b.config.PackerDebug,
+			Comm:  &b.config.RunConfig.Comm,
 		},
 		&StepWaitForRackConnect{
 			Wait: b.config.RackconnectWait,

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -1,10 +1,10 @@
 package vsphere
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -120,17 +120,26 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	if p.config.ResourcePool != "" {
 		ovftool_uri += "/Resources/" + p.config.ResourcePool
 	}
-
 	args := []string{
-		fmt.Sprintf("--noSSLVerify=%t", p.config.Insecure),
 		"--acceptAllEulas",
-		fmt.Sprintf("--name=\"%s\"", p.config.VMName),
-		fmt.Sprintf("--datastore=\"%s\"", p.config.Datastore),
-		fmt.Sprintf("--diskMode=\"%s\"", p.config.DiskMode),
-		fmt.Sprintf("--network=\"%s\"", p.config.VMNetwork),
-		fmt.Sprintf("--vmFolder=\"%s\"", p.config.VMFolder),
-		fmt.Sprintf("%s", source),
-		fmt.Sprintf("\"%s\"", ovftool_uri),
+		fmt.Sprintf(`--name=%s`, p.config.VMName),
+		fmt.Sprintf(`--datastore=%s`, p.config.Datastore),
+	}
+
+	if p.config.Insecure {
+		args = append(args, fmt.Sprintf(`--noSSLVerify=%t`, p.config.Insecure))
+	}
+
+	if p.config.DiskMode != "" {
+		args = append(args, fmt.Sprintf(`--diskMode=%s`, p.config.DiskMode))
+	}
+
+	if p.config.VMFolder != "" {
+		args = append(args, fmt.Sprintf(`--vmFolder=%s`, p.config.VMFolder))
+	}
+
+	if p.config.VMNetwork != "" {
+		args = append(args, fmt.Sprintf(`--network=%s`, p.config.VMNetwork))
 	}
 
 	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
@@ -143,16 +152,18 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		args = append(args, p.config.Options...)
 	}
 
+	args = append(args, fmt.Sprintf(`%s`, source))
+	args = append(args, fmt.Sprintf(`%s`, ovftool_uri))
+
 	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
-	var out bytes.Buffer
+
 	log.Printf("Starting ovftool with parameters: %s", strings.Join(args, " "))
 	cmd := exec.Command("ovftool", args...)
-	cmd.Stdout = &out
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return nil, false, fmt.Errorf("Failed: %s\nStdout: %s", err, out.String())
+		return nil, false, fmt.Errorf("Failed: %s\n", err)
 	}
-
-	ui.Message(fmt.Sprintf("%s", out.String()))
 
 	return artifact, false, nil
 }

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -1,1 +1,42 @@
 package vsphere
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestArgs(t *testing.T) {
+	var p PostProcessor
+
+	p.config.Username = "me"
+	p.config.Password = "notpassword"
+	p.config.Host = "myhost"
+	p.config.Datacenter = "mydc"
+	p.config.Cluster = "mycluster"
+	p.config.VMName = "my vm"
+	p.config.Datastore = "my datastore"
+	p.config.Insecure = true
+	p.config.DiskMode = "thin"
+	p.config.VMFolder = "my folder"
+
+	source := "something.vmx"
+	ovftool_uri := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
+		url.QueryEscape(p.config.Username),
+		url.QueryEscape(p.config.Password),
+		p.config.Host,
+		p.config.Datacenter,
+		p.config.Cluster)
+
+	if p.config.ResourcePool != "" {
+		ovftool_uri += "/Resources/" + p.config.ResourcePool
+	}
+
+	args, err := p.BuildArgs(source, ovftool_uri)
+	if err != nil {
+		t.Errorf("Error: %s", err)
+	}
+
+	t.Logf("ovftool %s", strings.Join(args, " "))
+}


### PR DESCRIPTION
Closes #3204

I tested this on some builds that were failing for me when using v0.9.0. v0.9.0 added quotes to parameters that broke the vsphere post-processor, this PR fixes that. Quotes aren't being passed in, but still handles spaces just fine (something I also tested). Also, optional arguments were being passed in regardless of whether or not they had values so I fixed that.

EDIT:

Instead of creating a buffer and putting Stdout there, the command's Stdout and Stderr were just set to os.Stdout and os.Stderr, respectively, since that makes a little bit more sense based on what we're doing here.