### PR TITLE
clean up EBS volumes on failure

### DIFF
--- a/builder/amazon/ebs/step_cleanup_volumes.go
+++ b/builder/amazon/ebs/step_cleanup_volumes.go
@@ -30,12 +30,6 @@ func (s *stepCleanupVolumes) Cleanup(state multistep.StateBag) {
 		instance = instanceRaw.(*ec2.Instance)
 	}
 	ui := state.Get("ui").(packer.Ui)
-	amisRaw := state.Get("amis")
-	if amisRaw == nil {
-		ui.Say("No AMIs to cleanup")
-		return
-	}
-
 	if instance == nil {
 		ui.Say("No volumes to clean up, skipping")
 		return


### PR DESCRIPTION
This fixes a case where EBS volumes would not be deleted when using the amazon-ebs builder when volume delete on termination was false on the source AMI and the build fails.  The cleanup step had an unnecessary check that would only pass if the build had completed successfully and generated an AMI.

Edit: This would fail to trigger when a build terminates early since there is no AMI, but the volumes still exist.

My solution was to delete this check since it seems to serve no purpose.  Testing by inserting a failure into a provisioner or aborting a debug run early showed expected behavior with the volume being deleted if it was created.  Volumes still stick around if the build is aborted during the wait for instance to become ready step, but I elected to leave that one for now.