### PR TITLE
(AWS Spot) Add 0.5 cents to discovered spot price

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -129,6 +129,10 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
+		} else {
+			// Add 0.5 cents to minimum spot bid to ensure capacity will be available
+			// Avoids price-too-low error in active markets which can fluctuate
+			price = price + 0.005
 		}
 
 		spotPrice = strconv.FormatFloat(price, 'f', -1, 64)


### PR DESCRIPTION
Related to #2979, in volatile spot markets the automatic price can
cause your instances to be evicted if the spot price rises. This change
adds one half a cent to your bid to protect against small amounts of
price volatility.

I encountered this when building in us-west-2 and my image build kept being evicted when using the automatic bid. 

Closes #2979