### PR TITLE
Update to go-autorest v7.0.5.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,6 @@
 {
 	"ImportPath": "github.com/mitchellh/packer",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
 	"Deps": [
 		{
 			"ImportPath": "github.com/ActiveState/tail",
@@ -40,23 +39,23 @@
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.5",
+			"Rev": "4bdf29b663ebad9598d2c391b73a4b46bdedbf42"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.5",
+			"Rev": "4bdf29b663ebad9598d2c391b73a4b46bdedbf42"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.5",
+			"Rev": "4bdf29b663ebad9598d2c391b73a4b46bdedbf42"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/to",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.5",
+			"Rev": "4bdf29b663ebad9598d2c391b73a4b46bdedbf42"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-ntlmssp",

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
@@ -39,6 +39,10 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 			if err != nil {
 				return resp, err
 			}
+			pollingCodes := []int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
+			if !autorest.ResponseHasStatusCode(resp, pollingCodes...) {
+				return resp, nil
+			}
 
 			ps := pollingState{}
 			for err == nil {
@@ -224,10 +228,6 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 				ps.uri = req.URL.String()
 			}
 		}
-
-		if ps.uri == "" {
-			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", req.Method, req.RequestURI)
-		}
 	}
 
 	// Read and interpret the response (saving the Body in case no polling is necessary)
@@ -260,6 +260,10 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 		default:
 			ps.state = operationFailed
 		}
+	}
+
+	if ps.state == operationInProgress && ps.uri == "" {
+		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
 	}
 
 	// For failed operation, check for error code and message in

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
@@ -34,13 +34,13 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 		return fmt.Errorf("failed to create directory (%s) to store token in: %v", dir, err)
 	}
 
-	newFile, err := ioutil.TempFile(os.TempDir(), "token")
+	newFile, err := ioutil.TempFile(dir, "token")
 	if err != nil {
 		return fmt.Errorf("failed to create the temp file to write the token: %v", err)
 	}
 	tempPath := newFile.Name()
 
-	if json.NewEncoder(newFile).Encode(token); err != nil {
+	if err := json.NewEncoder(newFile).Encode(token); err != nil {
 		return fmt.Errorf("failed to encode token to file (%s) while saving token: %v", tempPath, err)
 	}
 	if err := newFile.Close(); err != nil {
@@ -49,7 +49,7 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 
 	// Atomic replace to avoid multi-writer file corruptions
 	if err := os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("failed to move temporary token to desired output location. source=(%s). destination=(%s). error = %v", tempPath, path, err)
+		return fmt.Errorf("failed to move temporary token to desired output location. src=%s dst=%s: %v", tempPath, path, err)
 	}
 	if err := os.Chmod(path, mode); err != nil {
 		return fmt.Errorf("failed to chmod the token file %s: %v", path, err)

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -2,6 +2,7 @@ package autorest
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -53,7 +54,9 @@ func (li LoggingInspector) WithInspection() PrepareDecorator {
 			defer r.Body.Close()
 
 			r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &body))
-			r.Write(&b)
+			if err := r.Write(&b); err != nil {
+				return nil, fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(requestFormat, b.String())
 
@@ -76,7 +79,9 @@ func (li LoggingInspector) ByInspecting() RespondDecorator {
 			defer resp.Body.Close()
 
 			resp.Body = ioutil.NopCloser(io.TeeReader(resp.Body, &body))
-			resp.Write(&b)
+			if err := resp.Write(&b); err != nil {
+				return fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(responseFormat, b.String())
 

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -95,7 +95,9 @@ func ByClosing() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})
@@ -109,7 +111,9 @@ func ByClosingIfError() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err != nil && resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})


### PR DESCRIPTION
This version of go-autorest better handles long running operations that require polling, and its treatments of errors.  See the [issue](https://github.com/Azure/azure-sdk-for-go/issues/328) in the azure-sdk-for-go repo for details.

To summarize, this update will ensure the Packer displays the best error message it can to help the user solve the problem.

Instead of this message.
```text
azure#updatePollingState: Azure Polling Error - Unable to obtain polling URI for POST : StatusCode=0
```

The user will now see this error message.
```text
Failure responding to request: StatusCode=400 -- Original Error: azure: Service returned an error. Code="InvalidParameter" Message="Container name images--ASLKAJS is invalid. Container names must be 3-63 characters in length and may contain only lower-case alphanumeric characters and hyphen. Hyphen must be preceeded and followed by an alphanumeric character." Status=400
```

Closes #3556.