### PR TITLE
Add support for ctrl, shift and alt keys and using them as key modifier.

### DIFF
--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -186,6 +186,13 @@ func scancodes(message string) []string {
 	special["<pageUp>"] = []string{"49", "c9"}
 	special["<pageDown>"] = []string{"51", "d1"}
 
+	special["<leftAlt>"] = []string{"38", "b8"}
+	special["<leftCtrl>"] = []string{"1d", "9d"}
+	special["<leftShift>"] = []string{"2a", "aa"}
+	special["<rightAlt>"] = []string{"e038", "e0b8"}
+	special["<rightCtrl>"] = []string{"e01d", "e09d"}
+	special["<rightShift>"] = []string{"36", "b6"}
+
 	shiftedChars := "!@#$%^&*()_+{}:\"~|<>?"
 
 	scancodeIndex := make(map[string]uint)
@@ -213,6 +220,78 @@ func scancodes(message string) []string {
 	result := make([]string, 0, len(message)*2)
 	for len(message) > 0 {
 		var scancode []string
+
+		if strings.HasPrefix(message, "<leftAltOn>") {
+			scancode = []string{"38"}
+			message = message[len("<leftAltOn>"):]
+			log.Printf("Special code '<leftAltOn>' found, replacing with: 38")
+		}
+
+		if strings.HasPrefix(message, "<leftCtrlOn>") {
+			scancode = []string{"1d"}
+			message = message[len("<leftCtrlOn>"):]
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: 1d")
+		}
+
+		if strings.HasPrefix(message, "<leftShiftOn>") {
+			scancode = []string{"2a"}
+			message = message[len("<leftShiftOn>"):]
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: 2a")
+		}
+
+		if strings.HasPrefix(message, "<leftAltOff>") {
+			scancode = []string{"b8"}
+			message = message[len("<leftAltOff>"):]
+			log.Printf("Special code '<leftAltOff>' found, replacing with: b8")
+		}
+
+		if strings.HasPrefix(message, "<leftCtrlOff>") {
+			scancode = []string{"9d"}
+			message = message[len("<leftCtrlOff>"):]
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: 9d")
+		}
+
+		if strings.HasPrefix(message, "<leftShiftOff>") {
+			scancode = []string{"aa"}
+			message = message[len("<leftShiftOff>"):]
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: aa")
+		}
+
+		if strings.HasPrefix(message, "<rightAltOn>") {
+			scancode = []string{"e038"}
+			message = message[len("<rightAltOn>"):]
+			log.Printf("Special code '<rightAltOn>' found, replacing with: e038")
+		}
+
+		if strings.HasPrefix(message, "<rightCtrlOn>") {
+			scancode = []string{"e01d"}
+			message = message[len("<rightCtrlOn>"):]
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: e01d")
+		}
+
+		if strings.HasPrefix(message, "<rightShiftOn>") {
+			scancode = []string{"36"}
+			message = message[len("<rightShiftOn>"):]
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: 36")
+		}
+
+		if strings.HasPrefix(message, "<rightAltOff>") {
+			scancode = []string{"e0b8"}
+			message = message[len("<rightAltOff>"):]
+			log.Printf("Special code '<rightAltOff>' found, replacing with: e0b8")
+		}
+
+		if strings.HasPrefix(message, "<rightCtrlOff>") {
+			scancode = []string{"e09d"}
+			message = message[len("<rightCtrlOff>"):]
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: e09d")
+		}
+
+		if strings.HasPrefix(message, "<rightShiftOff>") {
+			scancode = []string{"b6"}
+			message = message[len("<rightShiftOff>"):]
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: b6")
+		}
 
 		if strings.HasPrefix(message, "<wait>") {
 			log.Printf("Special code <wait> found, will sleep 1 second at this point.")

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -153,7 +153,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftAltOn>") {
 			keyCode = special["<leftAlt>"]
 			original = original[len("<leftAltOn>"):]
-			log.Printf("Special code '<leftAltOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftAltOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -167,7 +167,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftCtrlOn>") {
 			keyCode = special["<leftCtrlOn>"]
 			original = original[len("<leftCtrlOn>"):]
-			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -181,7 +181,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftShiftOn>") {
 			keyCode = special["<leftShiftOn>"]
 			original = original[len("<leftShiftOn>"):]
-			log.Printf("Special code '<leftShiftOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -195,7 +195,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftAltOff>") {
 			keyCode = special["<leftAltOff>"]
 			original = original[len("<leftAltOff>"):]
-			log.Printf("Special code '<leftAltOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftAltOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -209,7 +209,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftCtrlOff>") {
 			keyCode = special["<leftCtrlOff>"]
 			original = original[len("<leftCtrlOff>"):]
-			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -223,7 +223,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftShiftOff>") {
 			keyCode = special["<leftShiftOff>"]
 			original = original[len("<leftShiftOff>"):]
-			log.Printf("Special code '<leftShiftOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -237,7 +237,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightAltOn>") {
 			keyCode = special["<rightAltOn>"]
 			original = original[len("<rightAltOn>"):]
-			log.Printf("Special code '<rightAltOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightAltOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -251,7 +251,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightCtrlOn>") {
 			keyCode = special["<rightCtrlOn>"]
 			original = original[len("<rightCtrlOn>"):]
-			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -265,7 +265,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightShiftOn>") {
 			keyCode = special["<rightShiftOn>"]
 			original = original[len("<rightShiftOn>"):]
-			log.Printf("Special code '<rightShiftOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -279,7 +279,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightAltOff>") {
 			keyCode = special["<rightAltOff>"]
 			original = original[len("<rightAltOff>"):]
-			log.Printf("Special code '<rightAltOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightAltOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -293,7 +293,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightCtrlOff>") {
 			keyCode = special["<rightCtrlOff>"]
 			original = original[len("<rightCtrlOff>"):]
-			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -307,7 +307,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightShiftOff>") {
 			keyCode = special["<rightShiftOff>"]
 			original = original[len("<rightShiftOff>"):]
-			log.Printf("Special code '<rightShiftOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -136,6 +136,12 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<end>"] = 0xFF57
 	special["<pageUp>"] = 0xFF55
 	special["<pageDown>"] = 0xFF56
+	special["<leftAlt>"] = 0xFFE9
+	special["<leftCtrl>"] = 0xFFE3
+	special["<leftShift>"] = 0xFFE1
+	special["<rightAlt>"] = 0xFFEA
+	special["<rightCtrl>"] = 0xFFE4
+	special["<rightShift>"] = 0xFFE2
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 
@@ -143,6 +149,174 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	for len(original) > 0 {
 		var keyCode uint32
 		keyShift := false
+
+		if strings.HasPrefix(original, "<leftAltOn>") {
+			keyCode = special["<leftAlt>"]
+			original = original[len("<leftAltOn>"):]
+			log.Printf("Special code '<leftAltOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftCtrlOn>") {
+			keyCode = special["<leftCtrlOn>"]
+			original = original[len("<leftCtrlOn>"):]
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftShiftOn>") {
+			keyCode = special["<leftShiftOn>"]
+			original = original[len("<leftShiftOn>"):]
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftAltOff>") {
+			keyCode = special["<leftAltOff>"]
+			original = original[len("<leftAltOff>"):]
+			log.Printf("Special code '<leftAltOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftCtrlOff>") {
+			keyCode = special["<leftCtrlOff>"]
+			original = original[len("<leftCtrlOff>"):]
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftShiftOff>") {
+			keyCode = special["<leftShiftOff>"]
+			original = original[len("<leftShiftOff>"):]
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightAltOn>") {
+			keyCode = special["<rightAltOn>"]
+			original = original[len("<rightAltOn>"):]
+			log.Printf("Special code '<rightAltOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightCtrlOn>") {
+			keyCode = special["<rightCtrlOn>"]
+			original = original[len("<rightCtrlOn>"):]
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightShiftOn>") {
+			keyCode = special["<rightShiftOn>"]
+			original = original[len("<rightShiftOn>"):]
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightAltOff>") {
+			keyCode = special["<rightAltOff>"]
+			original = original[len("<rightAltOff>"):]
+			log.Printf("Special code '<rightAltOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightCtrlOff>") {
+			keyCode = special["<rightCtrlOff>"]
+			original = original[len("<rightCtrlOff>"):]
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightShiftOff>") {
+			keyCode = special["<rightShiftOff>"]
+			original = original[len("<rightShiftOff>"):]
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			// qemu is picky, so no matter what, wait a small period
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
 
 		if strings.HasPrefix(original, "<wait>") {
 			log.Printf("Special code '<wait>' found, sleeping one second")

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -141,6 +141,12 @@ func scancodes(message string) []string {
 	special["<end>"] = []string{"4f", "cf"}
 	special["<pageUp>"] = []string{"49", "c9"}
 	special["<pageDown>"] = []string{"51", "d1"}
+	special["<leftAlt>"] = []string{"38", "b8"}
+	special["<leftCtrl>"] = []string{"1d", "9d"}
+	special["<leftShift>"] = []string{"2a", "aa"}
+	special["<rightAlt>"] = []string{"e038", "e0b8"}
+	special["<rightCtrl>"] = []string{"e01d", "e09d"}
+	special["<rightShift>"] = []string{"36", "b6"}
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 
@@ -169,6 +175,78 @@ func scancodes(message string) []string {
 	result := make([]string, 0, len(message)*2)
 	for len(message) > 0 {
 		var scancode []string
+
+		if strings.HasPrefix(message, "<leftAltOn>") {
+			scancode = []string{"38"}
+			message = message[len("<leftAltOn>"):]
+			log.Printf("Special code '<leftAltOn>' found, replacing with: 38")
+		}
+
+		if strings.HasPrefix(message, "<leftCtrlOn>") {
+			scancode = []string{"1d"}
+			message = message[len("<leftCtrlOn>"):]
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: 1d")
+		}
+
+		if strings.HasPrefix(message, "<leftShiftOn>") {
+			scancode = []string{"2a"}
+			message = message[len("<leftShiftOn>"):]
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: 2a")
+		}
+
+		if strings.HasPrefix(message, "<leftAltOff>") {
+			scancode = []string{"b8"}
+			message = message[len("<leftAltOff>"):]
+			log.Printf("Special code '<leftAltOff>' found, replacing with: b8")
+		}
+
+		if strings.HasPrefix(message, "<leftCtrlOff>") {
+			scancode = []string{"9d"}
+			message = message[len("<leftCtrlOff>"):]
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: 9d")
+		}
+
+		if strings.HasPrefix(message, "<leftShiftOff>") {
+			scancode = []string{"aa"}
+			message = message[len("<leftShiftOff>"):]
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: aa")
+		}
+
+		if strings.HasPrefix(message, "<rightAltOn>") {
+			scancode = []string{"e038"}
+			message = message[len("<rightAltOn>"):]
+			log.Printf("Special code '<rightAltOn>' found, replacing with: e038")
+		}
+
+		if strings.HasPrefix(message, "<rightCtrlOn>") {
+			scancode = []string{"e01d"}
+			message = message[len("<rightCtrlOn>"):]
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: e01d")
+		}
+
+		if strings.HasPrefix(message, "<rightShiftOn>") {
+			scancode = []string{"36"}
+			message = message[len("<rightShiftOn>"):]
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: 36")
+		}
+
+		if strings.HasPrefix(message, "<rightAltOff>") {
+			scancode = []string{"e0b8"}
+			message = message[len("<rightAltOff>"):]
+			log.Printf("Special code '<rightAltOff>' found, replacing with: e0b8")
+		}
+
+		if strings.HasPrefix(message, "<rightCtrlOff>") {
+			scancode = []string{"e09d"}
+			message = message[len("<rightCtrlOff>"):]
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: e09d")
+		}
+
+		if strings.HasPrefix(message, "<rightShiftOff>") {
+			scancode = []string{"b6"}
+			message = message[len("<rightShiftOff>"):]
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: b6")
+		}
 
 		if strings.HasPrefix(message, "<wait>") {
 			log.Printf("Special code <wait> found, will sleep 1 second at this point.")

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -159,6 +159,12 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<end>"] = 0xFF57
 	special["<pageUp>"] = 0xFF55
 	special["<pageDown>"] = 0xFF56
+	special["<leftAlt>"] = 0xFFE9
+	special["<leftCtrl>"] = 0xFFE3
+	special["<leftShift>"] = 0xFFE1
+	special["<rightAlt>"] = 0xFFEA
+	special["<rightCtrl>"] = 0xFFE4
+	special["<rightShift>"] = 0xFFE2
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 
@@ -166,6 +172,138 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	for len(original) > 0 {
 		var keyCode uint32
 		keyShift := false
+
+		if strings.HasPrefix(original, "<leftAltOn>") {
+			keyCode = special["<leftAlt>"]
+			original = original[len("<leftAltOn>"):]
+			log.Printf("Special code '<leftAltOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftCtrlOn>") {
+			keyCode = special["<leftCtrlOn>"]
+			original = original[len("<leftCtrlOn>"):]
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftShiftOn>") {
+			keyCode = special["<leftShiftOn>"]
+			original = original[len("<leftShiftOn>"):]
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftAltOff>") {
+			keyCode = special["<leftAltOff>"]
+			original = original[len("<leftAltOff>"):]
+			log.Printf("Special code '<leftAltOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftCtrlOff>") {
+			keyCode = special["<leftCtrlOff>"]
+			original = original[len("<leftCtrlOff>"):]
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftShiftOff>") {
+			keyCode = special["<leftShiftOff>"]
+			original = original[len("<leftShiftOff>"):]
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightAltOn>") {
+			keyCode = special["<rightAltOn>"]
+			original = original[len("<rightAltOn>"):]
+			log.Printf("Special code '<rightAltOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightCtrlOn>") {
+			keyCode = special["<rightCtrlOn>"]
+			original = original[len("<rightCtrlOn>"):]
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightShiftOn>") {
+			keyCode = special["<rightShiftOn>"]
+			original = original[len("<rightShiftOn>"):]
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightAltOff>") {
+			keyCode = special["<rightAltOff>"]
+			original = original[len("<rightAltOff>"):]
+			log.Printf("Special code '<rightAltOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightCtrlOff>") {
+			keyCode = special["<rightCtrlOff>"]
+			original = original[len("<rightCtrlOff>"):]
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightShiftOff>") {
+			keyCode = special["<rightShiftOff>"]
+			original = original[len("<rightShiftOff>"):]
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: %s", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
 
 		if strings.HasPrefix(original, "<wait>") {
 			log.Printf("Special code '<wait>' found, sleeping one second")

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -176,7 +176,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftAltOn>") {
 			keyCode = special["<leftAlt>"]
 			original = original[len("<leftAltOn>"):]
-			log.Printf("Special code '<leftAltOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftAltOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -187,7 +187,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftCtrlOn>") {
 			keyCode = special["<leftCtrlOn>"]
 			original = original[len("<leftCtrlOn>"):]
-			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftCtrlOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -198,7 +198,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftShiftOn>") {
 			keyCode = special["<leftShiftOn>"]
 			original = original[len("<leftShiftOn>"):]
-			log.Printf("Special code '<leftShiftOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftShiftOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -209,7 +209,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftAltOff>") {
 			keyCode = special["<leftAltOff>"]
 			original = original[len("<leftAltOff>"):]
-			log.Printf("Special code '<leftAltOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftAltOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -220,7 +220,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftCtrlOff>") {
 			keyCode = special["<leftCtrlOff>"]
 			original = original[len("<leftCtrlOff>"):]
-			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftCtrlOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -231,7 +231,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<leftShiftOff>") {
 			keyCode = special["<leftShiftOff>"]
 			original = original[len("<leftShiftOff>"):]
-			log.Printf("Special code '<leftShiftOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<leftShiftOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -242,7 +242,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightAltOn>") {
 			keyCode = special["<rightAltOn>"]
 			original = original[len("<rightAltOn>"):]
-			log.Printf("Special code '<rightAltOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightAltOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -253,7 +253,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightCtrlOn>") {
 			keyCode = special["<rightCtrlOn>"]
 			original = original[len("<rightCtrlOn>"):]
-			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightCtrlOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -264,7 +264,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightShiftOn>") {
 			keyCode = special["<rightShiftOn>"]
 			original = original[len("<rightShiftOn>"):]
-			log.Printf("Special code '<rightShiftOn>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightShiftOn>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, true)
 			time.Sleep(time.Second / 10)
@@ -275,7 +275,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightAltOff>") {
 			keyCode = special["<rightAltOff>"]
 			original = original[len("<rightAltOff>"):]
-			log.Printf("Special code '<rightAltOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightAltOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -286,7 +286,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightCtrlOff>") {
 			keyCode = special["<rightCtrlOff>"]
 			original = original[len("<rightCtrlOff>"):]
-			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightCtrlOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)
@@ -297,7 +297,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		if strings.HasPrefix(original, "<rightShiftOff>") {
 			keyCode = special["<rightShiftOff>"]
 			original = original[len("<rightShiftOff>"):]
-			log.Printf("Special code '<rightShiftOff>' found, replacing with: %s", keyCode)
+			log.Printf("Special code '<rightShiftOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(time.Second / 10)

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -256,9 +256,29 @@ proper key:
 
 -   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -278,7 +278,11 @@ proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, 
+otherwise they will be held down until the machine reboots. Use lowercase 
+characters as well inside modifiers. 
+
+For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/parallels-pvm.html.md
+++ b/website/source/docs/builders/parallels-pvm.html.md
@@ -198,9 +198,29 @@ proper key:
 
 -   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/parallels-pvm.html.md
+++ b/website/source/docs/builders/parallels-pvm.html.md
@@ -220,8 +220,6 @@ proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
-
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The
 available variables are:

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -354,12 +354,32 @@ by the proper key:
 
 -   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
 -   `<waitXX> ` - Add user defined time.Duration pause before sending any
     additional keys. For example `<wait10m>` or `<wait1m20s>`
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -290,9 +290,29 @@ by the proper key:
 
 -   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -312,7 +312,11 @@ by the proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, 
+otherwise they will be held down until the machine reboots. Use lowercase 
+characters as well inside modifiers. 
+
+For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -219,8 +219,7 @@ builder.
 
 The `boot_command` configuration is very important: it specifies the keys to
 type when the virtual machine is first booted in order to start the OS
-installer. This command is typed after `boot_wait`, which gives the virtual
-machine some time to actually load the ISO.
+installer. This command is typed after `boot_wait`.
 
 As documented above, the `boot_command` is an array of strings. The strings are
 all typed in sequence. It is an array only to improve readability within the
@@ -274,8 +273,6 @@ by the proper key:
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
-
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -215,6 +215,94 @@ builder.
     port in this range that appears available. By default this is 5900 to 6000.
     The minimum and maximum ports are inclusive.
 
+## Boot Command
+
+The `boot_command` configuration is very important: it specifies the keys to
+type when the virtual machine is first booted in order to start the OS
+installer. This command is typed after `boot_wait`, which gives the virtual
+machine some time to actually load the ISO.
+
+As documented above, the `boot_command` is an array of strings. The strings are
+all typed in sequence. It is an array only to improve readability within the
+template.
+
+The boot command is "typed" character for character over a VNC connection to the
+machine, simulating a human actually typing the keyboard. There are a set of
+special keys available. If these are in your boot command, they will be replaced
+by the proper key:
+
+-   `<bs>` - Backspace
+
+-   `<del>` - Delete
+
+-   `<enter>` and `<return>` - Simulates an actual "enter" or "return" keypress.
+
+-   `<esc>` - Simulates pressing the escape key.
+
+-   `<tab>` - Simulates pressing the tab key.
+
+-   `<f1>` - `<f12>` - Simulates pressing a function key.
+
+-   `<up>` `<down>` `<left>` `<right>` - Simulates pressing an arrow key.
+
+-   `<spacebar>` - Simulates pressing the spacebar.
+
+-   `<insert>` - Simulates pressing the insert key.
+
+-   `<home>` `<end>` - Simulates pressing the home and end keys.
+
+-   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
+
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
+-   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
+    sending any additional keys. This is useful if you have to generally wait
+    for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
+
+In addition to the special keys, each command to type is treated as a
+[configuration template](/docs/templates/configuration-templates.html). The
+available variables are:
+
+-   `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
+    that is started serving the directory specified by the `http_directory`
+    configuration parameter. If `http_directory` isn't specified, these will be
+    blank!
+
+Example boot command. This is actually a working boot command used to start an
+Ubuntu 12.04 installer:
+
+``` {.text}
+[
+  "<esc><esc><enter><wait>",
+  "/install/vmlinuz noapic ",
+  "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+  "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+  "hostname={{ .Name }} ",
+  "fb=false debconf/frontend=noninteractive ",
+  "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+  "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+  "initrd=/install/initrd.gz -- <enter>"
+]
+```
+
 ## Guest Additions
 
 Packer will automatically download the proper guest additions for the version of

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -336,7 +336,11 @@ by the proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, 
+otherwise they will be held down until the machine reboots. Use lowercase 
+characters as well inside modifiers. 
+
+For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -314,9 +314,29 @@ by the proper key:
 
 -   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -158,8 +158,7 @@ builder.
 
 The `boot_command` configuration is very important: it specifies the keys to
 type when the virtual machine is first booted in order to start the OS
-installer. This command is typed after `boot_wait`, which gives the virtual
-machine some time to actually load the ISO.
+installer. This command is typed after `boot_wait`.
 
 As documented above, the `boot_command` is an array of strings. The strings are
 all typed in sequence. It is an array only to improve readability within the
@@ -200,9 +199,11 @@ by the proper key:
 
 -   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
 
--   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl 
+    key. 
 
--   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the 
+    shift key.
 
 -   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
 
@@ -213,8 +214,6 @@ by the proper key:
 -   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
-
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 
 In addition to the special keys, each command to type is treated as a
 [configuration template](/docs/templates/configuration-templates.html). The

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -153,3 +153,91 @@ builder.
     the initial `boot_command`. Because Packer generally runs in parallel,
     Packer uses a randomly chosen port in this range that appears available. By
     default this is 5900 to 6000. The minimum and maximum ports are inclusive.
+
+## Boot Command
+
+The `boot_command` configuration is very important: it specifies the keys to
+type when the virtual machine is first booted in order to start the OS
+installer. This command is typed after `boot_wait`, which gives the virtual
+machine some time to actually load the ISO.
+
+As documented above, the `boot_command` is an array of strings. The strings are
+all typed in sequence. It is an array only to improve readability within the
+template.
+
+The boot command is "typed" character for character over a VNC connection to the
+machine, simulating a human actually typing the keyboard. There are a set of
+special keys available. If these are in your boot command, they will be replaced
+by the proper key:
+
+-   `<bs>` - Backspace
+
+-   `<del>` - Delete
+
+-   `<enter>` and `<return>` - Simulates an actual "enter" or "return" keypress.
+
+-   `<esc>` - Simulates pressing the escape key.
+
+-   `<tab>` - Simulates pressing the tab key.
+
+-   `<f1>` - `<f12>` - Simulates pressing a function key.
+
+-   `<up>` `<down>` `<left>` `<right>` - Simulates pressing an arrow key.
+
+-   `<spacebar>` - Simulates pressing the spacebar.
+
+-   `<insert>` - Simulates pressing the insert key.
+
+-   `<home>` `<end>` - Simulates pressing the home and end keys.
+
+-   `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
+
+-   `<leftAlt>` `<rightAlt>`  - Simulates pressing the alt key.
+
+-   `<leftCtrl>` `<rightCtrl>` - Simulates pressing the ctrl key.
+
+-   `<leftShift>` `<rightShift>` - Simulates pressing the shift key.
+
+-   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
+
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+
+-   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
+
+-   `<leftAltOff>` `<rightAltOff>`  - Simulates releasing a held alt key.
+
+-   `<leftCtrlOff>` `<rightCtrlOff>` - Simulates releasing a held ctrl key.
+
+-   `<leftShiftOff>` `<rightShiftOff>` - Simulates releasing a held shift key.
+
+-   `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before
+    sending any additional keys. This is useful if you have to generally wait
+    for the UI to update before typing more.
+
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, otherwise they will be held down until the machine reboots. Use lowercase characters as well inside modifiers. For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
+
+In addition to the special keys, each command to type is treated as a
+[configuration template](/docs/templates/configuration-templates.html). The
+available variables are:
+
+-   `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
+    that is started serving the directory specified by the `http_directory`
+    configuration parameter. If `http_directory` isn't specified, these will be
+    blank!
+
+Example boot command. This is actually a working boot command used to start an
+Ubuntu 12.04 installer:
+
+``` {.text}
+[
+  "<esc><esc><enter><wait>",
+  "/install/vmlinuz noapic ",
+  "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+  "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+  "hostname={{ .Name }} ",
+  "fb=false debconf/frontend=noninteractive ",
+  "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+  "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+  "initrd=/install/initrd.gz -- <enter>"
+]
+```


### PR DESCRIPTION
Add support to Parallels, Qemu, Vmware and VirtualBox for using ctrl, shift and alt as keys and as key modifiers. So you can now achieve ctrl+c by using "<leftCtrlOn>c<leftCtrlOff>".

Updated documentation for new key stroke tokens.

This should close:
#2146
#810
#3028