### PR TITLE
Amazon documentation, update policy document - minimal set of permiss…

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -116,7 +116,11 @@ Packer to work:
         "ec2:RegisterImage",
         "ec2:CreateTags",
         "ec2:ModifyImageAttribute",
-        "ec2:GetPasswordData"
+        "ec2:GetPasswordData",
+        "ec2:DescribeTags",
+        "ec2:DescribeImageAttribute",
+        "ec2:CopyImage",
+        "ec2:DescribeRegions"
       ],
       "Resource" : "*"
   }]


### PR DESCRIPTION
…ions to allow copying AMIs to other regions

This is an update to the Amazon documentation. The previous policy document does not allow copying AMIs to other regions
