### PR TITLE
azure: handle non-OK responses for key vault

### DIFF
--- a/builder/azure/arm/step_get_certificate.go
+++ b/builder/azure/arm/step_get_certificate.go
@@ -39,6 +39,10 @@ func (s *StepGetCertificate) getCertificateUrl(keyVaultName string, secretName s
 		return "", err
 	}
 
+	if secret == nil || secret.ID == nil {
+		return "", fmt.Errorf("certificate is nil")
+	}
+
 	return *secret.ID, err
 }
 

--- a/builder/azure/arm/step_get_certificate.go
+++ b/builder/azure/arm/step_get_certificate.go
@@ -39,10 +39,6 @@ func (s *StepGetCertificate) getCertificateUrl(keyVaultName string, secretName s
 		return "", err
 	}
 
-	if secret == nil || secret.ID == nil {
-		return "", fmt.Errorf("certificate is nil")
-	}
-
 	return *secret.ID, err
 }
 

--- a/builder/azure/common/vault.go
+++ b/builder/azure/common/vault.go
@@ -7,6 +7,7 @@
 package common
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -58,6 +59,15 @@ func (client *VaultClient) GetSecret(vaultName, secretName string) (*Secret, err
 	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(
+			"Failed to fetch secret from %s/%s, HTTP status code=%d (%s)",
+			vaultName,
+			secretName,
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode))
 	}
 
 	var secret Secret


### PR DESCRIPTION
Check the response when fetching a secret from KeyVault.  Any non-OK (200) are considered to be an error.  This will provide a more informed error message for the user.

Closes #3581