### PR TITLE
Add example of extra_arguments

### DIFF
--- a/website/source/docs/provisioners/ansible.html.markdown
+++ b/website/source/docs/provisioners/ansible.html.markdown
@@ -2,7 +2,7 @@
 layout: "docs"
 page_title: "Ansible Provisioner"
 description: |-
-  The `ansible` Packer provisioner allows Ansible playbooks to be run to provision the machine. 
+  The `ansible` Packer provisioner allows Ansible playbooks to be run to provision the machine.
 ---
 
 # Ansible Provisioner
@@ -81,6 +81,11 @@ Optional Parameters:
   Defaults to `/usr/lib/sftp-server -e`.
 
 - `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
+  Usage example:
+
+```
+"extra_arguments": [ "--extra-vars", "\"Region={{user `Region`}} Stage={{user `Stage`}}\"" ]
+```
 
 - `ansible_env_vars` (array of strings) - Environment variables to set before running Ansible.
   If unset, defaults to `ANSIBLE_HOST_KEY_CHECKING=False`.


### PR DESCRIPTION
Add a simple example to prevent misleading of extra_arguments in Ansible (remote) provisioner.
Following examples don't work when passing variables to Ansible:

```
"extra_arguments": [ "--extra-vars", "\"", "Region={{user `Region`}}", "Stage={{user `Stage`}}", "\""]
```

```
"extra_arguments": ["--extra-vars \"Region={{user `Region`}} Stage={{user `Stage`}} StreamName={{user `StreamName`}} HostedZoneName={{user `HostedZoneName`}}\""]
```