### PR TITLE
Check for nil when querying a certificate.

### DIFF
--- a/builder/azure/arm/step_get_certificate.go
+++ b/builder/azure/arm/step_get_certificate.go
@@ -39,6 +39,10 @@ func (s *StepGetCertificate) getCertificateUrl(keyVaultName string, secretName s
 		return "", err
 	}
 
+	if secret == nil || secret.ID == nil {
+		return "", fmt.Errorf("certificate is nil")
+	}
+
 	return *secret.ID, err
 }
 


### PR DESCRIPTION
The code already polls key vault because I have seen cases where the vault was ready immediately following deployment.  From the user report we have cases where the SDK does not return an error, but it also does not return a secret.  (I need a trace to figure out why.)  This PR add a check that will cause the code to re-poll with the expectation the secret will eventually be ready.

Closes #3581