### PR TITLE
Add VNCDisplay and VNCPort template settings to qemu builder

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -25,6 +25,8 @@ type qemuArgsTemplateData struct {
 	OutputDir   string
 	Name        string
 	SSHHostPort uint
+	VNCPort     uint
+	VNCDisplay  uint
 }
 
 func (s *stepRun) Run(state multistep.StateBag) multistep.StepAction {
@@ -150,6 +152,8 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 			config.OutputDir,
 			config.VMName,
 			sshHostPort,
+			vncPort,
+			vncPort-5900,
 		}
 		newQemuArgs, err := processArgs(config.QemuArgs, &ctx)
 		if err != nil {

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -68,6 +68,23 @@ from an unknown source. Place this file in the http directory with the proper
 name. For the example above, it should go into "httpdir" with a name of
 "centos6-ks.cfg".
 
+## Security note
+
+During the build, the qemu console port is accessible over the network via
+VNC for debugging purposes.
+
+If you are running in an untrusted environment then you may want to block this.
+You can do this by binding the VNC service to localhost:
+
+~~~
+      "qemuargs": [
+        [ "-vnc", "127.0.0.1:{{ .VNCDisplay }}" ]
+      ]
+~~~
+
+Alternatively you may firewall off the VNC TCP port range (default 5900 to
+6000 inclusive)
+
 ## Configuration Reference
 
 There are many configuration options available for the Qemu builder. They are


### PR DESCRIPTION
Add new template variables to qemu builder: VNCPort, VNCDisplay. Document that the VNC console is open by default, and show how to lock it down:

~~~
      "qemuargs": [
        [ "-vnc", "127.0.0.1:{{ .VNCDisplay }}" ]
      ]
~~~

This change does not alter the current behaviour.

FOR CONSIDERATION: it would now be possible to change the default to 127.0.0.1. Users who still want the open console port can explicitly bind to `0.0.0.0` or `[::]` using qemuargs as above.

Closes #3533 