### PR TITLE
Allow configurable VRDP bind IP for VirtualBox builders

### DIFF
--- a/builder/virtualbox/common/run_config.go
+++ b/builder/virtualbox/common/run_config.go
@@ -11,8 +11,9 @@ type RunConfig struct {
 	Headless    bool   `mapstructure:"headless"`
 	RawBootWait string `mapstructure:"boot_wait"`
 
-	VRDPPortMin uint `mapstructure:"vrdp_port_min"`
-	VRDPPortMax uint `mapstructure:"vrdp_port_max"`
+	VRDPBindAddress string `mapstructure:"vrdp_bind_address"`
+	VRDPPortMin     uint   `mapstructure:"vrdp_port_min"`
+	VRDPPortMax     uint   `mapstructure:"vrdp_port_max"`
 
 	BootWait time.Duration ``
 }
@@ -20,6 +21,10 @@ type RunConfig struct {
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.RawBootWait == "" {
 		c.RawBootWait = "10s"
+	}
+
+	if c.VRDPBindAddress == "" {
+		c.VRDPBindAddress = "127.0.0.1"
 	}
 
 	if c.VRDPPortMin == 0 {

--- a/builder/virtualbox/common/run_config_test.go
+++ b/builder/virtualbox/common/run_config_test.go
@@ -35,3 +35,27 @@ func TestRunConfigPrepare_BootWait(t *testing.T) {
 		t.Fatalf("should not have error: %s", errs)
 	}
 }
+
+func TestRunConfigPrepare_VRDPBindAddress(t *testing.T) {
+	var c *RunConfig
+	var errs []error
+
+	// Test a default VRDPBindAddress
+	c = new(RunConfig)
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("should not have error: %s", errs)
+	}
+
+	if c.VRDPBindAddress != "127.0.0.1" {
+		t.Fatalf("bad value: %s", c.VRDPBindAddress)
+	}
+
+	// Test with a good one
+	c = new(RunConfig)
+	c.VRDPBindAddress = "192.168.0.1"
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("should not have error: %s", errs)
+	}
+}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -209,8 +209,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			GuestAdditionsMode: b.config.GuestAdditionsMode,
 		},
 		&vboxcommon.StepConfigureVRDP{
-			VRDPPortMin: b.config.VRDPPortMin,
-			VRDPPortMax: b.config.VRDPPortMax,
+			VRDPBindAddress: b.config.VRDPBindAddress,
+			VRDPPortMin:     b.config.VRDPPortMin,
+			VRDPPortMax:     b.config.VRDPPortMax,
 		},
 		new(vboxcommon.StepAttachFloppy),
 		&vboxcommon.StepForwardSSH{

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -78,8 +78,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			GuestAdditionsMode: b.config.GuestAdditionsMode,
 		},
 		&vboxcommon.StepConfigureVRDP{
-			VRDPPortMin: b.config.VRDPPortMin,
-			VRDPPortMax: b.config.VRDPPortMax,
+			VRDPBindAddress: b.config.VRDPBindAddress,
+			VRDPPortMin:     b.config.VRDPPortMin,
+			VRDPPortMax:     b.config.VRDPPortMax,
 		},
 		new(vboxcommon.StepAttachFloppy),
 		&vboxcommon.StepForwardSSH{

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -242,6 +242,10 @@ builder.
     machine, without the file extension. By default this is "packer-BUILDNAME",
     where "BUILDNAME" is the name of the build.
 
+-   `vrdp_bind_address` (string / IP address) - The IP address that should be binded
+     to for VRDP. By default packer will use 127.0.0.1 for this. If you wish to bind
+     to all interfaces use 0.0.0.0
+
 -   `vrdp_port_min` and `vrdp_port_max` (integer) - The minimum and maximum port
     to use for VRDP access to the virtual machine. Packer uses a randomly chosen
     port in this range that appears available. By default this is 5900 to 6000.

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -207,6 +207,9 @@ builder.
     is exported. By default this is "packer-BUILDNAME", where "BUILDNAME" is the
     name of the build.
 
+-   `vrdp_bind_address` (string / IP address) - The IP address that should be binded
+     to for VRDP. By default packer will use 127.0.0.1 for this.
+
 -   `vrdp_port_min` and `vrdp_port_max` (integer) - The minimum and maximum port
     to use for VRDP access to the virtual machine. Packer uses a randomly chosen
     port in this range that appears available. By default this is 5900 to 6000.


### PR DESCRIPTION
Allow the bind IP for VRDP to be set by a user. Default to 127.0.0.1, can be set to 0.0.0.0 to bind to everything.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>