### PR TITLE
GCE builder: Switch to google.DefaultClient

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -51,15 +51,20 @@ func NewDriverGCE(ui packer.Ui, p string, a *accountFile) (Driver, error) {
 		// your service account.
 		client = conf.Client(oauth2.NoContext)
 	} else {
-		log.Printf("[INFO] Requesting Google token via GCE Service Role...")
-		client = &http.Client{
-			Transport: &oauth2.Transport{
-				// Fetch from Google Compute Engine's metadata server to retrieve
-				// an access token for the provided account.
-				// If no account is specified, "default" is used.
-				Source: google.ComputeTokenSource(""),
-			},
-		}
+		log.Printf("[INFO] Requesting Google token via GCE API Default Client Token Source...")
+		client, err = google.DefaultClient(oauth2.NoContext, DriverScopes...)
+		// The DefaultClient uses the DefaultTokenSource of the google lib.
+		// The DefaultTokenSource uses the "Application Default Credentials"
+		// It looks for credentials in the following places, preferring the first location found:
+		// 1. A JSON file whose path is specified by the
+		//    GOOGLE_APPLICATION_CREDENTIALS environment variable.
+		// 2. A JSON file in a location known to the gcloud command-line tool.
+		//    On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
+		//    On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+		// 3. On Google App Engine it uses the appengine.AccessToken function.
+		// 4. On Google Compute Engine and Google App Engine Managed VMs, it fetches
+		//    credentials from the metadata server.
+		//    (In this final case any provided scopes are ignored.)
 	}
 
 	if err != nil {

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -73,6 +73,22 @@ straightforwarded, it is documented here.
 4.  Click "Generate new JSON key" for the Service Account you just created. A
     JSON file will be downloaded automatically. This is your *account file*.
 
+### Precedence of Authentication Methods
+
+Packer looks for credentials in the following places, preferring the first location found:
+
+1.  A `account_file` option in your packer file.
+
+2.  A JSON file (Service Account) whose path is specified by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+3.  A JSON file in a location known to the `gcloud` command-line tool. (`gcloud` creates it when it's configured)
+
+    On Windows, this is: `%APPDATA%/gcloud/application_default_credentials.json`.
+
+    On other systems: `$HOME/.config/gcloud/application_default_credentials.json`.
+
+4.  On Google Compute Engine and Google App Engine Managed VMs, it fetches credentials from the metadata server. (Needs a correct VM authentication scope configuration, see above)
+
 ## Basic Example
 
 Below is a fully functioning example. It doesn't do anything useful, since no


### PR DESCRIPTION
The use of google.DefaultClient makes a series of authentication mechanisms possible.

See the code comment for the mech precedence.

Most important addition: Authentication through an already authenticated gcloud command.
Every GCE user has this, so there is no need to create service accounts any more or share keys. 