### PR TITLE
Go's -X linker flag now requires only one argument

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,7 +37,7 @@ set +e
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -ldflags "-X github.com/mitchellh/packer/version.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "-X github.com/mitchellh/packer/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .
 set -e


### PR DESCRIPTION
This fixes building `packer` with Go >1.6.  From https://golang.org/cmd/link/:

```
-X importpath.name=value
	Set the value of the string variable in importpath named name to value.
	Note that before Go 1.5 this option took two separate arguments.
	Now it takes one argument split on the first = sign.
```