### PR TITLE
Do not add remotedisplay.vnc.ip to vmx data on ESXi

### DIFF
--- a/builder/vmware/common/step_configure_vnc_test.go
+++ b/builder/vmware/common/step_configure_vnc_test.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStepConfigureVNC_implVNCAddressFinder(t *testing.T) {
+	var _ VNCAddressFinder = new(StepConfigureVNC)
+}
+
+func TestStepConfigureVNC_UpdateVMX(t *testing.T) {
+	var s StepConfigureVNC
+	data := make(map[string]string)
+	s.UpdateVMX("0.0.0.0", 5900, data)
+	if ip := data["remotedisplay.vnc.ip"]; ip != "0.0.0.0" {
+		t.Errorf("bad VMX data for key remotedisplay.vnc.ip: %v", ip)
+	}
+	if enabled := data["remotedisplay.vnc.enabled"]; enabled != "TRUE" {
+		t.Errorf("bad VMX data for key remotedisplay.vnc.enabled: %v", enabled)
+	}
+	if port := data["remotedisplay.vnc.port"]; port != fmt.Sprint(port) {
+		t.Errorf("bad VMX data for key remotedisplay.vnc.port: %v", port)
+	}
+}

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -176,7 +176,7 @@ func (d *ESX5Driver) HostIP() (string, error) {
 	return host, err
 }
 
-func (d *ESX5Driver) VNCAddress(vncBindIP string, portMin, portMax uint) (string, uint, error) {
+func (d *ESX5Driver) VNCAddress(_ string, portMin, portMax uint) (string, uint, error) {
 	var vncPort uint
 
 	//Process ports ESXi is listening on to determine which are available
@@ -230,6 +230,13 @@ func (d *ESX5Driver) VNCAddress(vncBindIP string, portMin, portMax uint) (string
 	}
 
 	return d.Host, vncPort, nil
+}
+
+// UpdateVMX, adds the VNC port to the VMX data.
+func (ESX5Driver) UpdateVMX(_ string, port uint, data map[string]string) {
+	// Do not set remotedisplay.vnc.ip - this breaks ESXi.
+	data["remotedisplay.vnc.enabled"] = "TRUE"
+	data["remotedisplay.vnc.port"] = fmt.Sprintf("%d", port)
 }
 
 func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {

--- a/builder/vmware/iso/driver_esx5_test.go
+++ b/builder/vmware/iso/driver_esx5_test.go
@@ -2,9 +2,10 @@ package iso
 
 import (
 	"fmt"
-	vmwcommon "github.com/mitchellh/packer/builder/vmware/common"
 	"net"
 	"testing"
+
+	vmwcommon "github.com/mitchellh/packer/builder/vmware/common"
 )
 
 func TestESX5Driver_implDriver(t *testing.T) {
@@ -13,6 +14,10 @@ func TestESX5Driver_implDriver(t *testing.T) {
 
 func TestESX5Driver_implOutputDir(t *testing.T) {
 	var _ vmwcommon.OutputDir = new(ESX5Driver)
+}
+
+func TestESX5Driver_implVNCAddressFinder(t *testing.T) {
+	var _ vmwcommon.VNCAddressFinder = new(ESX5Driver)
 }
 
 func TestESX5Driver_implRemoteDriver(t *testing.T) {
@@ -31,5 +36,21 @@ func TestESX5Driver_HostIP(t *testing.T) {
 
 	if host, _ := driver.HostIP(); host != expected_host {
 		t.Error(fmt.Sprintf("Expected string, %s but got %s", expected_host, host))
+	}
+}
+
+func TestESX5Driver_UpdateVMX(t *testing.T) {
+	var driver ESX5Driver
+	data := make(map[string]string)
+	driver.UpdateVMX("0.0.0.0", 5900, data)
+	if _, ok := data["remotedisplay.vnc.ip"]; ok {
+		// Do not add the remotedisplay.vnc.ip on ESXi
+		t.Fatal("invalid VMX data key: remotedisplay.vnc.ip")
+	}
+	if enabled := data["remotedisplay.vnc.enabled"]; enabled != "TRUE" {
+		t.Errorf("bad VMX data for key remotedisplay.vnc.enabled: %v", enabled)
+	}
+	if port := data["remotedisplay.vnc.port"]; port != fmt.Sprint(port) {
+		t.Errorf("bad VMX data for key remotedisplay.vnc.port: %v", port)
 	}
 }


### PR DESCRIPTION
A change to the `vmware` builder in 0327f6c9352f27e5eb7c9a6c84b9272e535e0b36 added a `remotedisplay.vnc.ip` value to the vmx data - this breaks ESXi. 

This PR prevents the key from being added when using the `ESX5` driver by adding a `UpdateVMX` method to the `VNCAddressFinder` interface.  The additional method was required to prevent an import loop.

@sunjayBhatia