### PR TITLE
Handle SSH to VM with more than one NIC - vmware ISO builder

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -258,18 +258,37 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 		return "", err
 	}
 
-	record, err = r.read()
-	if err != nil {
-		return "", err
-	}
+	// Loop through interfaces
+	for {
+		record, err = r.read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
 
-	if record["IPAddress"] == "0.0.0.0" {
-		return "", errors.New("VM network port found, but no IP address")
+		if record["IPAddress"] == "0.0.0.0" {
+			continue
+		}
+		// When multiple NICs are connected to the same network, choose
+		// one that has a route back. This Dial should ensure that.
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", record["IPAddress"], d.Port), 2*time.Second)
+		if err != nil {
+			if e, ok := err.(*net.OpError); ok {
+				if e.Timeout() {
+					log.Printf("Timeout connecting to %s", record["IPAddress"])
+					continue
+				}
+			}
+		} else {
+			defer conn.Close()
+			address := record["IPAddress"]
+			state.Put("vm_address", address)
+			return address, nil
+		}
 	}
-
-	address := record["IPAddress"]
-	state.Put("vm_address", address)
-	return address, nil
+	return "", errors.New("No interface on the VM has an IP address ready")
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Using the VMware ISO builder, if a VM is configured with more than one NIC and one of those NICs doesn't have DHCP enabled, the Packer build will fail because it only tries the first entry from `esxcli network vm port list`, and ESXi seems to do some sorting. 

For example, here's the output when Packer attempts to get the SSH IP address of a 3 NIC VM when one NIC has DHCP disabled:
`[root@ovabuild-us:~] esxcli --formatter csv network vm port list -w 1734526
ActiveFilters,DVPortID,IPAddress,MACAddress,PortID,Portgroup,TeamUplink,UplinkPortID,vSwitch,
,,0.0.0.0,00:0c:29:0b:fd:3e,33554576,VM Network,vmnic0,33554434,vSwitch0,
,,172.29.76.211,00:0c:29:0b:fd:34,33554577,VM Network,vmnic0,33554434,vSwitch0,
,,172.29.77.178,00:0c:29:0b:fd:2a,33554578,VM Network,vmnic0,33554434,vSwitch0,`

Because the 0.0.0.0 comes first and that row is the only one Packer checks, the build fails. This PR adds a loop through the interfaces. The net.Dial probably isn't strictly necessary, but it helps in the case where one of the IP addresses might not have a route back which would cause a failure to communicate.

Previous to patching this our workaround was to set all but one NIC to `startConnected: "FALSE"` in the vmx_data. 

I believe this relates to [issue 2530](https://github.com/mitchellh/packer/issues/2530).