### PR TITLE
azure-arm: Validate that resource_group_name is being set

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -455,6 +455,9 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 	if c.StorageAccount == "" {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("A storage_account must be specified"))
 	}
+	if c.ResourceGroupName == "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("A resource_group_name must be specified"))
+	}
 
 	/////////////////////////////////////////////
 	// OS

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -25,6 +25,7 @@ var requiredConfigValues = []string{
 	"location",
 	"os_type",
 	"storage_account",
+	"resource_group_name",
 	"subscription_id",
 	"tenant_id",
 }
@@ -121,6 +122,7 @@ func TestConfigInstantiatesCorrectAzureEnvironment(t *testing.T) {
 		"image_sku":              "ignore",
 		"location":               "ignore",
 		"storage_account":        "ignore",
+		"resource_group_name":    "ignore",
 		"subscription_id":        "ignore",
 		"os_type":                constants.Target_Linux,
 		"communicator":           "none",
@@ -151,7 +153,10 @@ func TestConfigInstantiatesCorrectAzureEnvironment(t *testing.T) {
 
 	for _, x := range table {
 		config["cloud_environment_name"] = x.name
-		c, _, _ := newConfig(config, packerConfiguration)
+		c, _, err := newConfig(config, packerConfiguration)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if c.cloudEnvironment == nil || c.cloudEnvironment.Name != x.environmentName {
 			t.Errorf("Expected 'cloudEnvironment' to be set to '%s', but got '%s'.", x.environmentName, c.cloudEnvironment)
@@ -354,6 +359,7 @@ func TestUserDeviceLoginIsEnabledForLinux(t *testing.T) {
 		"image_sku":              "ignore",
 		"location":               "ignore",
 		"storage_account":        "ignore",
+		"resource_group_name":    "ignore",
 		"subscription_id":        "ignore",
 		"os_type":                constants.Target_Linux,
 		"communicator":           "none",
@@ -374,6 +380,7 @@ func TestUseDeviceLoginIsDisabledForWindows(t *testing.T) {
 		"image_sku":              "ignore",
 		"location":               "ignore",
 		"storage_account":        "ignore",
+		"resource_group_name":    "ignore",
 		"subscription_id":        "ignore",
 		"os_type":                constants.Target_Windows,
 		"communicator":           "none",
@@ -408,6 +415,7 @@ func TestConfigShouldRejectMalformedCaptureNamePrefix(t *testing.T) {
 		"image_sku":              "ignore",
 		"location":               "ignore",
 		"storage_account":        "ignore",
+		"resource_group_name":    "ignore",
 		"subscription_id":        "ignore",
 		// Does not matter for this test case, just pick one.
 		"os_type": constants.Target_Linux,
@@ -457,6 +465,7 @@ func TestConfigShouldRejectMalformedCaptureContainerName(t *testing.T) {
 		"image_sku":           "ignore",
 		"location":            "ignore",
 		"storage_account":     "ignore",
+		"resource_group_name": "ignore",
 		"subscription_id":     "ignore",
 		// Does not matter for this test case, just pick one.
 		"os_type": constants.Target_Linux,
@@ -510,10 +519,10 @@ func getArmBuilderConfiguration() map[string]string {
 
 func getPackerConfiguration() interface{} {
 	config := map[string]interface{}{
-		"packer_build_name": "azure-arm-vm",
-		"packer_builder_type": "azure-arm-vm",
-		"packer_debug": "false",
-		"packer_force": "false",
+		"packer_build_name":    "azure-arm-vm",
+		"packer_builder_type":  "azure-arm-vm",
+		"packer_debug":         "false",
+		"packer_force":         "false",
 		"packer_template_path": "/home/jenkins/azure-arm-vm/template.json",
 	}
 


### PR DESCRIPTION
Adding validation logic for `resource_group_name`. This is a required setting. If it is absent, the url to retrieve the storage account keys is malformed, which leads to issues like #3454. The response from the Azure API to such a malformed uri may be cryptic because it is routed to the wrong component in the back end.

See also https://github.com/Azure/azure-sdk-for-go/issues/316

@boumenot please review