### PR TITLE
Don't use invalid -q flag for qemu-img

### DIFF
--- a/builder/qemu/step_convert_disk.go
+++ b/builder/qemu/step_convert_disk.go
@@ -31,7 +31,6 @@ func (s *stepConvertDisk) Run(state multistep.StateBag) multistep.StepAction {
 
 	command := []string{
 		"convert",
-		"-q",
 	}
 
 	if config.DiskCompression {


### PR DESCRIPTION
Removes the invalid `-q` from the `qemu-img` command:

```
2016/06/01 03:09:54 ui error: ==> qemu: Error converting hard drive: QemuImg error: convert: invalid option -- 'q'
```

It seems later versions of `qemu` support the `-q` flag, but neither the versions of `qemu-img` that ships with rhel 6.7 nor Ubuntu Precise do.

Closes #3592 