### PR TITLE
Add keep_registered flag to keep the VM in esxi when building  vmware-iso on remote esxi

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -46,6 +46,7 @@ type Config struct {
 	Version             string   `mapstructure:"version"`
 	VMName              string   `mapstructure:"vm_name"`
 	BootCommand         []string `mapstructure:"boot_command"`
+	KeepRegistered      bool     `mapstructure:"keep_registered"`
 	SkipCompaction      bool     `mapstructure:"skip_compaction"`
 	VMXTemplatePath     string   `mapstructure:"vmx_template_path"`
 	VMXDiskTemplatePath string   `mapstructure:"vmx_disk_template_path"`
@@ -147,7 +148,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	if b.config.RemotePort == 0 {
 		b.config.RemotePort = 22
 	}
-
 	if b.config.VMXTemplatePath != "" {
 		if err := b.validateVMXTemplatePath(); err != nil {
 			errs = packer.MultiErrorAppend(

--- a/builder/vmware/iso/step_register.go
+++ b/builder/vmware/iso/step_register.go
@@ -41,6 +41,14 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(vmwcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+	if (config.KeepRegistered == true) && (!cancelled && !halted) {
+		ui.Say("Keeping virtual machine registered with ESX host (keep_registered = true)")
+		return
+	}
 
 	if remoteDriver, ok := driver.(RemoteDriver); ok {
 		if s.Format == "" {

--- a/builder/vmware/iso/step_register_test.go
+++ b/builder/vmware/iso/step_register_test.go
@@ -32,6 +32,10 @@ func TestStepRegister_remoteDriver(t *testing.T) {
 	step := new(StepRegister)
 
 	driver := new(RemoteDriverMock)
+	var config Config
+	config.KeepRegistered = false
+	state.Put("config", &config)
+
 	state.Put("driver", driver)
 	state.Put("vmx_path", "foo")
 
@@ -61,5 +65,31 @@ func TestStepRegister_remoteDriver(t *testing.T) {
 	}
 	if driver.UnregisterPath != "foo" {
 		t.Fatal("should unregister proper path")
+	}
+}
+func TestStepRegister_WithoutUnregister_remoteDriver(t *testing.T) {
+	state := testState(t)
+	step := new(StepRegister)
+
+	driver := new(RemoteDriverMock)
+	var config Config
+	config.KeepRegistered = true 
+	state.Put("config", &config)
+
+	state.Put("driver", driver)
+	state.Put("vmx_path", "foo")
+
+	// Test the run
+	if action := step.Run(state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// cleanup
+	step.Cleanup(state)
+	if driver.UnregisterCalled {
+		t.Fatal("unregister should not be called")
 	}
 }

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -221,6 +221,11 @@ builder.
     slightly larger. If you find this to be the case, you can disable compaction
     using this configuration value.
 
+-   `keep_registered` (boolean) - Set this to `true` if you would like to keep
+    the VM registered with the remote ESXi server. This is convenient if you
+    use packer to provision VMs on ESXi and don't want to use ovftool to
+    deploy the resulting artifact (VMX or OVA or whatever you used as `format`)
+
 -   `tools_upload_flavor` (string) - The flavor of the VMware Tools ISO to
     upload into the VM. Valid values are "darwin", "linux", and "windows". By
     default, this is empty, which means VMware tools won't be uploaded.


### PR DESCRIPTION
As discussed in #2579 this is just doing what the subject says. Original patch applied cleanly against current master and survived a "go test". 