### PR TITLE
Add new interface method to the 'none' communicator

### DIFF
--- a/communicator/none/communicator.go
+++ b/communicator/none/communicator.go
@@ -38,3 +38,7 @@ func (c *comm) UploadDir(dst string, src string, excl []string) error {
 func (c *comm) Download(path string, output io.Writer) error {
 	return errors.New("Download is not implemented when communicator = 'none'")
 }
+
+func (c *comm) DownloadDir(dst string, src string, excl []string) error {
+	return errors.New("DownloadDir is not implemented when communicator = 'none'")
+}

--- a/communicator/none/communicator_test.go
+++ b/communicator/none/communicator_test.go
@@ -1,0 +1,16 @@
+package none
+
+import (
+	"testing"
+
+	"github.com/mitchellh/packer/packer"
+)
+
+func TestCommIsCommunicator(t *testing.T) {
+	var raw interface{}
+	raw = &comm{}
+	if _, ok := raw.(packer.Communicator); !ok {
+		t.Fatalf("comm must be a communicator")
+	}
+}
+


### PR DESCRIPTION
It looks like [this commit in v0.9.0](https://github.com/mitchellh/packer/commit/feee19e4) broke the `communicator: 'none'` option - it added an interface method but missed this particular communicator object.

Crash log:
```
2016/06/30 19:27:34 packer: panic: interface conversion: *none.comm is not packer.Communicator: missing method DownloadDir
2016/06/30 19:27:34 packer: 
2016/06/30 19:27:34 packer: goroutine 209 [running]:
2016/06/30 19:27:34 packer: panic(0x12d6880, 0xc8203641c0)
2016/06/30 19:27:34 packer:     /usr/local/go/src/runtime/panic.go:481 +0x3e6
2016/06/30 19:27:34 packer: github.com/mitchellh/packer/builder/vmware/common.(*StepShutdown).Run(0xc8203dafe0, 0x7f48ba6fb448, 0xc8203c15f0, 0x0)
2016/06/30 19:27:34 packer:     /Users/cbednarski/go/src/github.com/mitchellh/packer/builder/vmware/common/step_shutdown.go:37 +0xb4
2016/06/30 19:27:34 packer: github.com/mitchellh/packer/vendor/github.com/mitchellh/multistep.(*BasicRunner).Run(0xc8203a9800, 0x7f48ba6fb448, 0xc8203c15f0)
2016/06/30 19:27:34 packer:     /Users/cbednarski/go/src/github.com/mitchellh/packer/vendor/github.com/mitchellh/multistep/basic_runner.go:70 +0x330
2016/06/30 19:27:34 packer: github.com/mitchellh/packer/builder/vmware/iso.(*Builder).Run(0xc8201ad680, 0x7f48ba512040, 0xc8203e80e0, 0x7f48ba512088, 0xc8203e40e0, 0x7f48ba5120b8, 0xc8203fc000, 0x0, 0x0, 0
x0, ...)
2016/06/30 19:27:34 packer:     /Users/cbednarski/go/src/github.com/mitchellh/packer/builder/vmware/iso/builder.go:315 +0x1a0c
2016/06/30 19:27:34 packer: github.com/mitchellh/packer/packer/rpc.(*BuilderServer).Run(0xc8202121e0, 0x1, 0xc8203e4030, 0x0, 0x0)
2016/06/30 19:27:34 packer:     /Users/cbednarski/go/src/github.com/mitchellh/packer/packer/rpc/builder.go:93 +0x3b9
2016/06/30 19:27:34 packer: reflect.Value.call(0x11c2ca0, 0x1338f78, 0x13, 0x1511260, 0x4, 0xc8200c7ed8, 0x3, 0x3, 0x0, 0x0, ...)
2016/06/30 19:27:34 packer:     /usr/local/go/src/reflect/value.go:435 +0x120d
2016/06/30 19:27:34 packer: reflect.Value.Call(0x11c2ca0, 0x1338f78, 0x13, 0xc8200c7ed8, 0x3, 0x3, 0x0, 0x0, 0x0)
2016/06/30 19:27:34 packer:     /usr/local/go/src/reflect/value.go:303 +0xb1
2016/06/30 19:27:34 packer: net/rpc.(*service).call(0xc820208140, 0xc820208100, 0xc82020a0f8, 0xc82024a180, 0xc8202127e0, 0x1019300, 0xc8203e402c, 0x18a, 0xfe1ca0, 0xc8203e4030, ...)
2016/06/30 19:27:34 packer:     /usr/local/go/src/net/rpc/server.go:383 +0x1c2
2016/06/30 19:27:34 packer: created by net/rpc.(*Server).ServeCodec
2016/06/30 19:27:34 packer:     /usr/local/go/src/net/rpc/server.go:477 +0x49d
2016/06/30 19:27:34 ui error: Build 'testvm' errored: unexpected EOF
```

I've added the missing interface method.