### PR TITLE
Respect ssh_host/winrm_host in vmware-iso ESXi builder

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -61,6 +61,8 @@ type Config struct {
 	RemotePassword       string `mapstructure:"remote_password"`
 	RemotePrivateKey     string `mapstructure:"remote_private_key_file"`
 
+	CommConfig communicator.Config `mapstructure:",squash"`
+
 	ctx interpolate.Context
 }
 

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -338,3 +338,61 @@ func TestBuilderPrepare_VNCPort(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 }
+
+func TestBuilderPrepare_CommConfig(t *testing.T) {
+	// Test Winrm
+	{
+		config := testConfig()
+		config["communicator"] = "winrm"
+		config["winrm_username"] = "username"
+		config["winrm_password"] = "password"
+		config["winrm_host"] = "1.2.3.4"
+
+		var b Builder
+		warns, err := b.Prepare(config)
+		if len(warns) > 0 {
+			t.Fatalf("bad: %#v", warns)
+		}
+		if err != nil {
+			t.Fatalf("should not have error: %s", err)
+		}
+
+		if b.config.CommConfig.WinRMUser != "username" {
+			t.Errorf("bad winrm_username: %s", b.config.CommConfig.WinRMUser)
+		}
+		if b.config.CommConfig.WinRMPassword != "password" {
+			t.Errorf("bad winrm_password: %s", b.config.CommConfig.WinRMPassword)
+		}
+		if host := b.config.CommConfig.Host(); host != "1.2.3.4" {
+			t.Errorf("bad host: %s", host)
+		}
+	}
+
+	// Test SSH
+	{
+		config := testConfig()
+		config["communicator"] = "ssh"
+		config["ssh_username"] = "username"
+		config["ssh_password"] = "password"
+		config["ssh_host"] = "1.2.3.4"
+
+		var b Builder
+		warns, err := b.Prepare(config)
+		if len(warns) > 0 {
+			t.Fatalf("bad: %#v", warns)
+		}
+		if err != nil {
+			t.Fatalf("should not have error: %s", err)
+		}
+
+		if b.config.CommConfig.SSHUsername != "username" {
+			t.Errorf("bad ssh_username: %s", b.config.CommConfig.SSHUsername)
+		}
+		if b.config.CommConfig.SSHPassword != "password" {
+			t.Errorf("bad ssh_password: %s", b.config.CommConfig.SSHPassword)
+		}
+		if host := b.config.CommConfig.Host(); host != "1.2.3.4" {
+			t.Errorf("bad host: %s", host)
+		}
+	}
+}

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -239,6 +239,11 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 		return address.(string), nil
 	}
 
+	if address := config.CommConfig.Host(); address != "" {
+		state.Put("vm_address", address)
+		return address, nil
+	}
+
 	r, err := d.esxcli("network", "vm", "list")
 	if err != nil {
 		return "", err

--- a/builder/vmware/iso/driver_esx5_test.go
+++ b/builder/vmware/iso/driver_esx5_test.go
@@ -2,9 +2,11 @@ package iso
 
 import (
 	"fmt"
-	vmwcommon "github.com/mitchellh/packer/builder/vmware/common"
 	"net"
 	"testing"
+
+	"github.com/mitchellh/multistep"
+	vmwcommon "github.com/mitchellh/packer/builder/vmware/common"
 )
 
 func TestESX5Driver_implDriver(t *testing.T) {
@@ -31,5 +33,46 @@ func TestESX5Driver_HostIP(t *testing.T) {
 
 	if host, _ := driver.HostIP(); host != expected_host {
 		t.Error(fmt.Sprintf("Expected string, %s but got %s", expected_host, host))
+	}
+}
+
+func TestESX5Driver_CommHost(t *testing.T) {
+	const expected_host = "127.0.0.1"
+
+	config := testConfig()
+	config["communicator"] = "winrm"
+	config["winrm_username"] = "username"
+	config["winrm_password"] = "password"
+	config["winrm_host"] = expected_host
+
+	var b Builder
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if host := b.config.CommConfig.Host(); host != expected_host {
+		t.Fatalf("setup failed, bad host name: %s", host)
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("config", &b.config)
+
+	var driver ESX5Driver
+	host, err := driver.CommHost(state)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if host != expected_host {
+		t.Errorf("bad host name: %s", host)
+	}
+	address, ok := state.GetOk("vm_address")
+	if !ok {
+		t.Error("state not updated with vm_address")
+	}
+	if address.(string) != expected_host {
+		t.Errorf("bad vm_address: %s", address.(string))
 	}
 }


### PR DESCRIPTION
This PR builds upon the work of 9c9f8cd45160192587a90e95413aaa26fc21b762 to make the `vmware-iso` ESXi builder respect the `winrm_host` option.  If the `winrm_host` option is provided the builder will use that address to connect to the VM and will not poll ESXi for the VM's address.

This allows packer to work with statically assigned IPs and network environments without DHCP in ESXi.

@sunjayBhatia