### PR TITLE
Update to support azure-cli 0.10.1.

### DIFF
--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -126,7 +126,7 @@ createResourceGroup() {
 
 createStorageAccount() {
 	echo "==> Creating storage account"
-	azure storage account create -g $meta_name -l westus --type LRS $meta_name
+	azure storage account create -g $meta_name -l westus --sku-name LRS --kind Storage $meta_name
 	if [ $? -eq 0 ]; then
 		azure_storage_name=$meta_name
 	else


### PR DESCRIPTION
Storage creation has changed the command line options.  The option -type
-type has changed to --sku-name, and the user must specifcy --kind.

Closes #3653 