### PR TITLE
Fix up azure-arm examples: make sure the variable names line up.

### DIFF
--- a/examples/azure/centos.json
+++ b/examples/azure/centos.json
@@ -12,12 +12,12 @@
   "builders": [{
     "type": "azure-arm",
 
-    "client_id": "{{user `cid`}}",
-    "client_secret": "{{user `cst`}}",
-    "subscription_id": "{{user `sid`}}",
-    "tenant_id": "{{user `tid`}}",
-    "resource_group_name": "{{user `rgn`}}",
-    "storage_account": "{{user `sa`}}",
+    "client_id": "{{user `client_id`}}",
+    "client_secret": "{{user `client_secret`}}",
+    "resource_group_name": "{{user `resource_group`}}",
+    "storage_account": "{{user `storage_account`}}",
+    "subscription_id": "{{user `subscription_id`}}",
+    "tenant_id": "{{user `tenant_id`}}",
 
     "capture_container_name": "images",
     "capture_name_prefix": "packer",

--- a/examples/azure/debian.json
+++ b/examples/azure/debian.json
@@ -12,12 +12,12 @@
   "builders": [{
     "type": "azure-arm",
 
-    "client_id": "{{user `cid`}}",
-    "client_secret": "{{user `cst`}}",
-    "subscription_id": "{{user `sid`}}",
-    "tenant_id": "{{user `tid`}}",
-    "resource_group_name": "{{user `rgn`}}",
-    "storage_account": "{{user `sa`}}",
+    "client_id": "{{user `client_id`}}",
+    "client_secret": "{{user `client_secret`}}",
+    "resource_group_name": "{{user `resource_group`}}",
+    "storage_account": "{{user `storage_account`}}",
+    "subscription_id": "{{user `subscription_id`}}",
+    "tenant_id": "{{user `tenant_id`}}",
 
     "capture_container_name": "images",
     "capture_name_prefix": "packer",

--- a/examples/azure/opensuse.json
+++ b/examples/azure/opensuse.json
@@ -12,12 +12,12 @@
   "builders": [{
     "type": "azure-arm",
 
-    "client_id": "{{user `cid`}}",
-    "client_secret": "{{user `cst`}}",
-    "subscription_id": "{{user `sid`}}",
-    "tenant_id": "{{user `tid`}}",
-    "resource_group_name": "{{user `rgn`}}",
-    "storage_account": "{{user `sa`}}",
+    "client_id": "{{user `client_id`}}",
+    "client_secret": "{{user `client_secret`}}",
+    "resource_group_name": "{{user `resource_group`}}",
+    "storage_account": "{{user `storage_account`}}",
+    "subscription_id": "{{user `subscription_id`}}",
+    "tenant_id": "{{user `tenant_id`}}",
 
     "capture_container_name": "images",
     "capture_name_prefix": "packer",


### PR DESCRIPTION
The azure-arm examples for centos, debian and opensuse had misaligned variable names. This PR fixes that.
