### PR TITLE
extend export_opts documentation, add sample code

### DIFF
--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -101,8 +101,44 @@ builder.
     for the VM. By default, this is 40000 (about 40 GB).
 
 -   `export_opts` (array of strings) - Additional options to pass to the
-    `VBoxManage export`. This can be useful for passing product information to
-    include in the resulting appliance file.
+    [VBoxManage export](https://www.virtualbox.org/manual/ch08.html#vboxmanage-export).
+    This can be useful for passing product information to include in the
+    resulting appliance file. Packer JSON configuration file example:
+
+    ``` {.json}
+    {
+      "type": "virtualbox-iso",
+      "export_opts":
+      [
+        "--manifest",
+        "--vsys", "0",
+        "--description", "{{user `vm_description`}}",
+        "--version", "{{user `vm_version`}}"
+      ],
+      "format": "ova",
+    }
+    ```
+
+    A VirtualBox [VM description](https://www.virtualbox.org/manual/ch08.html#idm3756)
+    may contain arbitrary strings; the GUI interprets HTML formatting.
+    However, the JSON format does not allow arbitrary newlines within a
+    value. Add a multi-line description by preparing the string in the
+    shell before the packer call like this (shell `>` continuation
+    character snipped for easier copy & paste):
+
+    ``` {.shell}
+
+    vm_description='some
+    multiline
+    description'
+
+    vm_version='0.2.0'
+
+    packer build \
+        -var "vm_description=${vm_description}" \
+        -var "vm_version=${vm_version}"         \
+        "packer_conf.json"
+    ```
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for


### PR DESCRIPTION
Some sample code in the documentation would have saved me three days of pulling my hair out while trying to get `export_opts` with a multi-line description to work.

Hope this makes things easier for anyone with the same problem...