### PR TITLE
Optimize Packer document view for iPad portrait mode

### DIFF
--- a/website/source/assets/stylesheets/_footer.scss
+++ b/website/source/assets/stylesheets/_footer.scss
@@ -68,7 +68,7 @@ body{
 
     .footer-hashi{
       display: block;
-      float: none !important;
+      float: right !important;
       .hashicorp-project{
         margin-left: -30px;
       }
@@ -76,10 +76,9 @@ body{
 
     ul{
       display: block;
-      width: 100%;
       li{
         display: block;
-        float: none;
+        float: left;
       }
 
       &.external-links{

--- a/website/source/assets/stylesheets/_ipad.scss
+++ b/website/source/assets/stylesheets/_ipad.scss
@@ -1,0 +1,62 @@
+@media only screen 
+and (min-device-width : 768px) 
+and (max-device-width : 1024px) 
+and (orientation : portrait) {
+  #main-content {
+    display: flex;
+    flex-direction: row;
+
+    #sidebar-docs {
+      flex: 3;
+      h2 {
+        padding: 0;
+      }
+
+      ul {
+        padding: 0;
+        li {
+          padding: 10px 0;
+        }
+      }
+    }
+    .docs-body {
+      flex: 7;
+      h2 {
+        margin-top: 20px;
+      }
+
+      .docs-content {
+        padding: 0 0 80px;
+        div.alert {
+          padding: 20px 30px;
+        }
+
+        code {
+          font-size: 12px;
+        }
+
+        pre {
+          margin: 0 -15px;
+          padding: 15px;
+        }
+
+        ul {
+          margin-top: 0;
+          margin-left: 30px;
+          margin-bottom: 10px;
+        }
+      }
+    }
+  }
+
+  #footer {
+    padding: 20px 0 30px;
+    .edit-page-link {
+      top: -70px;
+    }
+  }
+
+  p {
+    line-height: 1.5;
+  }
+}

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -20,3 +20,6 @@
 @import "_footer";
 @import "_components";
 @import "_sidebar";
+
+// Fix view on iPad
+@import "_ipad";


### PR DESCRIPTION
Changes in this pull request:
- reduced margin, padding, line-height of several elements
- created iPad specific media selector
- removed unnecessary spaces around headers and list elements
- reduced code font size to 12px
- removed unnecessary optimization of page footer for tablets

I've found that although Packer's document is using Bootstrap framework, it's not tablet friendly. So here's my attempt to make it display better on iPad (768x1024).