### PR TITLE
Add support for ap-south-1 in AWS

### DIFF
--- a/builder/amazon/common/regions.go
+++ b/builder/amazon/common/regions.go
@@ -4,6 +4,7 @@ func listEC2Regions() []string {
 	return []string{
 		"ap-northeast-1",
 		"ap-northeast-2",
+		"ap-south-1",
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"cn-north-1",


### PR DESCRIPTION
Amazon recently announced support for ap-south-1 in Mumbai, adding this
to the list of known regions to Packer