### PR TITLE
Enable to select NVMe images for googlecompute builder

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -328,7 +328,7 @@ func (d *driverGCE) WaitForInstance(state, zone, name string) <-chan error {
 }
 
 func (d *driverGCE) getImage(img Image) (image *compute.Image, err error) {
-	projects := []string{img.ProjectId, "centos-cloud", "coreos-cloud", "debian-cloud", "google-containers", "opensuse-cloud", "rhel-cloud", "suse-cloud", "ubuntu-os-cloud", "windows-cloud"}
+	projects := []string{img.ProjectId, "centos-cloud", "coreos-cloud", "debian-cloud", "google-containers", "opensuse-cloud", "rhel-cloud", "suse-cloud", "ubuntu-os-cloud", "windows-cloud", "gce-nvme"}
 	for _, project := range projects {
 		image, err = d.service.Images.Get(project, img.Name).Do()
 		if err == nil && image != nil && image.SelfLink != "" {


### PR DESCRIPTION
I'd like to use preconfigured disk image optimized for NVMe interface to enhance local SSD performance on Google Compute Engine, so I created a simple template named `nvme.json`,
```nvme.json
{
  "builders": [
    {
      "type": "googlecompute",
      "project_id": "MYPROJECTID",
      "source_image": "nvme-backports-debian-7-wheezy-v20151104",
      "zone": "us-east1-b",
      "account_file": "/path/to/credentials.json"
    }
  ],
  "provisioners": [
    {
      "type": "shell",
      "inline": ["echo hoge"]
    }
  ]
}
```

and ran `packer run nvme.json`.

It failed with error:
```
==> googlecompute: Error creating instance: Image nvme-backports-debian-7-wheezy-v20151104 could not be found in any of these projects: [MYPROJECTID centos-cloud coreos-cloud debian-cloud google-containers opensuse-cloud rhel-cloud suse-cloud ubuntu-os-cloud windows-cloud]
Build 'googlecompute' errored: Error creating instance: Image nvme-backports-debian-7-wheezy-v20151104 could not be found in any of these projects: [MYPROJECTID centos-cloud coreos-cloud debian-cloud google-containers opensuse-cloud rhel-cloud suse-cloud ubuntu-os-cloud windows-cloud]
```

According to [Adding Local SSDs](https://cloud.google.com/compute/docs/disks/local-ssd), the owner of NVMe images is `gce-nvme` project.
So I've added it in the target projects where `googlecompute` builder looking for available images.