### PR TITLE
IAM permission needed to deregister failed images

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -114,6 +114,7 @@ Packer to work:
         "ec2:DescribeSnapshots",
         "ec2:DescribeImages",
         "ec2:RegisterImage",
+        "ec2:DeregisterImage",
         "ec2:CreateTags",
         "ec2:ModifyImageAttribute",
         "ec2:GetPasswordData",


### PR DESCRIPTION
Update documentation for IAM instance role policy. When packer fails to modify attributes of a successful AMI snapshot (e.g.: description, groups, etc.), it will attempt to deregister the image. This additional permission is needed for that.