### PR TITLE
Honor ssh_private_ip flag in EC2-Classic, not just VPC

### DIFF
--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -23,6 +23,8 @@ func SSHHost(e *ec2.EC2, private bool) func(multistep.StateBag) (string, error) 
 				} else {
 					host = *i.PrivateIpAddress
 				}
+			} else if private {
+				host = *i.PrivateIpAddress
 			} else if i.PublicDnsName != nil && *i.PublicDnsName != "" {
 				host = *i.PublicDnsName
 			}


### PR DESCRIPTION
VpcId will be nil in Classic, but we may still wish to ssh to the instance's private IP address -- if for example we are using security groups to block SSH access via the public IP.  We should honor the ssh_private_ip in Classic as well as VPC.  (Used to work this way; logic bug introduced sometime in the past year...) 

Closes #3751

