### PR TITLE
Move version to its own package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ bin: deps
 	@GO15VENDOREXPERIMENT=1 sh -c "$(CURDIR)/scripts/build.sh"
 
 releasebin: deps
-	@grep 'const VersionPrerelease = "dev"' version.go > /dev/null ; if [ $$? -eq 0 ]; then \
-		echo "ERROR: You must remove prerelease tags from version.go prior to release."; \
+	@grep 'const VersionPrerelease = "dev"' version/version.go > /dev/null ; if [ $$? -eq 0 ]; then \
+		echo "ERROR: You must remove prerelease tags from version/version.go prior to release."; \
 		exit 1; \
 	fi
 	@GO15VENDOREXPERIMENT=1 sh -c "$(CURDIR)/scripts/build.sh"
@@ -36,8 +36,8 @@ deps:
 	fi
 
 dev: deps
-	@grep 'const VersionPrerelease = ""' version.go > /dev/null ; if [ $$? -eq 0 ]; then \
-		echo "ERROR: You must add prerelease tags to version.go prior to making a dev build."; \
+	@grep 'const VersionPrerelease = ""' version/version.go > /dev/null ; if [ $$? -eq 0 ]; then \
+		echo "ERROR: You must add prerelease tags to version/version.go prior to making a dev build."; \
 		exit 1; \
 	fi
 	@PACKER_DEV=1 GO15VENDOREXPERIMENT=1 sh -c "$(CURDIR)/scripts/build.sh"

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-checkpoint"
 	"github.com/mitchellh/packer/command"
 	"github.com/mitchellh/packer/packer"
+	packerVersion "github.com/mitchellh/packer/version"
 )
 
 func init() {
@@ -33,9 +34,9 @@ func runCheckpoint(c *config) {
 		return
 	}
 
-	version := Version
-	if VersionPrerelease != "" {
-		version += fmt.Sprintf("-%s", VersionPrerelease)
+	version := packerVersion.Version
+	if packerVersion.VersionPrerelease != "" {
+		version += fmt.Sprintf("-%s", packerVersion.VersionPrerelease)
 	}
 
 	signaturePath := filepath.Join(configDir, "checkpoint_signature")

--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/packer/command"
+	"github.com/mitchellh/packer/version"
 )
 
 // Commands is the mapping of all the available Terraform commands.
@@ -53,9 +54,9 @@ func init() {
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
 				Meta:              *CommandMeta,
-				Revision:          GitCommit,
-				Version:           Version,
-				VersionPrerelease: VersionPrerelease,
+				Revision:          version.GitCommit,
+				Version:           version.Version,
+				VersionPrerelease: version.VersionPrerelease,
 				CheckFunc:         commandVersionCheck,
 			}, nil
 		},

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mitchellh/packer/command"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/mitchellh/packer/version"
 	"github.com/mitchellh/panicwrap"
 	"github.com/mitchellh/prefixedio"
 )
@@ -105,9 +106,7 @@ func wrappedMain() int {
 
 	log.SetOutput(os.Stderr)
 
-	log.Printf(
-		"[INFO] Packer version: %s %s %s",
-		Version, VersionPrerelease, GitCommit)
+	log.Printf("[INFO] Packer version: %s", version.FormattedVersion())
 	log.Printf("Packer Target OS/Arch: %s %s", runtime.GOOS, runtime.GOARCH)
 	log.Printf("Built with Go Version: %s", runtime.Version())
 
@@ -175,7 +174,7 @@ func wrappedMain() int {
 				PostProcessor: config.LoadPostProcessor,
 				Provisioner:   config.LoadProvisioner,
 			},
-			Version: Version,
+			Version: version.Version,
 		},
 		Cache: cache,
 		Ui:    ui,
@@ -188,7 +187,7 @@ func wrappedMain() int {
 		Commands:   Commands,
 		HelpFunc:   excludeHelpFunc(Commands, []string{"plugin"}),
 		HelpWriter: os.Stdout,
-		Version:    Version,
+		Version:    version.Version,
 	}
 
 	exitCode, err := cli.Run()

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,7 +37,7 @@ set +e
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "-X github.com/mitchellh/packer/version.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .
 set -e

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,9 @@
-package main
+package version
+
+import (
+	"bytes"
+	"fmt"
+)
 
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
@@ -10,3 +15,17 @@ const Version = "0.10.1"
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "dev"
+
+func FormattedVersion() string {
+	var versionString bytes.Buffer
+	fmt.Fprintf(&versionString, "%s", Version)
+	if VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, ".%s", VersionPrerelease)
+
+		if GitCommit != "" {
+			fmt.Fprintf(&versionString, " (%s)", GitCommit)
+		}
+	}
+
+	return versionString.String()
+}


### PR DESCRIPTION
Move version information to its own package to make version information accessible to sub-components.  It would be useful to include version information in all outbound requests for diagnostics and metrics.
