### PR TITLE
Allow elevated powershell provisioner to use Communicator's password if none provided

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -59,7 +59,7 @@ $t.XmlText = @'
 </Task>
 '@
 $f = $s.GetFolder("\")
-$f.RegisterTaskDefinition($name, $t, 6, "{{.User}}", "{{.Password}}", 1, $null) | Out-Null
+$f.RegisterTaskDefinition($name, $t, 6, "{{.User}}", $env:WINRM_PASSWORD, 1, $null) | Out-Null
 $t = $f.GetTask("\$name")
 $t.Run($null) | Out-Null
 $timeout = 10

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -144,8 +144,8 @@ func TestProvisionerPrepare_Elevated(t *testing.T) {
 	config["elevated_user"] = "vagrant"
 	err := p.Prepare(config)
 
-	if err == nil {
-		t.Fatal("should have error (only provided elevated_user)")
+	if err != nil {
+		t.Fatal("should allow elevated_password to be empty for runtime injection by the communicator")
 	}
 
 	config["elevated_password"] = "vagrant"
@@ -590,7 +590,7 @@ func TestProvision_createCommandText(t *testing.T) {
 	p.config.ElevatedUser = "vagrant"
 	p.config.ElevatedPassword = "vagrant"
 	cmd, _ = p.createCommandText()
-	matched, _ := regexp.MatchString("powershell -executionpolicy bypass -file \"%TEMP%(.{1})packer-elevated-shell.*", cmd)
+	matched, _ := regexp.MatchString("set \"WINRM_USERNAME=vagrant\" & set \"WINRM_PASSWORD=vagrant\" & powershell -executionpolicy bypass -file \"%TEMP%(.{1})packer-elevated-shell.*", cmd)
 	if !matched {
 		t.Fatalf("Got unexpected elevated command: %s", cmd)
 	}

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -68,7 +68,10 @@ Optional parameters:
 
 -   `elevated_user` and `elevated_password` (string) - If specified, the
     PowerShell script will be run with elevated privileges using the given
-    Windows user.
+    Windows user. `elevated_password` may be omitted if the `elevated_user`
+    matches the [Communicator](docs/templates/communicator.html#winrm)
+    username (`winrm_username`), this is nice for certain builders (such as the
+    AWS builder) that can automatically detect the password on launch.
 
 -   `remote_path` (string) - The path where the script will be uploaded to in
     the machine. This defaults to "/tmp/script.sh". This value must be a


### PR DESCRIPTION
Currently, when using certain Builders (e.g. AWS EBS Provisioner) you can omit the `winrm_password` configuration key and it will be auto-populated - this is really nice, as it means we don't need to proactively create an account with permissions on the remote box and it's nice and secure.

However, if you want to do perform [elevated](https://www.packer.io/docs/provisioners/powershell.html#elevated_user)  actions with Powershell (such as applying updates) you need to specify the `elevated_username` and the `elevated_password` keys, meaning the benefits of the key based passwords is gone.

This PR means the process can be completely hands off. It does so by applying a simple template to the command in the Communicator just prior to execution over WinRM, and injecting the user/pass into the environment. The scheduled task can now use local environment variables to get its credentials. 

Tests and docs have been updated accordingly.