### PR TITLE
Add custom_state config to salt provisioner

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -1,5 +1,5 @@
 // This package implements a provisioner for Packer that executes a
-// saltstack highstate within the remote machine
+// saltstack state within the remote machine
 package saltmasterless
 
 import (
@@ -28,6 +28,9 @@ type Config struct {
 
 	DisableSudo bool `mapstructure:"disable_sudo"`
 
+	// Custom state to run instead of highstate
+	CustomState string `mapstructure:"custom_state"`
+
 	// Local path to the minion config
 	MinionConfig string `mapstructure:"minion_config"`
 
@@ -49,7 +52,7 @@ type Config struct {
 	// Don't exit packer if salt-call returns an error code
 	NoExitOnFailure bool `mapstructure:"no_exit_on_failure"`
 
-	// Set the logging level for the salt highstate run
+	// Set the logging level for the salt-call run
 	LogLevel string `mapstructure:"log_level"`
 
 	// Command line args passed onto salt-call
@@ -103,6 +106,13 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	// build the command line args to pass onto salt
 	var cmd_args bytes.Buffer
+
+	if p.config.CustomState == "" {
+		cmd_args.WriteString(" state.highstate")
+	}	else {
+		cmd_args.WriteString(" state.sls ")
+		cmd_args.WriteString(p.config.CustomState)
+	}
 
 	if p.config.MinionConfig == "" {
 		// pass --file-root and --pillar-root if no minion_config is supplied
@@ -233,14 +243,14 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		}
 	}
 
-	ui.Message("Running highstate")
-	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("salt-call --local state.highstate %s", p.config.CmdArgs))}
+	ui.Message(fmt.Sprintf("Running: salt-call --local %s", p.config.CmdArgs))
+	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("salt-call --local %s", p.config.CmdArgs))}
 	if err = cmd.StartWithUi(comm, ui); err != nil || cmd.ExitStatus != 0 {
 		if err == nil {
 			err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus)
 		}
 
-		return fmt.Errorf("Error executing highstate: %s", err)
+		return fmt.Errorf("Error executing salt-call: %s", err)
 	}
 
 	return nil

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -48,6 +48,30 @@ func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_CustomeState(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "state.") {
+		t.Fatal("a state should be specified in CmdArgs")
+	}
+
+	config["custom_state"] = "birb"
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !strings.Contains(p.config.CmdArgs, "state.sls birb") {
+		t.Fatal("birb state should be specified in CmdArgs")
+	}
+}
+
 func TestProvisionerPrepare_MinionConfig(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -57,6 +57,9 @@ Optional:
     tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
     This will be uploaded to the `remote_state_tree` on the remote.
 
+-   `custom_state` (string) - A state to be ran instead of `state.highstate`.
+    Defaults to `state.highstate` if unspecified.
+
 -   `minion_config` (string) - The path to your local [minion config
     file](http://docs.saltstack.com/ref/configuration/minion.html). This will be
     uploaded to the `/etc/salt` on the remote. This option overrides the
@@ -69,7 +72,7 @@ Optional:
 -   `temp_config_dir` (string) - Where your local state tree will be copied
     before moving to the `/srv/salt` directory. Default is `/tmp/salt`.
 
--   `no_exit_on_failure` (boolean) - Packer will exit if the Salt highstate command
+-   `no_exit_on_failure` (boolean) - Packer will exit if the `salt-call` command
     fails. Set this option to true to ignore Salt failures.
 
--   `log_level` (string) - Set the logging level for the Salt highstate run.
+-   `log_level` (string) - Set the logging level for the `salt-call` run.


### PR DESCRIPTION
Adds a `custom_state` option for templates using the `salt-masterless` provisioner.

With these, I was able to successfully compile the packer executable and build from a template which utilized this option.