### PR TITLE
Fix IAM policy documentation

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -120,7 +120,8 @@ Packer to work:
         "ec2:DescribeTags",
         "ec2:DescribeImageAttribute",
         "ec2:CopyImage",
-        "ec2:DescribeRegions"
+        "ec2:DescribeRegions",
+        "ec2:ModifyInstanceAttribute"
       ],
       "Resource" : "*"
   }]


### PR DESCRIPTION
The IAM Policy is missing: "ModifyInstanceAttribute" for Enhanced Networking. Without you get error message: 

```
==> aws: Enabling Enhanced Networking...
==> aws: Error enabling Enhanced Networking on i-xxxxxxxxx: UnauthorizedOperation: You are not authorized to perform this operation.
==> aws:        status code: 403, request id:
```

This is documented in all aws provisioners, however adding it to the general IAM policy avoids trouble.