### PR TITLE
Type-o in documentation

### DIFF
--- a/website/source/docs/templates/user-variables.html.md
+++ b/website/source/docs/templates/user-variables.html.md
@@ -172,7 +172,7 @@ provisioner only run if the `do_nexpose_scan` variable is non-empty.
 In order to use `$HOME` variable, you can create a `home` variable in packer:
 
 ``` {.javascript}
-"variables" {
+"variables": {
   "home": "{{env `HOME`}}"
 }
 ```


### PR DESCRIPTION
Corrected type-o in documentation code syntax.