### PR TITLE
Correct staging directory name for chef-solo provisioner

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -29,12 +29,12 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: guestOSTypeConfig{
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-solo --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
 		installCommand: "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo {{end}}bash",
-		stagingDir:     "/tmp/packer-chef-client",
+		stagingDir:     "/tmp/packer-chef-solo",
 	},
 	provisioner.WindowsOSType: guestOSTypeConfig{
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
 		installCommand: "powershell.exe -Command \"(New-Object System.Net.WebClient).DownloadFile('http://chef.io/chef/install.msi', 'C:\\Windows\\Temp\\chef.msi');Start-Process 'msiexec' -ArgumentList '/qb /i C:\\Windows\\Temp\\chef.msi' -NoNewWindow -Wait\"",
-		stagingDir:     "C:/Windows/Temp/packer-chef-client",
+		stagingDir:     "C:/Windows/Temp/packer-chef-solo",
 	},
 }
 


### PR DESCRIPTION
So that the code reflects the documentation:

> By default this is "/tmp/packer-chef-solo" when guest_os_type unix and "$env:TEMP/packer-chef-solo" when windows.