### PR TITLE
Fix for issue #2972 - Implemented ssh_host for virtualbox builders

### DIFF
--- a/builder/virtualbox/common/ssh.go
+++ b/builder/virtualbox/common/ssh.go
@@ -7,8 +7,10 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
-func CommHost(state multistep.StateBag) (string, error) {
-	return "127.0.0.1", nil
+func CommHost(host string) func(multistep.StateBag) (string, error) {
+	return func(state multistep.StateBag) (string, error) {
+		return host, nil
+	}
 }
 
 func SSHPort(state multistep.StateBag) (int, error) {

--- a/builder/virtualbox/common/ssh_config.go
+++ b/builder/virtualbox/common/ssh_config.go
@@ -21,6 +21,10 @@ type SSHConfig struct {
 }
 
 func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
+	if c.Comm.SSHHost == "" {
+		c.Comm.SSHHost = "127.0.0.1"
+	}
+
 	if c.SSHHostPortMin == 0 {
 		c.SSHHostPortMin = 2222
 	}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -235,7 +235,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      vboxcommon.CommHost,
+			Host:      vboxcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: vboxcommon.SSHConfigFunc(b.config.SSHConfig),
 			SSHPort:   vboxcommon.SSHPort,
 		},

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -104,7 +104,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      vboxcommon.CommHost,
+			Host:      vboxcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: vboxcommon.SSHConfigFunc(b.config.SSHConfig),
 			SSHPort:   vboxcommon.SSHPort,
 		},


### PR DESCRIPTION
The virtualbox-* builders are hardcoded to use 127.0.0.1 as the ssh_host, and the template value for "ssh_host" was essentially ignored.  This pull request removes the hardcoded 127.0.0.1 and allows the developer to set the ssh_host for virtualbox-* builders.  In the event that ssh_host isn't set in the template file, it will default to 127.0.0.1, preserving backwards compatibility.

Closes #2972
_EDIT:_ Don't ~~Closes 2185~~

