### PR TITLE
Clarify googlecompute#metadata usage.

### DIFF
--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -140,7 +140,8 @@ builder.
 
 -   `machine_type` (string) - The machine type. Defaults to `"n1-standard-1"`.
 
--   `metadata` (object of key/value strings)
+-   `metadata` (object of key/value strings) - Metadata applied to the launched
+    instance.
 
 -   `network` (string) - The Google Compute network to use for the
     launched instance. Defaults to `"default"`.


### PR DESCRIPTION
The current documentation for how `metadata` is used for Google images is ambiguous. This clarifies that the `metadata` is applied to the launched instance, not the resulting image.

Ref #3709