### PR TITLE
Adding a functional test with an Ansible message very long

### DIFF
--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -1,6 +1,7 @@
 package ansible
 
 import (
+	"bytes"
 	"crypto/rand"
 	"fmt"
 	"io"
@@ -242,4 +243,33 @@ func TestProvisionerPrepare_LocalPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestAnsibleGetVersion(t *testing.T) {
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("This test is only run with PACKER_ACC=1 and it requires Ansible to be installed")
+	}
+
+	var p Provisioner
+	p.config.Command = "ansible-playbook"
+	p.getVersion()
+}
+
+func TestAnsibleLongMessages(t *testing.T) {
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("This test is only run with PACKER_ACC=1 and it requires Ansible to be installed")
+	}
+
+	var p Provisioner
+	p.config.Command = "ansible-playbook"
+	p.config.PlaybookFile = "./test-fixtures/long-debug-message.yml"
+	p.Prepare()
+
+	comm := &packer.MockCommunicator{}
+	ui := &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
+
+	p.Provision(ui, comm)
 }

--- a/provisioner/ansible/test-fixtures/long-debug-message.yml
+++ b/provisioner/ansible/test-fixtures/long-debug-message.yml
@@ -1,0 +1,8 @@
+- name: Stub for Packer testing long Ansible messages
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Very long Ansible output (>65535 chars) (Issue https://github.com/mitchellh/packer/issues/3268)
+      debug:
+        msg: "{{ lipsum(n=300, html=false) }}"


### PR DESCRIPTION
Related to the discussion at https://github.com/mitchellh/packer/pull/3392

This adds a functional test to validate that the error does not longer exist in large Ansible messages
I have cherry-picked this commit on an older version before the previous patch was applied and I was seeing the old error messages (and in fact the tests got stuck there) so at least the new code gets executed successfully

Not sure if this is enough, I also added a small test to the Version method which I used to understand how the class worked but I don´t have much experience with tests in Go so comments are appreciated

Also ran make ci locally but again, feedback very much appreciated