### PR TITLE
append ANSIBLE_HOST_KEY_CHECKING correctly

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -312,7 +312,9 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 	cmd.Env = os.Environ()
 	if len(envvars) > 0 {
 		cmd.Env = append(cmd.Env, envvars...)
-	} else if !checkHostKey {
+	}
+
+	if !checkHostKey {
 		cmd.Env = append(cmd.Env, "ANSIBLE_HOST_KEY_CHECKING=False")
 	}
 


### PR DESCRIPTION
Append the ANSIBLE_HOST_KEY_CHECKING environment variable correctly
regardless of whether the template specifies some environment variables.