### PR TITLE
Return list of <region>/<ami> for the file function

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -28,9 +28,15 @@ func (a *Artifact) BuilderId() string {
 	return a.BuilderIdValue
 }
 
-func (*Artifact) Files() []string {
-	// We have no files
-	return nil
+func (a *Artifact) Files() []string {
+	filePaths := make([]string, 0, len(a.Amis))
+	for region, id := range a.Amis {
+		single := fmt.Sprintf("%s/%s", region, id)
+		filePaths = append(filePaths, single)
+	}
+
+	sort.Strings(filePaths)
+	return filePaths
 }
 
 func (a *Artifact) Id() string {


### PR DESCRIPTION
The shell-local post provisioner loops over an artifacts file function.

The AMI artifact does not return anything for file, the shell
local processor requires a file to get the artifact id.

As a workaround, this commit returns an array of <region>/<ami> as
the file list.

Open to better suggestions/ways of doing this if people feel there are some. 

Signed-off-by: Ian Duffy <ian@ianduffy.ie>