### PR TITLE
GCE: Docs - changed basic level example so it can be copied & pasted

### DIFF
--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -83,11 +83,15 @@ the path to the file containing the JSON.
 
 ``` {.javascript}
 {
-  "type": "googlecompute",
-  "account_file": "account.json",
-  "project_id": "my-project",
-  "source_image": "debian-7-wheezy-v20150127",
-  "zone": "us-central1-a"
+  "builders": [
+    {
+      	"type": "googlecompute",
+		"account_file": "account.json",
+		"project_id": "my project",
+		"source_image": "debian-7-wheezy-v20150127",
+		"zone": "us-central1-a"
+    }
+  ]
 }
 ```
 

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -83,15 +83,13 @@ the path to the file containing the JSON.
 
 ``` {.javascript}
 {
-  "builders": [
-    {
-      	"type": "googlecompute",
-		"account_file": "account.json",
-		"project_id": "my project",
-		"source_image": "debian-7-wheezy-v20150127",
-		"zone": "us-central1-a"
-    }
-  ]
+  "builders": [{
+    "type": "googlecompute",
+    "account_file": "account.json",
+    "project_id": "my project",
+    "source_image": "debian-7-wheezy-v20150127",
+    "zone": "us-central1-a"
+  }]
 }
 ```
 


### PR DESCRIPTION
The base level example doesn't actually work unless enclosed with a "builders" section. All fixed now.

Previous:

    {
      	"type": "googlecompute",
		"account_file": "account.json",
		"project_id": "my project",
		"source_image": "debian-7-wheezy-v20150127",
		"zone": "us-central1-a"
    }

Now:

	{
	  "builders": [
	    {
	      	"type": "googlecompute",
			"account_file": "account.json",
			"project_id": "my project",
			"source_image": "debian-7-wheezy-v20150127",
			"zone": "us-central1-a"
	    }
	  ]
	}

Please include tests. Check out these examples:

Just docs - no tests. I verified on three machines/instances. 1 Mac, 1 linux, and 1 Windows. From what I can tell this will copy & paste cleanly, vs the other, which assumed that one would know to enclose the JSON in a builders block.
