### PR TITLE
Swap width and height when allocating a pty

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -94,7 +94,7 @@ func (c *comm) Start(cmd *packer.RemoteCmd) (err error) {
 			ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
 		}
 
-		if err = session.RequestPty("xterm", 80, 40, termModes); err != nil {
+		if err = session.RequestPty("xterm", 40, 80, termModes); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
RequestPty from crypto/ssh looks like this:

func (s *Session) RequestPty(term string, h, w int, termmodes TerminalModes) error

So arguments 2 and 3 are height and width, respectively. I'm not sure if
the original was just a typo, or if there's an actual reason we want a
40 column terminal. Either way, having a terminal this narrow led me to
a really "fun" bug[0], where `wget` in my shell provisioner scripts
would segfault when trying to display the progress bar.

[0] http://lists.gnu.org/archive/html/bug-wget/2016-02/msg00041.html