### PR TITLE
Modify documents of extra_arguments for both ansible(remote) and ansi…

### DIFF
--- a/website/source/docs/provisioners/ansible-local.html.md
+++ b/website/source/docs/provisioners/ansible-local.html.md
@@ -52,6 +52,11 @@ Optional:
 
 -   `extra_arguments` (array of strings) - An array of extra arguments to pass
     to the ansible command. By default, this is empty.
+    Usage example:
+
+```
+"extra_arguments": [ "--extra-vars \"Region={{user `Region`}} Stage={{user `Stage`}}\"" ]
+```
 
 -   `inventory_groups` (string) - A comma-separated list of groups to which
     packer will assign the host `127.0.0.1`. A value of `my_group_1,my_group_2`

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -84,7 +84,7 @@ Optional Parameters:
   Usage example:
 
 ```
-"extra_arguments": [ "--extra-vars", "\"Region={{user `Region`}} Stage={{user `Stage`}}\"" ]
+"extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
 ```
 
 - `ansible_env_vars` (array of strings) - Environment variables to set before running Ansible.


### PR DESCRIPTION
I should apologize for my misleading.

When I printed  out all variables in ansible, I found that the example in #3330 did not work well.
It just add another variable but not overwrite the role default variables as I expected.
After removed escaped double quote it just worked with packer 0.10.0.

#3353 mentioned the difference of "extra_arguments" behavior of "ansible (remote)" and "ansible-local".
Most Packer user may get confused without documentation.
Maybe we still need some example to indicate how to pass arguments to ansible before the behavior of ansible(remote) and ansible-local to be consistent.
I also add documents of ansible-local and It works well with packer 0.10.0.