### PR TITLE
Use Fprint instead of Fprintf

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -231,7 +231,7 @@ func (c BuildCommand) Run(args []string) int {
 				fmt.Fprintf(&message, "--> %s: ", name)
 
 				if artifact != nil {
-					fmt.Fprintf(&message, artifact.String())
+					fmt.Fprint(&message, artifact.String())
 				} else {
 					fmt.Fprint(&message, "<nothing>")
 				}


### PR DESCRIPTION
The Azure builder outputs SAS URLs that containn formatting characters, which caused the use of Fprintf to garble the output with "!A(MISSING)".  I think the use of **Fprintf** was accidental, so I'm changing it to **Fprint**.