### PR TITLE
azure/builder: fix token validity test

### DIFF
--- a/builder/azure/common/devicelogin.go
+++ b/builder/azure/common/devicelogin.go
@@ -197,8 +197,7 @@ func mkTokenCallback(path string) azure.TokenRefreshCallback {
 // expired). This check is essentially to make sure refresh_token is good.
 func validateToken(env azure.Environment, token *azure.ServicePrincipalToken) error {
 	c := subscriptionsClient(env.ResourceManagerEndpoint)
-	// WTF(chrboum)
-	//c.Authorizer = token
+	c.Authorizer = token
 	_, err := c.List()
 	if err != nil {
 		return fmt.Errorf("Token validity check failed: %v", err)


### PR DESCRIPTION
The token validity test wasn't really checking anything: `==> azure-arm: Error: Token validity check failed: subscriptions.Client#List: Failure responding to request: StatusCode=401 -- Original Error: azure: Service returned an error. Code="AuthenticationFailed" Message="Authentication failed. The 'Authorization' header is missing." Status=401`

@boumenot you better merge this before anybody notices... :smile: 

