### PR TITLE
Fix file provisioner dotfile matching w/ docker builder

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -179,7 +179,7 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 
 	// Make the directory, then copy into it
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("set -e; mkdir -p %s; command cp -R %s/* %s",
+		Command: fmt.Sprintf("set -e; mkdir -p %s; cd %s; command cp -R $(ls -A .) %s",
 			containerDst, containerSrc, containerDst),
 	}
 	if err := c.Start(cmd); err != nil {

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -179,7 +179,7 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 
 	// Make the directory, then copy into it
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("set -e; mkdir -p %s; cd %s; command cp -R $(ls -A .) %s",
+		Command: fmt.Sprintf("set -e; mkdir -p %s; cd %s; command cp -R `ls -A .` %s",
 			containerDst, containerSrc, containerDst),
 	}
 	if err := c.Start(cmd); err != nil {


### PR DESCRIPTION
Use `ls -A` instead of `*` glob for copying paths.

Closes #3142
