### PR TITLE
3474 file mkdir all

### DIFF
--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -163,7 +162,6 @@ func TestProvisionDownloadMkdirAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error tempfile: %s", err)
 	}
-	fmt.Println(tf.Name())
 	defer os.Remove(tf.Name())
 
 	config := map[string]interface{}{


### PR DESCRIPTION
This addresses https://github.com/mitchellh/packer/issues/3474 by creating all necessary dirs in the specified path for the file provisiner, when downloading..  The file provisioner documentations should also be updated, but I'm probably going to open a separate issue for that as it may touch on things outside the scope of this change.

Tests for this change are in the `TestProvisionDownloadMkdirAll()` func.

Closes #3474
