### PR TITLE
provisioner/puppet-masterless: Add ignore exit codes option

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -54,6 +54,9 @@ type Config struct {
 	// The directory from which the command will be executed.
 	// Packer requires the directory to exist when running puppet.
 	WorkingDir string `mapstructure:"working_directory"`
+
+	// If true, packer will ignore all exit-codes from a puppet run
+	IgnoreExitCodes bool `mapstructure:"ignore_exit_codes"`
 }
 
 type Provisioner struct {
@@ -242,7 +245,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return err
 	}
 
-	if cmd.ExitStatus != 0 && cmd.ExitStatus != 2 {
+	if cmd.ExitStatus != 0 && cmd.ExitStatus != 2 && !p.config.IgnoreExitCodes {
 		return fmt.Errorf("Puppet exited with a non-zero exit status: %d", cmd.ExitStatus)
 	}
 

--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -73,6 +73,9 @@ Optional parameters:
     configuration to be uploaded to the remote machine. Hiera data directories
     must be uploaded using the file provisioner separately.
 
+-   `ignore_exit_codes` (boolean) - If true, Packer will never consider the
+    provisioner a failure.
+
 -   `manifest_dir` (string) - The path to a local directory with manifests to be
     uploaded to the remote machine. This is useful if your main manifest file
     uses imports. This directory doesn't necessarily contain the


### PR DESCRIPTION
As for https://github.com/mitchellh/packer/pull/2280, this PR adds an option to ignore puppet exit codes during builds to the puppet-masterless provisioner. This will prevent us from failing builds for just warnings or unimportant errors.