### PR TITLE
Adding ability to ignore region validation for AWS

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -17,12 +17,12 @@ import (
 
 // AccessConfig is for common configuration related to AWS access
 type AccessConfig struct {
-	AccessKey   string `mapstructure:"access_key"`
-	SecretKey   string `mapstructure:"secret_key"`
-	RawRegion   string `mapstructure:"region"`
-	SkipValidation bool `mapstructure:"skip_region_validation"`
-	Token       string `mapstructure:"token"`
-	ProfileName string `mapstructure:"profile"`
+	AccessKey      string `mapstructure:"access_key"`
+	SecretKey      string `mapstructure:"secret_key"`
+	RawRegion      string `mapstructure:"region"`
+	SkipValidation bool   `mapstructure:"skip_region_validation"`
+	Token          string `mapstructure:"token"`
+	ProfileName    string `mapstructure:"profile"`
 }
 
 // Config returns a valid aws.Config object for access to AWS services, or
@@ -66,7 +66,7 @@ func (c *AccessConfig) Config() (*aws.Config, error) {
 // the region from the instance metadata if possible.
 func (c *AccessConfig) Region() (string, error) {
 	if c.RawRegion != "" {
-		if(c.SkipValidation == false) {
+		if c.SkipValidation == false {
 			if valid := ValidateRegion(c.RawRegion); valid == false {
 				return "", fmt.Errorf("Not a valid region: %s", c.RawRegion)
 			}
@@ -86,7 +86,7 @@ func (c *AccessConfig) Region() (string, error) {
 func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
 	if c.RawRegion != "" {
-		if(c.SkipValidation == false) {
+		if c.SkipValidation == false {
 			if valid := ValidateRegion(c.RawRegion); valid == false {
 				errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
 			}

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -66,7 +66,7 @@ func (c *AccessConfig) Config() (*aws.Config, error) {
 // the region from the instance metadata if possible.
 func (c *AccessConfig) Region() (string, error) {
 	if c.RawRegion != "" {
-		if c.SkipValidation == false {
+		if !c.SkipValidation {
 			if valid := ValidateRegion(c.RawRegion); valid == false {
 				return "", fmt.Errorf("Not a valid region: %s", c.RawRegion)
 			}
@@ -85,11 +85,9 @@ func (c *AccessConfig) Region() (string, error) {
 
 func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
-	if c.RawRegion != "" {
-		if c.SkipValidation == false {
-			if valid := ValidateRegion(c.RawRegion); valid == false {
-				errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
-			}
+	if c.RawRegion != "" && !c.SkipValidation {
+		if valid := ValidateRegion(c.RawRegion); valid == false {
+			errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
 		}
 	}
 

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -20,6 +20,7 @@ type AccessConfig struct {
 	AccessKey   string `mapstructure:"access_key"`
 	SecretKey   string `mapstructure:"secret_key"`
 	RawRegion   string `mapstructure:"region"`
+	SkipValidation bool `mapstructure:"skip_region_validation"`
 	Token       string `mapstructure:"token"`
 	ProfileName string `mapstructure:"profile"`
 }
@@ -65,8 +66,10 @@ func (c *AccessConfig) Config() (*aws.Config, error) {
 // the region from the instance metadata if possible.
 func (c *AccessConfig) Region() (string, error) {
 	if c.RawRegion != "" {
-		if valid := ValidateRegion(c.RawRegion); valid == false {
-			return "", fmt.Errorf("Not a valid region: %s", c.RawRegion)
+		if(c.SkipValidation == false) {
+			if valid := ValidateRegion(c.RawRegion); valid == false {
+				return "", fmt.Errorf("Not a valid region: %s", c.RawRegion)
+			}
 		}
 		return c.RawRegion, nil
 	}
@@ -83,8 +86,10 @@ func (c *AccessConfig) Region() (string, error) {
 func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
 	if c.RawRegion != "" {
-		if valid := ValidateRegion(c.RawRegion); valid == false {
-			errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
+		if(c.SkipValidation == false) {
+			if valid := ValidateRegion(c.RawRegion); valid == false {
+				errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
+			}
 		}
 	}
 

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -37,5 +37,4 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	}
 	c.SkipValidation = false
 
-
 }

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -24,4 +24,18 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	if err := c.Prepare(nil); err != nil {
 		t.Fatalf("shouldn't have err: %s", err)
 	}
+
+	c.RawRegion = "custom"
+	if err := c.Prepare(nil); err == nil {
+		t.Fatalf("should have err")
+	}
+
+	c.RawRegion = "custom"
+	c.SkipValidation = true
+	if err := c.Prepare(nil); err != nil {
+		t.Fatalf("shouldn't have err: %s", err)
+	}
+	c.SkipValidation = false
+
+
 }

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -15,6 +15,7 @@ type AMIConfig struct {
 	AMIGroups             []string          `mapstructure:"ami_groups"`
 	AMIProductCodes       []string          `mapstructure:"ami_product_codes"`
 	AMIRegions            []string          `mapstructure:"ami_regions"`
+	AMISkipRegionValidation bool			`mapstructure:"skip_region_validation"`
 	AMITags               map[string]string `mapstructure:"tags"`
 	AMIEnhancedNetworking bool              `mapstructure:"enhanced_networking"`
 	AMIForceDeregister    bool              `mapstructure:"force_deregister"`
@@ -40,9 +41,11 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 			regionSet[region] = struct{}{}
 
 			// Verify the region is real
-			if valid := ValidateRegion(region); valid == false {
-				errs = append(errs, fmt.Errorf("Unknown region: %s", region))
-				continue
+			if c.AMISkipRegionValidation == false {
+				if valid := ValidateRegion(region); valid == false {
+					errs = append(errs, fmt.Errorf("Unknown region: %s", region))
+					continue
+				}
 			}
 
 			regions = append(regions, region)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -8,17 +8,17 @@ import (
 
 // AMIConfig is for common configuration related to creating AMIs.
 type AMIConfig struct {
-	AMIName               string            `mapstructure:"ami_name"`
-	AMIDescription        string            `mapstructure:"ami_description"`
-	AMIVirtType           string            `mapstructure:"ami_virtualization_type"`
-	AMIUsers              []string          `mapstructure:"ami_users"`
-	AMIGroups             []string          `mapstructure:"ami_groups"`
-	AMIProductCodes       []string          `mapstructure:"ami_product_codes"`
-	AMIRegions            []string          `mapstructure:"ami_regions"`
-	AMISkipRegionValidation bool			`mapstructure:"skip_region_validation"`
-	AMITags               map[string]string `mapstructure:"tags"`
-	AMIEnhancedNetworking bool              `mapstructure:"enhanced_networking"`
-	AMIForceDeregister    bool              `mapstructure:"force_deregister"`
+	AMIName                 string            `mapstructure:"ami_name"`
+	AMIDescription          string            `mapstructure:"ami_description"`
+	AMIVirtType             string            `mapstructure:"ami_virtualization_type"`
+	AMIUsers                []string          `mapstructure:"ami_users"`
+	AMIGroups               []string          `mapstructure:"ami_groups"`
+	AMIProductCodes         []string          `mapstructure:"ami_product_codes"`
+	AMIRegions              []string          `mapstructure:"ami_regions"`
+	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
+	AMITags                 map[string]string `mapstructure:"tags"`
+	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
+	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 }
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -40,8 +40,8 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 			// Mark that we saw the region
 			regionSet[region] = struct{}{}
 
-			// Verify the region is real
-			if c.AMISkipRegionValidation == false {
+			if !c.AMISkipRegionValidation {
+				// Verify the region is real
 				if valid := ValidateRegion(region); valid == false {
 					errs = append(errs, fmt.Errorf("Unknown region: %s", region))
 					continue

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -49,4 +49,12 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	if !reflect.DeepEqual(c.AMIRegions, expected) {
 		t.Fatalf("bad: %#v", c.AMIRegions)
 	}
+
+	c.AMIRegions = []string{"custom"}
+	c.AMISkipRegionValidation = true
+	if err := c.Prepare(nil); err != nil {
+		t.Fatal("shouldn't have error")
+	}
+	c.AMISkipRegionValidation = false
+
 }

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -146,6 +146,9 @@ builder.
 -   `root_volume_size` (integer) - The size of the root volume for the chroot
     environment, and the resulting AMI
 
+-   `skip_region_validation` (boolean) - Set to true if you want to skip 
+    validation of the ami_regions configuration option.  Defaults to false.
+
 -   `tags` (object of key/value strings) - Tags applied to the AMI.
 
 ## Basic Example

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -166,6 +166,9 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `skip_region_validation` (boolean) - Set to true if you want to skip 
+    validation of the region configuration option.  Defaults to false.
+
 -   `spot_price` (string) - The maximum hourly price to pay for a spot instance
     to create the AMI. Spot instances are a type of instance that EC2 starts
     when the current spot price is less than the maximum price you specify. Spot

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -191,6 +191,9 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `skip_region_validation` (boolean) - Set to true if you want to skip 
+    validation of the region configuration option.  Defaults to false.
+
 -   `spot_price` (string) - The maximum hourly price to launch a spot instance
     to create the AMI. It is a type of instances that EC2 starts when the
     maximum price that you specify exceeds the current spot price. Spot price


### PR DESCRIPTION
Useful for C2S or other AWS clouds that are not in the standard list.