### PR TITLE
Support interaction using STDIN/STDOUT while command execution in Doc…

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -267,9 +267,10 @@ func (c *Communicator) run(cmd *exec.Cmd, remote *packer.RemoteCmd, outputFile *
 	// is truly complete (because the file will have data), what the
 	// exit status is (because Docker loses it because of the pty, not
 	// Docker's fault), and get the output (Docker bug).
-	remoteCmd := fmt.Sprintf("(%s); echo $? >%s",
+	remoteCmd := fmt.Sprintf("(%s); echo $? > %s/%s",
 		remote.Command,
-		filepath.Join(c.ContainerDir, filepath.Base(exitCodePath)))
+		c.ContainerDir,
+		filepath.Base(exitCodePath))
 
 	// Start the command
 	log.Printf("Executing in container %s: %#v", c.ContainerId, remoteCmd)


### PR DESCRIPTION
Docker builder communicator was changed to work with STDIN and STDOUT when command is executing like other communicators do. This functionality is vital for some provisioners (i.e. `ansible-remote`, because it runs `sftp-server` which communicates using stdin/stdout, see #3260 for details about issue).

I added test `TestInteractionByStdinStdout` which demonstrates this functionality.

Closes #3260