### PR TITLE
Seperate remote_path into remote_folder and remote_script.

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -44,8 +44,17 @@ type Config struct {
 	// your command(s) are executed.
 	Vars []string `mapstructure:"environment_vars"`
 
+	// The remote folder where the local shell script will be uploaded to.
+	// This should be set to a pre-existing directory, it defaults to /tmp
+	RemoteFolder string `mapstructure:"remote_folder"`
+
+	// The remote file name of the local shell script.
+	// This defaults to script_nnn.sh
+	RemoteFile string `mapstructure:"remote_file"`
+
 	// The remote path where the local shell script will be uploaded to.
 	// This should be set to a writable file that is in a pre-existing directory.
+	// This defaults to remote_folder/remote_file
 	RemotePath string `mapstructure:"remote_path"`
 
 	// The command used to execute the script. The '{{ .Path }}' variable
@@ -104,9 +113,17 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		p.config.RawStartRetryTimeout = "5m"
 	}
 
+	if p.config.RemoteFolder == "" {
+		p.config.RemoteFolder = "/tmp"
+	}
+
+	if p.config.RemoteFile == "" {
+		p.config.RemoteFile = fmt.Sprintf("script_%d.sh", rand.Intn(9999))
+	}
+
 	if p.config.RemotePath == "" {
 		p.config.RemotePath = fmt.Sprintf(
-			"/tmp/script_%d.sh", rand.Intn(9999))
+			"%s/%s", p.config.RemoteFolder, p.config.RemoteFile)
 	}
 
 	if p.config.Scripts == nil {

--- a/website/source/docs/provisioners/shell.html.md
+++ b/website/source/docs/provisioners/shell.html.md
@@ -78,10 +78,15 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
--   `remote_path` (string) - The filename where the script will be uploaded
-    to in the machine. This defaults to `/tmp/script_nnn.sh` where "nnn" is
-    a randomly generated number. This value must be a writable location and
-    any parent directories must already exist.
+-   `remote_folder` (string) - The folder where the uploaded script will reside on
+    the machine. This defaults to '/tmp'.
+
+-   `remote_file` (string) - The filename the uploaded script will have on the machine.
+    This defaults to 'script_nnn.sh'.
+
+-   `remote_path` (string) - The full path to the uploaded script will have on the
+     machine. By default this is remote_folder/remote_file, if set this option will
+     override both remote_folder and remote_file.
 
 -   `skip_clean` (boolean) - If true, specifies that the helper scripts 
     uploaded to the system will not be removed by Packer. This defaults to 


### PR DESCRIPTION
Commonly /tmp is set as noexec, as a result packer scripts
fail to run. In order to get around this one can set a
remote_path, whoever, remote path requires full filename
and path.

By making remote_path a combination of
remote_folder/remote_script we can change remote_folder
and keep the default script_nnn.sh