### PR TITLE
Fix extra backslash in front of dollar signs in website documentation

### DIFF
--- a/website/source/intro/getting-started/parallel-builds.html.md
+++ b/website/source/intro/getting-started/parallel-builds.html.md
@@ -45,10 +45,10 @@ this example.
 
 In order to do this, you'll need an account with DigitalOcean. [Sign up for an
 account now](https://www.digitalocean.com/). It is free to sign up. Because the
-"droplets" (servers) are charged hourly, you *will* be charged \$0.01 for every
+"droplets" (servers) are charged hourly, you *will* be charged $0.01 for every
 image you create with Packer. If you're not okay with this, just follow along.
 
-!&gt; **Warning!** You *will* be charged \$0.01 by DigitalOcean per image
+!&gt; **Warning!** You *will* be charged $0.01 by DigitalOcean per image
 created with Packer because of the time the "droplet" is running.
 
 Once you sign up for an account, grab your API token from the [DigitalOcean API


### PR DESCRIPTION
The dollar signs do not need to be escaped. The backslashes show up on
the website right now. This commit makes it so that they do not show up
on the website.

https://www.packer.io/intro/getting-started/parallel-builds.html

![image](https://cloud.githubusercontent.com/assets/385448/14894889/f09778c6-0d43-11e6-8458-b412c85fad5c.png)