### PR TITLE
Include Alternative Installation Method for Windows

### DIFF
--- a/website/source/intro/getting-started/setup.html.md
+++ b/website/source/intro/getting-started/setup.html.md
@@ -74,6 +74,14 @@ alternatives available.
 If you're using OS X and [Homebrew](http://brew.sh), you can install Packer:
 
     $ brew install packer
+    
+### Windows Package Management
+
+If you're using Windows and [package management](https://technet.microsoft.com/en-us/library/dn890706.aspx), you can install Packer:
+
+```powershell
+Install-Package -Name Packer -Source Chocolatey
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
If a machine has PowerShell v5 or the Package Management update installed (v3 or v4), Packer can be installed from the chocolatey repository.

No tests included/required for update to documentation.