### PR TITLE
fix docs to match code for puppet-server provisioner staging_dir

### DIFF
--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -68,7 +68,7 @@ listed below:
 -   `puppet_server` (string) - Hostname of the Puppet server. By default
     "puppet" will be used.
 
--   `staging_directory` (string) - This is the directory where all the
+-   `staging_dir` (string) - This is the directory where all the
     configuration of Puppet by Packer will be placed. By default this
     is "/tmp/packer-puppet-server". This directory doesn't need to exist but
     must have proper permissions so that the SSH user that Packer uses is able


### PR DESCRIPTION
Fixing the documentation of the staging_dir attribute to match the code. Note that the parameter is called staging_directory (vs. staging_dir) on all the other provisioners so if you prefer to change the code to match the documentation that would also be an option. Let me know if you prefer to do that and I could update the changelog to note the possibly breaking change.  