### PR TITLE
Make docker-push only pushes the specified tag but not all

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -2,7 +2,6 @@ package dockerpush
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mitchellh/packer/builder/docker"
 	"github.com/mitchellh/packer/common"
@@ -81,17 +80,8 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		}()
 	}
 
-	// Get the name. We strip off any tags from the name because the
-	// push doesn't use those.
+	// Get the name.
 	name := artifact.Id()
-
-	if i := strings.Index(name, "/"); i >= 0 {
-		// This should always be true because the / is required. But we have
-		// to get the index to this so we don't accidentally strip off the port
-		if j := strings.Index(name[i:], ":"); j >= 0 {
-			name = name[:i+j]
-		}
-	}
 
 	ui.Message("Pushing: " + name)
 	if err := driver.Push(name); err != nil {

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -108,7 +108,7 @@ func TestPostProcessor_PostProcess_tags(t *testing.T) {
 	if !driver.PushCalled {
 		t.Fatal("should call push")
 	}
-	if driver.PushName != "hashicorp/ubuntu" {
+	if driver.PushName != "hashicorp/ubuntu:precise" {
 		t.Fatalf("bad name: %s", driver.PushName)
 	}
 }


### PR DESCRIPTION
Currently, for modern docker, packer would push all local tags of an image to Docker hub but not just the tag specified in template file. This is because old version of docker-push did not support tagging.
However, Docker API now supports pushing image with tagging. This PR is to pass both image name+tagging to docker-push so that it will only push the desired tag but not all existing ones from local to Docker hub.

Closes #3393 

