### PR TITLE
Add comment on required subnet_id when using vpc_id

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -214,7 +214,8 @@ builder.
     data when launching the instance.
 
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
-    in order to create a temporary security group within the VPC.
+    in order to create a temporary security group within the VPC. Requires `subnet_id`
+    to be set.
 
 -   `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: "10m"


### PR DESCRIPTION
Ran into the issue where I was not able to create an AMI within a VPC because the `subnet_id` was missing. Couldn't tell from the docs, so updating this.

It would be great if someone could confirm that the `subnet_id` is always required when using `vpc_id` or that perhaps the comment needs updating.