### PR TITLE
Update winrmcp revision to include Windows path fix

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -379,7 +379,7 @@
 		},
 		{
 			"ImportPath": "github.com/packer-community/winrmcp/winrmcp",
-			"Rev": "f1bcf36a69fa2945e65dd099eee11b560fbd3346"
+			"Rev": "edcdaf386f9ed1b7e6a2cf826d6a4a2963be3aa5"
 		},
 		{
 			"ImportPath": "github.com/pierrec/lz4",


### PR DESCRIPTION
On Windows, **packer**'s `file` provisioner fails to copy files/directories where the effective destination path includes both a volume identifier (e.g. `C:`) _and_ spaces in the path.  For example, if this is the structure of the local `system` directory (i.e. the system on which **packer** is invoked):
```
system/Program Files/MyApp/MyConfigFile.ini
```
and this is the related `file` provisioner:
```
  "provisioners": [
    {
      "type": "file",
      "source": "{{template_dir}}/system",
      "destination": "C:\\"
    }
  ]
```
the **packer** build will fail with an error similar to:
```
Error restoring file from $env:TEMP\winrmcp-57240961-974c-217b-2732-179c243988e1.tmp to
'C:\\Program Files\MyApp\MyConfigFile.ini': restore operation returned code=1
```
The root cause of this error was found to be embedded single quotes, added by the [winrmcp](https://github.com/packer-community/winrmcp/winrmcp) project, as discussed in https://github.com/packer-community/winrmcp/pull/14.

This [updated winrmcp revision](https://github.com/packer-community/winrmcp/commit/edcdaf386f9ed1b7e6a2cf826d6a4a2963be3aa5) includes the fix to resolve this issue.

Closes https://github.com/mitchellh/packer/issues/2714