### PR TITLE
Installs 64bit chef on windows if available

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -28,12 +28,12 @@ type guestOSTypeConfig struct {
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: guestOSTypeConfig{
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-solo --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo {{end}}bash",
+		installCommand: "curl -L  https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
 		stagingDir:     "/tmp/packer-chef-client",
 	},
 	provisioner.WindowsOSType: guestOSTypeConfig{
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "powershell.exe -Command \"(New-Object System.Net.WebClient).DownloadFile('http://chef.io/chef/install.msi', 'C:\\Windows\\Temp\\chef.msi');Start-Process 'msiexec' -ArgumentList '/qb /i C:\\Windows\\Temp\\chef.msi' -NoNewWindow -Wait\"",
+		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\"",
 		stagingDir:     "C:/Windows/Temp/packer-chef-client",
 	},
 }

--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -28,7 +28,7 @@ type guestOSTypeConfig struct {
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: guestOSTypeConfig{
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-solo --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "curl -L  https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
+		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
 		stagingDir:     "/tmp/packer-chef-client",
 	},
 	provisioner.WindowsOSType: guestOSTypeConfig{


### PR DESCRIPTION
## linux

Moves install.sh to new omnitruck.chef.io download url

## powershell

Points to [omnitruck](https://blog.chef.io/2016/03/16/weve-moved-our-software-distribution-to-packages-chef-io/) powershell script that detects if should install 32 or 64 bit chef client. 
Before this fix, windows packer vms would always install 32 bit client msi. The 64 bit windows client was introduced with chef 12.7.x

Resolves #3847

Before fix
```
virtualbox-iso: [2016-08-30T18:27:36+00:00] INFO: *** Chef 12.13.37 ***
virtualbox-iso: [2016-08-30T18:27:36+00:00] INFO: Platform: i386-mingw32
```
After fix
```
 vmware-iso: [2016-09-01T19:32:32+00:00] INFO: *** Chef 12.13.37 ***
 vmware-iso: [2016-09-01T19:32:32+00:00] INFO: Platform: x64-mingw32
```