### PR TITLE
post-processor/checksum: keep input artifact files

### DIFF
--- a/post-processor/checksum/artifact.go
+++ b/post-processor/checksum/artifact.go
@@ -12,10 +12,6 @@ type Artifact struct {
 	files []string
 }
 
-func NewArtifact(files []string) *Artifact {
-	return &Artifact{files: files}
-}
-
 func (a *Artifact) BuilderId() string {
 	return BuilderId
 }

--- a/post-processor/checksum/post-processor.go
+++ b/post-processor/checksum/post-processor.go
@@ -83,16 +83,16 @@ func getHash(t string) hash.Hash {
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-	files := artifact.Files()
 	var h hash.Hash
 	var checksumFile string
 
-	newartifact := NewArtifact(artifact.Files())
+	newartifact := &Artifact{}
+	copy(newartifact.files, artifact.Files())
 
 	for _, ct := range p.config.ChecksumTypes {
 		h = getHash(ct)
 
-		for _, art := range files {
+		for _, art := range artifact.Files() {
 			if len(artifact.Files()) > 1 {
 				checksumFile = filepath.Join(filepath.Dir(art), ct+"sums")
 			} else if p.config.OutputPath != "" {


### PR DESCRIPTION
fixes next post-processor if it exists after checksum

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>