### PR TITLE
Fix unit tests, broken in #3547

### DIFF
--- a/builder/parallels/common/step_test.go
+++ b/builder/parallels/common/step_test.go
@@ -9,6 +9,7 @@ import (
 
 func testState(t *testing.T) multistep.StateBag {
 	state := new(multistep.BasicStateBag)
+	state.Put("debug", false)
 	state.Put("driver", new(DriverMock))
 	state.Put("ui", &packer.BasicUi{
 		Reader: new(bytes.Buffer),


### PR DESCRIPTION
This will fix tests in the future when vmware, qemu, and vbox all grow similar tests to what's in Parallels.