### PR TITLE
Clarify how to run with logs if qemu fails to start

### DIFF
--- a/builder/qemu/driver.go
+++ b/builder/qemu/driver.go
@@ -123,7 +123,7 @@ func (d *QemuDriver) Qemu(qemuArgs ...string) error {
 	select {
 	case exit := <-endCh:
 		if exit != 0 {
-			return fmt.Errorf("Qemu failed to start. Please run with logs to get more info.")
+			return fmt.Errorf("Qemu failed to start. Please run with PACKER_LOG=1 to get more info.")
 		}
 	case <-time.After(2 * time.Second):
 	}


### PR DESCRIPTION
SImple enhancement to error message given when qemu fails to start, to help newcomers who don't know about `PACKER_LOG=1`

Closes #3530 