### PR TITLE
Create community-tools.md

### DIFF
--- a/website/source/community/community-tools.md
+++ b/website/source/community/community-tools.md
@@ -1,0 +1,12 @@
+Maintained Images
+- bento - prepackaged minimal vagrant images, for testing
+
+DSL Tools
+- racker - eliminate duplication: write packer templates using a Ruby DSL - https://github.com/aspring/racker
+- packer-config A Ruby way to generate packer.io configurations https://github.com/ianchesal/packer-config
+
+Uploaders
+- suitcase - store your Packer Images in S3, for CentOS
+
+Builder
+- Debian and Ubuntu virtual machine images for Vagrant, VirtualBox and QEMU. https://github.com/tylert/packer-build


### PR DESCRIPTION
Further to https://github.com/mitchellh/packer/issues/3854 - I'm suggesting that the Packer.io website list 3rd party tools. Especially those that work to complement functionality (rather than just merely be templates for Packer)
