### PR TITLE
Updated ansible provisioner documentation to cite situation encounter…

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -100,4 +100,11 @@ Optional Parameters:
 
 ## Limitations
 
-The `ansible` provisioner does not support SCP to transfer files.
+- The `ansible` provisioner does not support SCP to transfer files.
+
+- Redhat / CentOS builds have been known to fail with the following error due to `sftp_command`, which should be set to `/usr/libexec/openssh/sftp-server -e`:
+
+```
+==> virtualbox-ovf: starting sftp subsystem
+    virtualbox-ovf: fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "SSH Error: data could not be sent to the remote host. Make sure this host can be reached over ssh", "unreachable": true}
+```


### PR DESCRIPTION
Seeing [myself](https://groups.google.com/forum/#!topic/packer-tool/dnbyOYa1Xtk) and [others](https://github.com/mitchellh/packer/issues/3529) having build issues around Redhat family due to the sftp_command not being standard, I wanted to save others time hopefully by listing this as a current limitation until such time the sftp_command default is changed.