### PR TITLE
fix triton builder key material handling when key matieral specified …

### DIFF
--- a/builder/triton/access_config.go
+++ b/builder/triton/access_config.go
@@ -38,8 +38,10 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("triton_key_id is required to use the triton builder"))
 	}
 
-	if c.KeyMaterial == "" {
-		errs = append(errs, fmt.Errorf("triton_key_material is required to use the triton builder"))
+	var err error
+	c.KeyMaterial, err = processKeyMaterial(c.KeyMaterial)
+	if c.KeyMaterial == "" || err != nil {
+		errs = append(errs, fmt.Errorf("valid triton_key_material is required to use the triton builder"))
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
…is a file path.

As best I could tell, there is code in the Prepare() method of triton/builder.go that
is trying to be smart and use the contents of the triton_key_matieral supplied to the
triton builder to auto-configure the SSH communicator so that the communicator
doesn't have to be explicitly specified.

What I was seeing, though, was that it didn't work (SSH would time out
trying to connect) if the value of key_material supplied to "triton_key_material"
in the config was a file path.

There was existing code in triton/access_config.go that already solved the
problem of detecting that it was a file path and reading key from disk, so
I just used that.
