### PR TITLE
Remove Communicator section from amazon-chroot docs

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -54,10 +54,6 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the options listed here, a
-[communicator](/docs/templates/communicator.html) can be configured for this
-builder.
-
 ### Required:
 
 -   `access_key` (string) - The access key used to communicate with AWS. [Learn


### PR DESCRIPTION
Updates amazon-chroot docs to remove Communication section as it does not apply in this case.

Closes #3711