### PR TITLE
Portable createDir in puppet-server/provisioner

### DIFF
--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -191,7 +191,7 @@ func (p *Provisioner) Cancel() {
 
 func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir string) error {
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("mkdir -p '%s'", dir),
+		Command: fmt.Sprintf("command mkdir -p \"%s\" || (pushd \"%s\" && popd || mkdir \"%s\")", dir, dir, dir),
 	}
 
 	if err := cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
Here's a polyglot approach to solving the "mkdir" problem that is valid in bash and batch.

More generally speaking, though, it seems that [windows-host](https://github.com/mitchellh/packer/issues?q=is%3Aissue+is%3Aopen+label%3Awindows-host) issues are often related to the fact that a lot of provisioners assume POSIX environments on the other end.

A lot of PRs relating to these bugs aren't being pulled in, I don't really expect my PR to be any different. What's a better approach to solving this problem? I don't think batch compatible bashisms are going to work for everything, but littering all the provisioners with "if windows" blocks doesn't seem like a good idea either.

Relates to #3381
Relates to #1317