### PR TITLE
Fix incorrect amazon-ebs property in documentation

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -138,7 +138,8 @@ builder.
 -   `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`.
--   `volume_run_tags` (object of key/value strings) - Tags to apply to the volumes
+
+-   `run_volume_tags` (object of key/value strings) - Tags to apply to the volumes
     that are *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`.
 


### PR DESCRIPTION
There is a small error in the amazon-ebs documentation concerning volume tags. Looking at [this code](https://github.com/mitchellh/packer/blob/master/builder/amazon/ebs/builder.go#L32), the property name is incorrect.
