### PR TITLE
Fix -debug command line option misbehaviour: forbid stdin redirection…

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,10 @@ func wrappedMain() int {
 	log.Printf("Built with Go Version: %s", runtime.Version())
 
 	// Prepare stdin for plugin usage by switching it to a pipe
-	setupStdin()
+	// But do not switch to pipe in plugin
+	if os.Getenv(plugin.MagicCookieKey) != plugin.MagicCookieValue {
+		setupStdin()
+	}
 
 	config, err := loadConfig()
 	if err != nil {


### PR DESCRIPTION
new packer architecture (0.9.0) runs packer 'main' several time (plugin server processes)
therefore stdin.go:setupStdin is called several times, and creates several consumers for the piped stdin (stdin.go does io.Copy(w, originalStdin))
Several processes read stdin in the same time, that leads to race condition.

we can see in strace log that several processes read the same input, here is excerpt from strace output formated:
![thisfile](https://cloud.githubusercontent.com/assets/13113250/13728550/8495bbf4-e92d-11e5-957f-00f22589ab42.png)

to fix that we can check if packer main called as plugin, by checking plugin.MagicCookieKey os env variable, which is set when packer starts plugin process, and disable stdin redirection to a pipe, because it was redirected by parent.

Closes #3250