### PR TITLE
Use config StateTimeout for DigitalOcean unlock and off transitions.

### DIFF
--- a/builder/digitalocean/step_power_off.go
+++ b/builder/digitalocean/step_power_off.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/digitalocean/godo"
 	"github.com/mitchellh/multistep"

--- a/builder/digitalocean/step_power_off.go
+++ b/builder/digitalocean/step_power_off.go
@@ -50,7 +50,7 @@ func (s *stepPowerOff) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Wait for the droplet to become unlocked for future steps
-	if err := waitForDropletUnlocked(client, dropletId, 4*time.Minute); err != nil {
+	if err := waitForDropletUnlocked(client, dropletId, c.StateTimeout); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error powering off droplet: %s", err)
 		state.Put("error", err)

--- a/builder/digitalocean/step_shutdown.go
+++ b/builder/digitalocean/step_shutdown.go
@@ -14,6 +14,7 @@ type stepShutdown struct{}
 
 func (s *stepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
+	c := state.Get("config").(Config)
 	ui := state.Get("ui").(packer.Ui)
 	dropletId := state.Get("droplet_id").(int)
 
@@ -63,7 +64,7 @@ func (s *stepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 		}
 	}()
 
-	err = waitForDropletState("off", dropletId, client, 2*time.Minute)
+	err = waitForDropletState("off", dropletId, client, c.StateTimeout)
 	if err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error shutting down droplet: %s", err)
@@ -72,7 +73,7 @@ func (s *stepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	if err := waitForDropletUnlocked(client, dropletId, 4*time.Minute); err != nil {
+	if err := waitForDropletUnlocked(client, dropletId, c.StateTimeout); err != nil {
 		// If we get an error the first time, actually report it
 		err := fmt.Errorf("Error shutting down droplet: %s", err)
 		state.Put("error", err)


### PR DESCRIPTION
The unlock and power off state transitions timeouts were hardcoded for DigitalOcean.
When their API is responding slowly, there was no way to prevent the builder from timing out.

This change makes the timeouts be controlled by the config's StateTimeout setting.
The default for this timeout is 6m. This is greater than the previously hardcoded values of 2m and 4m for the builder - so, a user who doesn't override StateTimeout will not get failures due to a shorter timeout.