### PR TITLE
Lock down access to qemu console port to 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## (Unreleased)
 
+BACKWARDS INCOMPATIBILITIES:
+
+  * builder/qemu: for security, VNC console access is now limited to 127.0.0.1.  To re-enable
+    open console, specify `"qemuargs": [ "-vnc", "0.0.0.0:{{ .VNCDisplay }}" ]` [GH-3533]
+
 FEATURES:
 
   * **New Checksum post-processor**: Create a checksum file from your build artifacts as part of your build. [GH-3492]

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -25,6 +25,8 @@ type qemuArgsTemplateData struct {
 	OutputDir   string
 	Name        string
 	SSHHostPort uint
+	VNCPort     uint
+	VNCDisplay  uint
 }
 
 func (s *stepRun) Run(state multistep.StateBag) multistep.StepAction {
@@ -66,7 +68,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	ui := state.Get("ui").(packer.Ui)
 	driver := state.Get("driver").(Driver)
 
-	vnc := fmt.Sprintf("0.0.0.0:%d", vncPort-5900)
+	vnc := fmt.Sprintf("127.0.0.1:%d", vncPort-5900)
 	vmName := config.VMName
 	imgPath := filepath.Join(config.OutputDir, vmName)
 
@@ -150,6 +152,8 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 			config.OutputDir,
 			config.VMName,
 			sshHostPort,
+			vncPort,
+			vncPort-5900,
 		}
 		newQemuArgs, err := processArgs(config.QemuArgs, &ctx)
 		if err != nil {

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -172,7 +172,18 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     value is set to true, the machine will start without a console.
 
     You can still see the console if you make a note of the VNC display
-    number chosen, and then connect using `vncviewer -Shared <host>:<display>`
+    number chosen, and then connect using `vncviewer -Shared 127.0.0.1:<display>`
+
+    If you are running in a trusted environment, you can allow access over the
+    network to the console as follows:
+
+    ~~~
+          "qemuargs": [
+            [ "-vnc", "0.0.0.0:{{ .VNCDisplay }}" ]
+          ]
+    ~~~
+
+    You can then connect with `vncviewer -Shared <host>:<display>`
 
 -   `http_directory` (string) - Path to a directory to serve using an
     HTTP server. The files in this directory will be available over HTTP that


### PR DESCRIPTION
Alternative resolution to #3533: make VNC console bind by default to 127.0.0.1, but configurable to bind to 0.0.0.0