### PR TITLE
Added a hook to query the security groups before launching the instan…

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -45,6 +45,18 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 
 	securityGroupIds := make([]*string, len(tempSecurityGroupIds))
 	for i, sg := range tempSecurityGroupIds {
+		for i := 0; i < 5; i++ {
+			log.Printf("Describing tempSecurityGroup to ensure it is available: %s", sg)
+			_, err := ec2conn.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				GroupIds: []*string{aws.String(sg)},
+			})
+			if err == nil {
+				log.Printf("Found security group %s", sg)
+				break			
+			}       
+			log.Printf("Error in querying security group %s", err)
+                	time.Sleep(5 * time.Second)
+		}
 		securityGroupIds[i] = aws.String(sg)
 	}
 


### PR DESCRIPTION
Added a hook to query the security groups before launching the instance. 

```
==> amazon-ebs: Authorizing access to port 22 the temporary security group...
2016/06/27 16:19:19 packer: 2016/06/27 16:19:19 Describing tempSecurityGroup to ensure it is available: sg-6c420317
2016/06/27 16:19:19 packer: 2016/06/27 16:19:19 Error in querying security group InvalidGroup.NotFound: The security group 'sg-6c420317' does not exist
2016/06/27 16:19:19 packer: 	status code: 400, request id:
2016/06/27 16:19:24 packer: 2016/06/27 16:19:24 Describing tempSecurityGroup to ensure it is available: sg-6c420317
2016/06/27 16:19:24 packer: 2016/06/27 16:19:24 Found security group sg-6c420317
2016/06/27 16:19:24 ui: ==> amazon-ebs: Launching a source AWS instance...
```

Closes #2606

