### PR TITLE
post-processor/compress: add bgzf compressor

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -308,8 +308,12 @@
 		},
 		{
 			"ImportPath": "github.com/klauspost/pgzip",
-			"Rev": "47f36e165cecae5382ecf1ec28ebf7d4679e307d"
+			"Rev": "95e8170c5d4da28db9c64dfc9ec3138ea4466fd4"
 		},
+		{
+			"ImportPath": "github.com/biogo/hts/bgzf",
+			"Rev": "50da7d4131a3b5c9d063932461cab4d1fafb20b0"
+                },
 		{
 			"ImportPath": "github.com/kr/fs",
 			"Rev": "2788f0dbd16903de03cb8186e5c7d97b69ad387b"

--- a/post-processor/compress/artifact.go
+++ b/post-processor/compress/artifact.go
@@ -8,16 +8,8 @@ import (
 const BuilderId = "packer.post-processor.compress"
 
 type Artifact struct {
-	Path     string
-	Provider string
-	files    []string
-}
-
-func NewArtifact(provider, path string) *Artifact {
-	return &Artifact{
-		Path:     path,
-		Provider: provider,
-	}
+	Path  string
+	files []string
 }
 
 func (a *Artifact) BuilderId() string {
@@ -33,7 +25,7 @@ func (a *Artifact) Files() []string {
 }
 
 func (a *Artifact) String() string {
-	return fmt.Sprintf("'%s' compressing: %s", a.Provider, a.Path)
+	return fmt.Sprintf("compressed artifacts in: %s", a.Path)
 }
 
 func (*Artifact) State(name string) interface{} {

--- a/post-processor/compress/post-processor.go
+++ b/post-processor/compress/post-processor.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 
+	"github.com/biogo/hts/bgzf"
 	"github.com/klauspost/pgzip"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/helper/config"
@@ -36,6 +37,7 @@ type Config struct {
 
 	// Fields from config file
 	OutputPath        string `mapstructure:"output"`
+	Format            string `mapstructure:"format"`
 	CompressionLevel  int    `mapstructure:"compression_level"`
 	KeepInputArtifact bool   `mapstructure:"keep_input_artifact"`
 
@@ -115,6 +117,10 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	keep := p.config.KeepInputArtifact
 	newArtifact := &Artifact{Path: target}
 
+	if err = os.MkdirAll(filepath.Dir(target), os.FileMode(0755)); err != nil {
+		return nil, false, fmt.Errorf(
+			"Unable to create dir for archive %s: %s", target, err)
+	}
 	outputFile, err := os.Create(target)
 	if err != nil {
 		return nil, false, fmt.Errorf(
@@ -126,6 +132,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	// compression writer. Otherwise it's just a file.
 	var output io.WriteCloser
 	switch p.config.Algorithm {
+	case "bgzf":
+		ui.Say(fmt.Sprintf("Using bgzf compression with %d cores for %s",
+			runtime.GOMAXPROCS(-1), target))
+		output, err = makeBGZFWriter(outputFile, p.config.CompressionLevel)
+		defer output.Close()
 	case "lz4":
 		ui.Say(fmt.Sprintf("Using lz4 compression with %d cores for %s",
 			runtime.GOMAXPROCS(-1), target))
@@ -190,15 +201,21 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 }
 
 func (config *Config) detectFromFilename() {
+	var result [][]string
 
 	extensions := map[string]string{
-		"tar": "tar",
-		"zip": "zip",
-		"gz":  "pgzip",
-		"lz4": "lz4",
+		"tar":  "tar",
+		"zip":  "zip",
+		"gz":   "pgzip",
+		"lz4":  "lz4",
+		"bgzf": "bgzf",
 	}
 
-	result := filenamePattern.FindAllStringSubmatch(config.OutputPath, -1)
+	if config.Format == "" {
+		result = filenamePattern.FindAllStringSubmatch(config.OutputPath, -1)
+	} else {
+		result = filenamePattern.FindAllStringSubmatch(fmt.Sprintf("%s.%s", config.OutputPath, config.Format), -1)
+	}
 
 	// No dots. Bail out with defaults.
 	if len(result) == 0 {
@@ -238,6 +255,14 @@ func (config *Config) detectFromFilename() {
 	config.Algorithm = "pgzip"
 	config.Archive = "tar"
 	return
+}
+
+func makeBGZFWriter(output io.WriteCloser, compressionLevel int) (io.WriteCloser, error) {
+	bgzfWriter, err := bgzf.NewWriterLevel(output, compressionLevel, runtime.GOMAXPROCS(-1))
+	if err != nil {
+		return nil, ErrInvalidCompressionLevel
+	}
+	return bgzfWriter, nil
 }
 
 func makeLZ4Writer(output io.WriteCloser, compressionLevel int) (io.WriteCloser, error) {

--- a/website/source/docs/post-processors/compress.html.md
+++ b/website/source/docs/post-processors/compress.html.md
@@ -31,6 +31,9 @@ you will need to specify the `output` option.
     you are executing multiple builders in parallel you should make sure
     `output` is unique for each one. For example `packer_{{.BuildName}}.zip`.
 
+-   `format` (string) - Disable archive format autodetection and use provided
+    string.
+
 -   `compression_level` (integer) - Specify the compression level, for
     algorithms that support it, from 1 through 9 inclusive. Typically higher
     compression levels take longer but produce smaller files. Defaults to `6`


### PR DESCRIPTION
- Add bgzf compressor support. BGZF allows to seek inside compressed file.
- Also added `format` (string) - Disable archive format autodetection.
- Update `pgzip` to get  sse4 and avx optimizations.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>