### PR TITLE
chef-client validation_key_path fixes

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -235,6 +235,14 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Error uploading encrypted data bag secret: %s", err)
 		}
 	}
+
+	if p.config.ValidationKeyPath != "" {
+		remoteValidationKeyPath = fmt.Sprintf("%s/validation.pem", p.config.StagingDir)
+		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, p.config.ValidationKeyPath); err != nil {
+			return fmt.Errorf("Error copying validation key: %s", err)
+		}
+	}
+
 	configPath, err := p.createConfig(
 		ui,
 		comm,
@@ -248,13 +256,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		p.config.SslVerifyMode)
 	if err != nil {
 		return fmt.Errorf("Error creating Chef config file: %s", err)
-	}
-
-	if p.config.ValidationKeyPath != "" {
-		remoteValidationKeyPath = fmt.Sprintf("%s/validation.pem", p.config.StagingDir)
-		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, p.config.ValidationKeyPath); err != nil {
-			return fmt.Errorf("Error copying validation key: %s", err)
-		}
 	}
 
 	jsonPath, err := p.createJson(ui, comm)


### PR DESCRIPTION
Updating order of operations prior p.createConfig to ensure that remoteValidationKeyPath is properly set. 

NOTE: Currently there are not any tests around testing the content of the files rendered or any of the actual provision steps and did not address that here. 

Closes #3466 
Closes #2961
Closes #3263 