### PR TITLE
Allow configurable VNC bind IP for VMware builders

### DIFF
--- a/builder/vmware/common/run_config.go
+++ b/builder/vmware/common/run_config.go
@@ -11,8 +11,9 @@ type RunConfig struct {
 	Headless    bool   `mapstructure:"headless"`
 	RawBootWait string `mapstructure:"boot_wait"`
 
-	VNCPortMin uint `mapstructure:"vnc_port_min"`
-	VNCPortMax uint `mapstructure:"vnc_port_max"`
+	VNCBindAddress string `mapstructure:"vnc_bind_address"`
+	VNCPortMin     uint   `mapstructure:"vnc_port_min"`
+	VNCPortMax     uint   `mapstructure:"vnc_port_max"`
 
 	BootWait time.Duration ``
 }
@@ -28,6 +29,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.VNCPortMax == 0 {
 		c.VNCPortMax = 6000
+	}
+
+	if c.VNCBindAddress == "" {
+		c.VNCBindAddress = "127.0.0.1"
 	}
 
 	var errs []error

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -21,15 +21,16 @@ import (
 // Produces:
 //   vnc_port uint - The port that VNC is configured to listen on.
 type StepConfigureVNC struct {
-	VNCPortMin uint
-	VNCPortMax uint
+	VNCBindAddress string
+	VNCPortMin     uint
+	VNCPortMax     uint
 }
 
 type VNCAddressFinder interface {
-	VNCAddress(uint, uint) (string, uint, error)
+	VNCAddress(string, uint, uint) (string, uint, error)
 }
 
-func (StepConfigureVNC) VNCAddress(portMin, portMax uint) (string, uint, error) {
+func (StepConfigureVNC) VNCAddress(vncBindAddress string, portMin, portMax uint) (string, uint, error) {
 	// Find an open VNC port. Note that this can still fail later on
 	// because we have to release the port at some point. But this does its
 	// best.
@@ -43,13 +44,13 @@ func (StepConfigureVNC) VNCAddress(portMin, portMax uint) (string, uint, error) 
 		}
 
 		log.Printf("Trying port: %d", vncPort)
-		l, err := net.Listen("tcp", fmt.Sprintf(":%d", vncPort))
+		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", vncBindAddress, vncPort))
 		if err == nil {
 			defer l.Close()
 			break
 		}
 	}
-	return "127.0.0.1", vncPort, nil
+	return vncBindAddress, vncPort, nil
 }
 
 func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
@@ -80,7 +81,7 @@ func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
 		vncFinder = s
 	}
 	log.Printf("Looking for available port between %d and %d", s.VNCPortMin, s.VNCPortMax)
-	vncIp, vncPort, err := vncFinder.VNCAddress(s.VNCPortMin, s.VNCPortMax)
+	vncBindAddress, vncPort, err := vncFinder.VNCAddress(s.VNCBindAddress, s.VNCPortMin, s.VNCPortMax)
 	if err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())
@@ -92,6 +93,7 @@ func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
 	vmxData := ParseVMX(string(vmxBytes))
 	vmxData["remotedisplay.vnc.enabled"] = "TRUE"
 	vmxData["remotedisplay.vnc.port"] = fmt.Sprintf("%d", vncPort)
+	vmxData["remotedisplay.vnc.ip"] = fmt.Sprintf("%s", vncBindAddress)
 
 	if err := WriteVMX(vmxPath, vmxData); err != nil {
 		err := fmt.Errorf("Error writing VMX data: %s", err)
@@ -101,7 +103,7 @@ func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	state.Put("vnc_port", vncPort)
-	state.Put("vnc_ip", vncIp)
+	state.Put("vnc_ip", vncBindAddress)
 
 	return multistep.ActionContinue
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -254,8 +254,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			HTTPPortMax: b.config.HTTPPortMax,
 		},
 		&vmwcommon.StepConfigureVNC{
-			VNCPortMin: b.config.VNCPortMin,
-			VNCPortMax: b.config.VNCPortMax,
+			VNCBindAddress: b.config.VNCBindAddress,
+			VNCPortMin:     b.config.VNCPortMin,
+			VNCPortMax:     b.config.VNCPortMax,
 		},
 		&StepRegister{
 			Format: b.config.Format,

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -176,7 +176,7 @@ func (d *ESX5Driver) HostIP() (string, error) {
 	return host, err
 }
 
-func (d *ESX5Driver) VNCAddress(portMin, portMax uint) (string, uint, error) {
+func (d *ESX5Driver) VNCAddress(vncBindIP string, portMin, portMax uint) (string, uint, error) {
 	var vncPort uint
 
 	//Process ports ESXi is listening on to determine which are available

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -79,8 +79,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			HTTPPortMax: b.config.HTTPPortMax,
 		},
 		&vmwcommon.StepConfigureVNC{
-			VNCPortMin: b.config.VNCPortMin,
-			VNCPortMax: b.config.VNCPortMax,
+			VNCBindAddress: b.config.VNCBindAddress,
+			VNCPortMin:     b.config.VNCPortMin,
+			VNCPortMax:     b.config.VNCPortMax,
 		},
 		&vmwcommon.StepRun{
 			BootWait:           b.config.BootWait,

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -266,6 +266,10 @@ builder.
     below for more information. For basic VMX modifications, try
     `vmx_data` first.
 
+-   `vnc_bind_address` (string / IP address) - The IP address that should be binded
+     to for VNC. By default packer will use 127.0.0.1 for this. If you wish to bind
+     to all interfaces use 0.0.0.0
+
 -   `vnc_port_min` and `vnc_port_max` (integer) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
     the initial `boot_command`. Because Packer generally runs in parallel,

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -145,6 +145,9 @@ builder.
     except that it is run after the virtual machine is shutdown, and before the
     virtual machine is exported.
 
+-   `vnc_bind_address` (string / IP address) - The IP address that should be binded
+     to for VNC. By default packer will use 127.0.0.1 for this.
+
 -   `vnc_port_min` and `vnc_port_max` (integer) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
     the initial `boot_command`. Because Packer generally runs in parallel,


### PR DESCRIPTION
We were passing a hard coded string of 127.0.0.1 for the VNC bind IP address, we never did fully pass this down into the VMX data.

This PR updates the code to default the bind IP to 127.0.0.1, otherwise taking an option from user configuration.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>