### PR TITLE
Update example AWS policy document

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -89,6 +89,7 @@ Packer to work:
 
 ``` {.javascript}
 {
+  "Version": "2012-10-17",
   "Statement": [{
       "Effect": "Allow",
       "Action" : [


### PR DESCRIPTION
This is a tiny update to project docs.

The example AWS policy document does not contain version string. Therefore, pasting it into AWS console triggers an error. Please have a look over screenshot below:
![iam_management_console](https://cloud.githubusercontent.com/assets/2097938/17859793/5188cb92-688b-11e6-9dfb-f08bef0c2320.jpg)


Setting a version number allows to create valid policy document and have it attached to was credentials.