### PR TITLE
Note added: Command line var on Windows

### DIFF
--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -113,6 +113,10 @@ With a properly validated template. It is time to build your first image. This
 is done by calling `packer build` with the template file. The output should look
 similar to below. Note that this process typically takes a few minutes.
 
+-&gt; **Note:** When using packer on Windows, replace the single-quotes in the 
+command below with double-quotes.
+
+
 ``` {.text}
 $ packer build \
     -var 'aws_access_key=YOUR ACCESS KEY' \

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -116,7 +116,6 @@ similar to below. Note that this process typically takes a few minutes.
 -&gt; **Note:** When using packer on Windows, replace the single-quotes in the 
 command below with double-quotes.
 
-
 ``` {.text}
 $ packer build \
     -var 'aws_access_key=YOUR ACCESS KEY' \


### PR DESCRIPTION
Added a note to the Intro - Getting Started - Building an Image page for packer builds on Windows. Variables must be enclosed in double quotes instead of single quotes.

I have not created an issue ticket for this.