### PR TITLE
[WIP] skip_register_ami option

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -242,29 +242,34 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepCopyFiles{},
 		&StepChrootProvision{},
 		&StepEarlyCleanup{},
-		&StepSnapshot{},
-		&awscommon.StepDeregisterAMI{
-			ForceDeregister: b.config.AMIForceDeregister,
-			AMIName:         b.config.AMIName,
-		},
-		&StepRegisterAMI{
-			RootVolumeSize: b.config.RootVolumeSize,
-		},
-		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
-		},
-		&awscommon.StepModifyAMIAttributes{
-			Description:  b.config.AMIDescription,
-			Users:        b.config.AMIUsers,
-			Groups:       b.config.AMIGroups,
-			ProductCodes: b.config.AMIProductCodes,
-		},
-		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
-		},
 	)
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps,
+			&StepSnapshot{},
+			&awscommon.StepDeregisterAMI{
+				ForceDeregister: b.config.AMIForceDeregister,
+				AMIName:         b.config.AMIName,
+			},
+			&StepRegisterAMI{
+				RootVolumeSize: b.config.RootVolumeSize,
+			},
+			&awscommon.StepAMIRegionCopy{
+				AccessConfig: &b.config.AccessConfig,
+				Regions:      b.config.AMIRegions,
+				Name:         b.config.AMIName,
+			},
+			&awscommon.StepModifyAMIAttributes{
+				Description:  b.config.AMIDescription,
+				Users:        b.config.AMIUsers,
+				Groups:       b.config.AMIGroups,
+				ProductCodes: b.config.AMIProductCodes,
+			},
+			&awscommon.StepCreateTags{
+				Tags: b.config.AMITags,
+			},
+		)
+	}
 
 	// Run!
 	b.runner = common.NewRunner(steps, b.config.PackerConfig, ui)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -25,9 +25,11 @@ type AMIConfig struct {
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
-	if c.AMIName == "" {
+	if c.AMIName == "" && !c.AMISkipRegister {
 		errs = append(errs, fmt.Errorf("ami_name must be specified"))
 	}
+
+	// TODO: confirm that bypassed options aren't supplied with skip_register_ami
 
 	if len(c.AMIRegions) > 0 {
 		regionSet := make(map[string]struct{})

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -20,6 +20,7 @@ type AMIConfig struct {
 	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
+	AMISkipRegister         bool              `mapstructure:"skip_register_ami"`
 }
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -157,33 +157,38 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
-		&awscommon.StepStopEBSBackedInstance{
-			SpotPrice:           b.config.SpotPrice,
-			DisableStopInstance: b.config.DisableStopInstance,
-		},
-		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
-		},
-		&awscommon.StepDeregisterAMI{
-			ForceDeregister: b.config.AMIForceDeregister,
-			AMIName:         b.config.AMIName,
-		},
-		&stepCreateAMI{},
-		&stepCreateEncryptedAMICopy{},
-		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
-		},
-		&awscommon.StepModifyAMIAttributes{
-			Description:  b.config.AMIDescription,
-			Users:        b.config.AMIUsers,
-			Groups:       b.config.AMIGroups,
-			ProductCodes: b.config.AMIProductCodes,
-		},
-		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
-		},
+	}
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps,
+			&awscommon.StepStopEBSBackedInstance{
+				SpotPrice:           b.config.SpotPrice,
+				DisableStopInstance: b.config.DisableStopInstance,
+			},
+			&awscommon.StepModifyEBSBackedInstance{
+				EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			},
+			&awscommon.StepDeregisterAMI{
+				ForceDeregister: b.config.AMIForceDeregister,
+				AMIName:         b.config.AMIName,
+			},
+			&stepCreateAMI{},
+			&stepCreateEncryptedAMICopy{},
+			&awscommon.StepAMIRegionCopy{
+				AccessConfig: &b.config.AccessConfig,
+				Regions:      b.config.AMIRegions,
+				Name:         b.config.AMIName,
+			},
+			&awscommon.StepModifyAMIAttributes{
+				Description:  b.config.AMIDescription,
+				Users:        b.config.AMIUsers,
+				Groups:       b.config.AMIGroups,
+				ProductCodes: b.config.AMIProductCodes,
+			},
+			&awscommon.StepCreateTags{
+				Tags: b.config.AMITags,
+			},
+		)
 	}
 
 	// Run!

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -239,32 +239,37 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
-		&StepUploadX509Cert{},
-		&StepBundleVolume{
-			Debug: b.config.PackerDebug,
-		},
-		&StepUploadBundle{
-			Debug: b.config.PackerDebug,
-		},
-		&awscommon.StepDeregisterAMI{
-			ForceDeregister: b.config.AMIForceDeregister,
-			AMIName:         b.config.AMIName,
-		},
-		&StepRegisterAMI{},
-		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
-		},
-		&awscommon.StepModifyAMIAttributes{
-			Description:  b.config.AMIDescription,
-			Users:        b.config.AMIUsers,
-			Groups:       b.config.AMIGroups,
-			ProductCodes: b.config.AMIProductCodes,
-		},
-		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
-		},
+	}
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps,
+			&StepUploadX509Cert{},
+			&StepBundleVolume{
+				Debug: b.config.PackerDebug,
+			},
+			&StepUploadBundle{
+				Debug: b.config.PackerDebug,
+			},
+			&awscommon.StepDeregisterAMI{
+				ForceDeregister: b.config.AMIForceDeregister,
+				AMIName:         b.config.AMIName,
+			},
+			&StepRegisterAMI{},
+			&awscommon.StepAMIRegionCopy{
+				AccessConfig: &b.config.AccessConfig,
+				Regions:      b.config.AMIRegions,
+				Name:         b.config.AMIName,
+			},
+			&awscommon.StepModifyAMIAttributes{
+				Description:  b.config.AMIDescription,
+				Users:        b.config.AMIUsers,
+				Groups:       b.config.AMIGroups,
+				ProductCodes: b.config.AMIProductCodes,
+			},
+			&awscommon.StepCreateTags{
+				Tags: b.config.AMITags,
+			},
+		)
 	}
 
 	// Run!


### PR DESCRIPTION
I thought I'd put this up here as an idea for feedback before I do any more work.

It would be nice to avoid doing any AMI build steps in workflows where the AMI is not the true product and Packer is being used as a convenient mechanism to create a temporary AWS instance.   I presume anyone using the artifice post processor would want this toggle.

Let me know if this makes any sense from a high level or implementation standpoint.
