### PR TITLE
Fix License check to work with licensed VMware Workstation

### DIFF
--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -15,7 +15,7 @@ import (
 )
 
 func workstationCheckLicense() error {
-	matches, err := filepath.Glob("/etc/vmware/license-*")
+	matches, err := filepath.Glob("/etc/vmware/license-ws-*")
 	if err != nil {
 		return fmt.Errorf("Error looking for VMware license: %s", err)
 	}


### PR DESCRIPTION
This fixes the detection of vmware-workstation license. 

In genreal you can have:

* "Freeware" - VMWare Player without license  (non commercial only, no license file)
* "Commercial" - VMWare Player with license (/etc/vmware/license-player-*)
* "Commercial" - VMWare Workstation with license (/etc/vmware/license-ws-*)

The old check disabled the usage of a commercial vmware player product (as it then uses -T ws, while no workstation license is in place). 

Tested with VMWare Player / Workstation 12.1.1 on Linux.

