### PR TITLE
Fix Scanner buffer too long error in ansible-remote provisioner

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"golang.org/x/crypto/ssh"
 
@@ -327,12 +328,21 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 
 	wg := sync.WaitGroup{}
 	repeat := func(r io.ReadCloser) {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			ui.Message(scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			ui.Error(err.Error())
+		reader := bufio.NewReader(r)
+		for {
+			line, err := reader.ReadString('\n')
+			if line != "" {
+				line = strings.TrimRightFunc(line, unicode.IsSpace)
+				ui.Message(line)
+			}
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					ui.Error(err.Error())
+					break
+				}
+			}
 		}
 		wg.Done()
 	}


### PR DESCRIPTION
The ansible provisioner uses a bufio.Scanner to forward lines from internal SSH to packer UI.

Ansible may produce lines longer than 65535 characters which causes the Scanner instance to crash.

This replaces the Scanner with a Reader and uses the ReadString method to read an arbitrary large line from the ansible-playbook stdout pipe.

It closes #3268 but there are not tests yet, see issue for discussion.