### PR TITLE
Azure: Ignore Created and Updated in KeyVault GetSecret Response

### DIFF
--- a/builder/azure/common/vault.go
+++ b/builder/azure/common/vault.go
@@ -27,13 +27,6 @@ type VaultClient struct {
 type Secret struct {
 	ID         *string          `json:"id,omitempty"`
 	Value      string           `json:"value"`
-	Attributes SecretAttributes `json:"attributes"`
-}
-
-type SecretAttributes struct {
-	Enabled bool    `json:"enabled"`
-	Created *string `json:"created"`
-	Updated *string `json:"updated"`
 }
 
 func (client *VaultClient) GetSecret(vaultName, secretName string) (*Secret, error) {


### PR DESCRIPTION
The Azure API for GetSecret response has changed, and it is breaking the code's ability to
properly deserialize the response.  These value do not matter, and will be ignored.