### PR TITLE
Update WinRM to address connect issue.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -329,11 +329,11 @@
 		},
 		{
 			"ImportPath": "github.com/masterzen/winrm/soap",
-			"Rev": "54ea5d01478cfc2afccec1504bd0dfcd8c260cfa"
+			"Rev": "3bcd362f63ba55f1c01757da148e6a4cdad5e996"
 		},
 		{
 			"ImportPath": "github.com/masterzen/winrm/winrm",
-			"Rev": "54ea5d01478cfc2afccec1504bd0dfcd8c260cfa"
+			"Rev": "3bcd362f63ba55f1c01757da148e6a4cdad5e996"
 		},
 		{
 			"ImportPath": "github.com/masterzen/xmlpath",
@@ -393,7 +393,7 @@
 		},
 		{
 			"ImportPath": "github.com/packer-community/winrmcp/winrmcp",
-			"Rev": "f1bcf36a69fa2945e65dd099eee11b560fbd3346"
+			"Rev": "edcdaf386f9ed1b7e6a2cf826d6a4a2963be3aa5"
 		},
 		{
 			"ImportPath": "github.com/pierrec/lz4",

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -30,17 +30,16 @@ func New(config *Config) (*Communicator, error) {
 		Port:     config.Port,
 		HTTPS:    config.Https,
 		Insecure: config.Insecure,
+		Timeout:  config.ConnectTimeout,
 
 		/*
 			TODO
-			HTTPS:    connInfo.HTTPS,
-			Insecure: connInfo.Insecure,
 			CACert:   connInfo.CACert,
 		*/
 	}
 
 	// Create the client
-	params := winrm.DefaultParameters()
+	params := winrm.DefaultParameters
 
 	if config.TransportDecorator != nil {
 		params.TransportDecorator = config.TransportDecorator
@@ -158,6 +157,7 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		},
 		Https:                 c.config.Https,
 		Insecure:              c.config.Insecure,
+		ConnectTimeout:        c.config.ConnectTimeout,
 		OperationTimeout:      c.config.Timeout,
 		MaxOperationsPerShell: 15, // lowest common denominator
 		TransportDecorator:    c.config.TransportDecorator,

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -46,11 +46,12 @@ func TestStart(t *testing.T) {
 	defer wrm.Close()
 
 	c, err := New(&Config{
-		Host:     wrm.Host,
-		Port:     wrm.Port,
-		Username: "user",
-		Password: "pass",
-		Timeout:  30 * time.Second,
+		Host:           wrm.Host,
+		Port:           wrm.Port,
+		Username:       "user",
+		Password:       "pass",
+		ConnectTimeout: 10 * time.Second,
+		Timeout:        30 * time.Second,
 	})
 	if err != nil {
 		t.Fatalf("error creating communicator: %s", err)
@@ -77,11 +78,12 @@ func TestUpload(t *testing.T) {
 	defer wrm.Close()
 
 	c, err := New(&Config{
-		Host:     wrm.Host,
-		Port:     wrm.Port,
-		Username: "user",
-		Password: "pass",
-		Timeout:  30 * time.Second,
+		Host:           wrm.Host,
+		Port:           wrm.Port,
+		Username:       "user",
+		Password:       "pass",
+		ConnectTimeout: 10 * time.Second,
+		Timeout:        30 * time.Second,
 	})
 	if err != nil {
 		t.Fatalf("error creating communicator: %s", err)

--- a/communicator/winrm/config.go
+++ b/communicator/winrm/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Port               int
 	Username           string
 	Password           string
+	ConnectTimeout     time.Duration
 	Timeout            time.Duration
 	Https              bool
 	Insecure           bool

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	WinRMPassword           string        `mapstructure:"winrm_password"`
 	WinRMHost               string        `mapstructure:"winrm_host"`
 	WinRMPort               int           `mapstructure:"winrm_port"`
+	WinRMConnectTimeout     time.Duration `mapstructure:"winrm_connect_timeout"`
 	WinRMTimeout            time.Duration `mapstructure:"winrm_timeout"`
 	WinRMUseSSL             bool          `mapstructure:"winrm_use_ssl"`
 	WinRMInsecure           bool          `mapstructure:"winrm_insecure"`
@@ -143,6 +144,10 @@ func (c *Config) prepareWinRM(ctx *interpolate.Context) []error {
 		c.WinRMPort = 5986
 	} else if c.WinRMPort == 0 {
 		c.WinRMPort = 5985
+	}
+
+	if c.WinRMConnectTimeout == 0 {
+		c.WinRMConnectTimeout = 60 * time.Second
 	}
 
 	if c.WinRMTimeout == 0 {

--- a/helper/communicator/config_test.go
+++ b/helper/communicator/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mitchellh/packer/template/interpolate"
+	"time"
 )
 
 func testConfig() *Config {
@@ -99,6 +100,24 @@ func TestConfig_winrm_port_ssl(t *testing.T) {
 		t.Fatalf("WinRMPort doesn't match custom port 5510 when SSL is enabled.")
 	}
 
+}
+
+func TestConfig_winrm_timeout(t *testing.T) {
+	c := &Config{
+		Type:      "winrm",
+		WinRMUser: "admin",
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMConnectTimeout != 60 * time.Second {
+		t.Fatalf("WinRMConnectTimeout doesn't match default value of 60s.")
+	}
+
+	if c.WinRMTimeout != 30 * time.Minute {
+		t.Fatalf("WinRMTimeout doesn't match default value of 30m.")
+	}
 }
 
 func TestConfig_winrm(t *testing.T) {

--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -128,6 +128,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 			Port:               port,
 			Username:           user,
 			Password:           password,
+			ConnectTimeout:     s.Config.WinRMConnectTimeout,
 			Timeout:            s.Config.WinRMTimeout,
 			Https:              s.Config.WinRMUseSSL,
 			Insecure:           s.Config.WinRMInsecure,

--- a/vendor/github.com/masterzen/winrm/soap/message.go
+++ b/vendor/github.com/masterzen/winrm/soap/message.go
@@ -19,7 +19,6 @@ type MessageBuilder interface {
 	Header() *SoapHeader
 	Doc() *dom.Document
 	Free()
-
 	String() string
 }
 

--- a/vendor/github.com/masterzen/winrm/winrm/certgen.go
+++ b/vendor/github.com/masterzen/winrm/winrm/certgen.go
@@ -1,0 +1,241 @@
+package winrm
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// KeyType for RSA/ECDSA
+type KeyType uint8
+
+// CertConfig struct for
+// generating base certificates x509
+// for ssl/tls auth
+type CertConfig struct {
+	// Subject identifies the entity associated with the public
+	// key stored in the subject public key fields.
+	Subject pkix.Name
+	// ValidFrom creation date formated as Feb 16 10:04:20 2016
+	ValidFrom time.Time
+	// ValidFor the duration that certificate will be valid for
+	// The validity period for a certificate is the period of time
+	// form notBefore through notAfter, inclusive.
+	//	Note this fileds will be parsed into the notAfter,notBefore
+	//	x509 cert fields
+	ValidFor time.Duration
+	// SizeT can represent the size of bytes RSA cert if you specify in the
+	SizeT int
+	// Method to be RSA or it can be ECDSA flag if you specify the ECDSA flag
+	Method KeyType
+}
+
+// definition flags for specific elliptic curves formats
+const (
+	// P224 curve which implements P-224 (see FIPS 186-3, section D.2.2)
+	P224 = iota
+	// P256 curve which implements P-256 (see FIPS 186-3, section D.2.3)
+	P256
+	// P384 curve which implements P-384 (see FIPS 186-3, section D.2.4)
+	P384
+	// P521 curve which implements P-521 (see FIPS 186-3, section D.2.5)
+	P521
+
+	// definition flags for specific methods that the cert will be generated
+	// RSA method
+	RSA KeyType = iota
+	// ECDSA method
+	ECDSA
+)
+
+// OtherName type for asn1 encoding
+type OtherName struct {
+	A string `asn1:"utf8"`
+}
+
+// GeneralName type for asn1 encoding
+type GeneralName struct {
+	OID       asn1.ObjectIdentifier
+	OtherName `asn1:"tag:0"`
+}
+
+// GeneralNames type for asn1 encoding
+type GeneralNames struct {
+	GeneralName `asn1:"tag:0"`
+}
+
+var (
+	// https://support.microsoft.com/en-us/kb/287547
+	//  szOID_NT_PRINCIPAL_NAME 1.3.6.1.4.1.311.20.2.3
+	szOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 20, 2, 3}
+	// http://www.umich.edu/~x509/ssleay/asn1-oids.html
+	// 2 5 29 17  subjectAltName
+	subjAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+)
+
+//  getUPNExtensionValue returns marsheled asn1 encoded info
+func getUPNExtensionValue(subject pkix.Name) ([]byte, error) {
+	// returns the ASN.1 encoding of val
+	// in addition to the struct tags recognized
+	// we used:
+	// utf8 => causes string to be marsheled as ASN.1, UTF8 strings
+	// tag:x => specifies the ASN.1 tag number; imples ASN.1 CONTEXT SPECIFIC
+	return asn1.Marshal(GeneralNames{
+		GeneralName: GeneralName{
+			// init our ASN.1 object identifier
+			OID: szOID,
+			OtherName: OtherName{
+				A: subject.CommonName,
+			},
+		},
+	})
+}
+
+// NewCert generates a new x509 certificates based on the CertConfig passed
+func NewCert(config CertConfig) (string, string, error) {
+	var (
+		err       error
+		notAfter  time.Time
+		notBefore time.Time
+		// PrivateKey that can be:
+		// type e.g *rsa.PrivateKey
+		// or *ecdsa.PrivateKey
+		PrivateKey interface{}
+	)
+	// parse the time vars from the config into notAfter and notBefore
+	notBefore = config.ValidFrom
+	notAfter = notBefore.Add(config.ValidFor)
+
+	// choose the method to generate the certificate
+	switch config.Method {
+	case RSA:
+		PrivateKey, err = rsa.GenerateKey(rand.Reader, config.SizeT)
+		if err != nil {
+			return "", "", fmt.Errorf("Can't generate rsa private key")
+		}
+
+	// if the ECDSA byte is set
+	case ECDSA:
+		PrivateKey, err = genKeyEcdsa(config.SizeT)
+		if err != nil {
+			return "", "", fmt.Errorf("Can't generate ecdsa private key")
+		}
+	default:
+		return "", "", fmt.Errorf("Unknown method type to use")
+	}
+
+	// get asn1 encoded info of the subject pkix
+	value, err := getUPNExtensionValue(config.Subject)
+	if err != nil {
+		return "", "", fmt.Errorf("Can't marshal asn1 encoded")
+	}
+
+	// A serial number can be up to 20 octets in size.
+	// https://tools.ietf.org/html/rfc5280#section-4.1.2.2
+	serialNum, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 8*20))
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to generate serial number: %s", err.Error())
+	}
+
+	// make a new x509 temaplte certificate
+	// entry point for the generation process
+	template := x509.Certificate{
+		SerialNumber: serialNum,
+		Subject:      config.Subject,
+		// when extenstions are used, as expected in this profile,
+		// versions MUST be 3(value is 2).
+		Version:     2,
+		NotBefore:   config.ValidFrom,
+		NotAfter:    notAfter,
+		KeyUsage:    x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtraExtensions: []pkix.Extension{
+			{
+				Id:       subjAltName,
+				Critical: false,
+				Value:    value,
+			},
+		},
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, getPublicKey(PrivateKey), PrivateKey)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to generate cert")
+	}
+
+	certPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+
+	privPem, err := exportPrivKeyToPem(PrivateKey)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to export priv key")
+	}
+
+	return string(certPem), string(privPem), nil
+}
+
+// getPublicKey fetch public key with assertion
+func getPublicKey(p interface{}) interface{} {
+	switch t := p.(type) {
+	case *rsa.PrivateKey:
+		return t.Public()
+	case *ecdsa.PrivateKey:
+		return t.Public()
+	default:
+		return nil
+	}
+}
+
+// choose the format for the key and generate it
+func genKeyEcdsa(szT int) (*ecdsa.PrivateKey, error) {
+	switch szT {
+	case P224:
+		return ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case P256:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case P384:
+		return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case P521:
+		return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	default:
+		return nil, fmt.Errorf("Can't generate private key, please specify a format")
+	}
+
+}
+
+// ExportPrivKeyToPem exports private key from the previous generation
+func exportPrivKeyToPem(key interface{}) ([]byte, error) {
+
+	var pemBlock *pem.Block
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		pemBlock = &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(k),
+		}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to export ecdsa private key")
+		}
+		pemBlock = &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: b,
+		}
+	default:
+		return nil, fmt.Errorf("The private key is not RSA or ECDSA")
+	}
+
+	return pem.EncodeToMemory(pemBlock), nil
+}

--- a/vendor/github.com/masterzen/winrm/winrm/endpoint.go
+++ b/vendor/github.com/masterzen/winrm/winrm/endpoint.go
@@ -1,13 +1,19 @@
 package winrm
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
+// Endpoint struct holds configurations
+// for the server endpoint
 type Endpoint struct {
 	Host     string
 	Port     int
 	HTTPS    bool
 	Insecure bool
 	CACert   *[]byte
+	Timeout  time.Duration
 }
 
 func (ep *Endpoint) url() string {
@@ -19,4 +25,28 @@ func (ep *Endpoint) url() string {
 	}
 
 	return fmt.Sprintf("%s://%s:%d/wsman", scheme, ep.Host, ep.Port)
+}
+
+// NewEndpoint returns new pointer to struct Endpoint, with a default 60s response header timeout
+func NewEndpoint(host string, port int, https bool, insecure bool, cert *[]byte) *Endpoint {
+	return &Endpoint{
+		Host:     host,
+		Port:     port,
+		HTTPS:    https,
+		Insecure: insecure,
+		CACert:   cert,
+		Timeout:  60 * time.Second,
+	}
+}
+
+// NewEndpointWithTimeout returns a new Endpoint with a defined timeout
+func NewEndpointWithTimeout(host string, port int, https bool, insecure bool, cert *[]byte, timeout time.Duration) *Endpoint {
+	return &Endpoint{
+		Host:     host,
+		Port:     port,
+		HTTPS:    https,
+		Insecure: insecure,
+		CACert:   cert,
+		Timeout:  timeout,
+	}
 }

--- a/vendor/github.com/masterzen/winrm/winrm/parameters.go
+++ b/vendor/github.com/masterzen/winrm/winrm/parameters.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 )
 
+// Parameters struct defines
+// metadata information and http transport config
 type Parameters struct {
 	Timeout            string
 	Locale             string
@@ -11,10 +13,16 @@ type Parameters struct {
 	TransportDecorator func(*http.Transport) http.RoundTripper
 }
 
-func DefaultParameters() *Parameters {
-	return NewParameters("PT60S", "en-US", 153600)
-}
+// DefaultParameters return constant config
+// of type Parameters
+var DefaultParameters = NewParameters("PT60S", "en-US", 153600)
 
-func NewParameters(timeout string, locale string, envelopeSize int) *Parameters {
-	return &Parameters{Timeout: timeout, Locale: locale, EnvelopeSize: envelopeSize}
+// NewParameters return new struct of type Parameters
+// this struct makes the configuration for the request, size message, etc.
+func NewParameters(timeout, locale string, envelopeSize int) *Parameters {
+	return &Parameters{
+		Timeout:      timeout,
+		Locale:       locale,
+		EnvelopeSize: envelopeSize,
+	}
 }

--- a/vendor/github.com/masterzen/winrm/winrm/powershell.go
+++ b/vendor/github.com/masterzen/winrm/winrm/powershell.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 )
 
-// Wraps a PowerShell script and prepares it for execution by the winrm client
+// Powershell wraps a PowerShell script
+// and prepares it for execution by the winrm client
 func Powershell(psCmd string) string {
 	// 2 byte chars to make PowerShell happy
 	wideCmd := ""

--- a/vendor/github.com/masterzen/winrm/winrm/request.go
+++ b/vendor/github.com/masterzen/winrm/winrm/request.go
@@ -12,16 +12,16 @@ func genUUID() string {
 	return "uuid:" + uuid.String()
 }
 
-func defaultHeaders(message *soap.SoapMessage, url string, params *Parameters) (h *soap.SoapHeader) {
-	h = message.Header()
-	h.To(url).ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(params.EnvelopeSize).Id(genUUID()).Locale(params.Locale).Timeout(params.Timeout)
-	return
+func defaultHeaders(message *soap.SoapMessage, url string, params *Parameters) *soap.SoapHeader {
+	return message.Header().To(url).ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(params.EnvelopeSize).Id(genUUID()).Locale(params.Locale).Timeout(params.Timeout)
 }
 
+//NewOpenShellRequest makes a new soap request
 func NewOpenShellRequest(uri string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
+
 	message = soap.NewMessage()
 	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").AddOption(soap.NewHeaderOption("WINRS_NOPROFILE", "FALSE")).AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "65001")).Build()
 
@@ -33,9 +33,10 @@ func NewOpenShellRequest(uri string, params *Parameters) (message *soap.SoapMess
 	return
 }
 
+// NewDeleteShellRequest ...
 func NewDeleteShellRequest(uri string, shellId string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
 	message = soap.NewMessage()
 	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete").ShellId(shellId).ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").Build()
@@ -45,9 +46,10 @@ func NewDeleteShellRequest(uri string, shellId string, params *Parameters) (mess
 	return
 }
 
+// NewExecuteCommandRequest exec command on specific shellID
 func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
 	message = soap.NewMessage()
 	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).AddOption(soap.NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE")).AddOption(soap.NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).Build()
@@ -69,7 +71,7 @@ func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, 
 
 func NewGetOutputRequest(uri string, shellId string, commandId string, streams string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
 	message = soap.NewMessage()
 	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
@@ -83,7 +85,7 @@ func NewGetOutputRequest(uri string, shellId string, commandId string, streams s
 
 func NewSendInputRequest(uri string, shellId string, commandId string, input []byte, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
 	message = soap.NewMessage()
 
@@ -101,7 +103,7 @@ func NewSendInputRequest(uri string, shellId string, commandId string, input []b
 
 func NewSignalRequest(uri string, shellId string, commandId string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
-		params = DefaultParameters()
+		params = DefaultParameters
 	}
 	message = soap.NewMessage()
 

--- a/vendor/github.com/masterzen/winrm/winrm/shell.go
+++ b/vendor/github.com/masterzen/winrm/winrm/shell.go
@@ -2,20 +2,20 @@ package winrm
 
 // Shell is the local view of a WinRM Shell of a given Client
 type Shell struct {
-	client  *Client
-	ShellId string
+	client *Client
+	ID     string
 }
 
 // Execute command on the given Shell, returning either an error or a Command
 func (shell *Shell) Execute(command string, arguments ...string) (cmd *Command, err error) {
-	request := NewExecuteCommandRequest(shell.client.url, shell.ShellId, command, arguments, &shell.client.Parameters)
+	request := NewExecuteCommandRequest(shell.client.url, shell.ID, command, arguments, &shell.client.Parameters)
 	defer request.Free()
 
 	response, err := shell.client.sendRequest(request)
 	if err == nil {
-		var commandId string
-		if commandId, err = ParseExecuteCommandResponse(response); err == nil {
-			cmd = newCommand(shell, commandId)
+		var commandID string
+		if commandID, err = ParseExecuteCommandResponse(response); err == nil {
+			cmd = newCommand(shell, commandID)
 		}
 	}
 	return
@@ -23,7 +23,7 @@ func (shell *Shell) Execute(command string, arguments ...string) (cmd *Command, 
 
 // Close will terminate this shell. No commands can be issued once the shell is closed.
 func (shell *Shell) Close() (err error) {
-	request := NewDeleteShellRequest(shell.client.url, shell.ShellId, &shell.client.Parameters)
+	request := NewDeleteShellRequest(shell.client.url, shell.ID, &shell.client.Parameters)
 	defer request.Free()
 
 	_, err = shell.client.sendRequest(request)

--- a/vendor/github.com/packer-community/winrmcp/winrmcp/cp.go
+++ b/vendor/github.com/packer-community/winrmcp/winrmcp/cp.go
@@ -10,18 +10,21 @@ import (
 	"sync"
 
 	"github.com/masterzen/winrm/winrm"
-	"github.com/mitchellh/packer/common/uuid"
+	"github.com/nu7hatch/gouuid"
 )
 
 func doCopy(client *winrm.Client, config *Config, in io.Reader, toPath string) error {
-	tempFile := fmt.Sprintf("winrmcp-%s.tmp", uuid.TimeOrderedUUID())
+	tempFile, err := tempFileName()
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error generating unique filename: %v", err))
+	}
 	tempPath := "$env:TEMP\\" + tempFile
 
 	if os.Getenv("WINRMCP_DEBUG") != "" {
 		log.Printf("Copying file to %s\n", tempPath)
 	}
 
-	err := uploadContent(client, config.MaxOperationsPerShell, "%TEMP%\\"+tempFile, in)
+	err = uploadContent(client, config.MaxOperationsPerShell, "%TEMP%\\"+tempFile, in)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Error uploading file to %s: %v", tempPath, err))
 	}
@@ -113,7 +116,7 @@ func restoreContent(client *winrm.Client, fromPath, toPath string) error {
 	defer shell.Close()
 	script := fmt.Sprintf(`
 		$tmp_file_path = [System.IO.Path]::GetFullPath("%s")
-		$dest_file_path = [System.IO.Path]::GetFullPath("%s")
+		$dest_file_path = [System.IO.Path]::GetFullPath("%s".Trim("'"))
 		if (Test-Path $dest_file_path) {
 			rm $dest_file_path
 		}
@@ -197,4 +200,13 @@ func appendContent(shell *winrm.Shell, filePath, content string) error {
 	}
 
 	return nil
+}
+
+func tempFileName() (string, error) {
+	uniquePart, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("winrmcp-%s.tmp", uniquePart), nil
 }

--- a/vendor/github.com/packer-community/winrmcp/winrmcp/winrmcp.go
+++ b/vendor/github.com/packer-community/winrmcp/winrmcp/winrmcp.go
@@ -23,6 +23,7 @@ type Config struct {
 	Https                 bool
 	Insecure              bool
 	CACertBytes           []byte
+	ConnectTimeout        time.Duration
 	OperationTimeout      time.Duration
 	MaxOperationsPerShell int
 	TransportDecorator    func(*http.Transport) http.RoundTripper
@@ -42,7 +43,17 @@ func New(addr string, config *Config) (*Winrmcp, error) {
 		config = &Config{}
 	}
 
-	params := winrm.DefaultParameters()
+	connectTimeout := winrm.DefaultParameters.Timeout
+	if config.ConnectTimeout.Seconds() > 0 {
+		connectTimeout = iso8601.FormatDuration(config.ConnectTimeout)
+	}
+
+	params := winrm.NewParameters(
+		connectTimeout,
+		winrm.DefaultParameters.Locale,
+		winrm.DefaultParameters.EnvelopeSize,
+	)
+
 	if config.TransportDecorator != nil {
 		params.TransportDecorator = config.TransportDecorator
 	}

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -115,6 +115,11 @@ The WinRM communicator has the following options.
     become available. This defaults to "30m" since setting up a Windows
     machine generally takes a long time.
 
+  * `winrm_connect_timeout` (string) - The amount of time to wait for WinRM to connect.  When
+    the Windows firewall is on, and WinRM is not blocked, the connection will be accepted, but
+    no response will be sent by the WinRM server.  In this case, WinRM will wait indefinitely.
+    This prevents WinRM from waiting unnecessarily.  This defaults to "60s".
+
   * `winrm_use_ssl` (boolean) - If true, use HTTPS for WinRM
 
   * `winrm_insecure` (boolean) - If true, do not check server certificate


### PR DESCRIPTION
This PR is in reference to https://github.com/masterzen/winrm/pull/47.

  When the windows firewall is on, and winrm is not blocked, the
  connection will be accepted but no response will be sent by the winrm
  server.  In this case, the winrm client will wait almost indefinitely.
  This prevents packer from being able to detect when winrm is ready on a
  prepared VM.