### PR TITLE
Headless documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,7 +538,7 @@ BUG FIXES:
   * builder/parallels: Disconnect cdrom0 [GH-1605]
   * builder/qemu: Don't use `-redir` flag anymore, replace with
       `hostfwd` options. [GH-1561]
-  * builder/qmeu: Use `pc` as default machine type instead of `pc-1.0`.
+  * builder/qemu: Use `pc` as default machine type instead of `pc-1.0`.
   * providers/aws: Ignore transient network errors. [GH-1579]
   * provisioner/ansible: Don't buffer output so output streams in. [GH-1585]
   * provisioner/ansible: Use inventory file always to avoid potentially

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -78,6 +78,10 @@ In addition to the options listed here, a
 [communicator](/docs/templates/communicator.html) can be configured for this
 builder.
 
+Note that you will need to set `"headless": true` if you are running Packer
+on a Linux server without X11; or if you are connected via ssh to a remote
+Linux server and have not enabled X11 forwarding (`ssh -X`).
+
 ### Required:
 
 -   `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
@@ -166,6 +170,9 @@ builder.
 -   `headless` (boolean) - Packer defaults to building QEMU virtual machines by
     launching a GUI that shows the console of the machine being built. When this
     value is set to true, the machine will start without a console.
+
+    You can still see the console if you make a note of the VNC display
+    number chosen, and then connect using `vncviewer -Shared <host>:<display>`
 
 -   `http_directory` (string) - Path to a directory to serve using an
     HTTP server. The files in this directory will be available over HTTP that


### PR DESCRIPTION
Minor documentation notes on 'headless' for #3530

Does not fully close it: ideally I would like to see a CLI hint to use PACKER_LOG=1 if qemu fails to start, or to show the qemu error message.
