### PR TITLE
builder/googlecompute: provision VM without external IP address

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`
+	OmitExternalIP       bool              `mapstructure:"omit_external_ip"`
 	Preemptible          bool              `mapstructure:"preemptible"`
 	RawStateTimeout      string            `mapstructure:"state_timeout"`
 	Region               string            `mapstructure:"region"`
@@ -167,6 +168,14 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if err := processAccountFile(&c.account, c.AccountFile); err != nil {
 			errs = packer.MultiErrorAppend(errs, err)
 		}
+	}
+
+	if c.OmitExternalIP && c.Address != "" {
+		errs = packer.MultiErrorAppend(fmt.Errorf("you can not specify an external address when 'omit_external_ip' is true"))
+	}
+
+	if c.OmitExternalIP && !c.UseInternalIP {
+		errs = packer.MultiErrorAppend(fmt.Errorf("'use_internal_ip' must be true if 'omit_external_ip' is true"))
 	}
 
 	// Check for any errors.

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -53,6 +53,7 @@ type InstanceConfig struct {
 	Metadata            map[string]string
 	Name                string
 	Network             string
+	OmitExternalIP      bool
 	Preemptible         bool
 	Region              string
 	ServiceAccountEmail string

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -25,7 +25,7 @@ func (config *Config) getImage() Image {
 
 func (config *Config) getInstanceMetadata(sshPublicKey string) (map[string]string, error) {
 	instanceMetadata := make(map[string]string)
-  var err error
+	var err error
 
 	// Copy metadata from config.
 	for k, v := range config.Metadata {
@@ -77,6 +77,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Metadata:            metadata,
 		Name:                name,
 		Network:             config.Network,
+		OmitExternalIP:      config.OmitExternalIP,
 		Preemptible:         config.Preemptible,
 		Region:              config.Region,
 		ServiceAccountEmail: config.account.ClientEmail,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -146,6 +146,9 @@ builder.
 -   `network` (string) - The Google Compute network to use for the
     launched instance. Defaults to `"default"`.
 
+-   `omit_external_ip` (boolean) - If true, the instance will not have an external IP.
+    `use_internal_ip` must be true if this property is true.
+
 -   `preemptible` (boolean) - If true, launch a preembtible instance.
 
 -   `region` (string) - The region in which to launch the instance. Defaults to


### PR DESCRIPTION
This change adds an `omit_external_ip` configuration property that, when true,
will cause no external IP address to be associated with the Google Compute
Engine VM provisioned to create an image. When using `omit_external_ip`, you
must also set the `use_internal_ip` configuration property to true.

Closes #3296