### PR TITLE
RFC: Use the default AppVeyor version of Go.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,18 +12,12 @@ os: Windows Server 2012 R2
 
 environment:
   GOPATH: c:\gopath
-  matrix:
-  - GOARCH: amd64
-    GOVERSION: 1.6
 
 clone_folder: c:\gopath\src\github.com\mitchellh\packer
 
 install:
-  - set Path=c:\go\bin;%Path%
   - set GO15VENDOREXPERIMENT=1
   - echo %Path%
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-%GOARCH%.msi
-  - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
   - go version
   - go env
   - go get github.com/mitchellh/gox


### PR DESCRIPTION
AppVeyor comes with Go 1.6 amd64 preinstalled, and added to the path.  There's no need to re-download.

See https://www.appveyor.com/docs/installed-software#go

Unfortunately, there's no way to track 1.6 when AppVeyor upgrades to the next version of Go.  This is why I marked the PR as RFC.  I'll log an issue with AppVeyor to get their thoughts.