### PR TITLE
Adding reference to GetPasswordData in the Amazon builder docs

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -115,7 +115,8 @@ Packer to work:
         "ec2:DescribeImages",
         "ec2:RegisterImage",
         "ec2:CreateTags",
-        "ec2:ModifyImageAttribute"
+        "ec2:ModifyImageAttribute",
+        "ec2:GetPasswordData"
       ],
       "Resource" : "*"
   }]


### PR DESCRIPTION
Updating the documentation to require `ec2:GetPasswordData` for Windows builds. Fixes #3546