### PR TITLE
add scp support to ansible provisioner

### DIFF
--- a/provisioner/ansible/adapter.go
+++ b/provisioner/ansible/adapter.go
@@ -159,26 +159,13 @@ func (c *adapter) handleSession(newChannel ssh.NewChannel) error {
 					if len(sftpCmd) == 0 {
 						sftpCmd = "/usr/lib/sftp-server -e"
 					}
-					cmd := &packer.RemoteCmd{
-						Stdin:   channel,
-						Stdout:  channel,
-						Stderr:  channel.Stderr(),
-						Command: sftpCmd,
-					}
 
 					c.ui.Say("starting sftp subsystem")
-					if err := c.comm.Start(cmd); err != nil {
-						c.ui.Error(err.Error())
-						req.Reply(false, nil)
-						close(done)
-						return
-					}
-
-					req.Reply(true, nil)
 					go func() {
-						cmd.Wait()
+						_ = c.remoteExec(sftpCmd, channel, channel, channel.Stderr())
 						close(done)
 					}()
+					req.Reply(true, nil)
 				default:
 					c.ui.Error(fmt.Sprintf("unsupported subsystem requested: %s", req.Payload))
 					req.Reply(false, nil)

--- a/provisioner/ansible/scp.go
+++ b/provisioner/ansible/scp.go
@@ -1,0 +1,338 @@
+package ansible
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/packer/packer"
+)
+
+const (
+	scpOK         = "\x00"
+	scpEmptyError = "\x02\n"
+)
+
+/*
+scp is a simple, but poorly documented, protocol. Thankfully, its source is
+freely available, and there is at least one page that describes it reasonably
+well.
+
+* https://raw.githubusercontent.com/openssh/openssh-portable/master/scp.c
+* https://opensource.apple.com/source/OpenSSH/OpenSSH-7.1/openssh/scp.c
+* https://blogs.oracle.com/janp/entry/how_the_scp_protocol_works is a great
+	resource, but has some bad information. Its first problem is that it doesn't
+	correctly describe why the producer has to read more responses than messages
+	it sends (because it has to read the 0 sent by the sink to start the
+	transfer). The second problem is that it omits that the producer needs to
+	send a 0 byte after file contents.
+*/
+
+func scpUploadSession(opts []byte, rest string, in io.Reader, out io.Writer, comm packer.Communicator) error {
+	rest = strings.TrimSpace(rest)
+	if len(rest) == 0 {
+		fmt.Fprintf(out, scpEmptyError)
+		return errors.New("no scp target specified")
+	}
+
+	d, err := ioutil.TempDir("", "packer-ansible-upload")
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+	defer os.RemoveAll(d)
+
+	state := &scpUploadState{destRoot: rest, srcRoot: d, comm: comm}
+
+	fmt.Fprintf(out, scpOK) // signal the client to start the transfer.
+	return state.Protocol(bufio.NewReader(in), out)
+}
+
+func scpDownloadSession(opts []byte, rest string, in io.Reader, out io.Writer, comm packer.Communicator) error {
+	rest = strings.TrimSpace(rest)
+	if len(rest) == 0 {
+		fmt.Fprintf(out, scpEmptyError)
+		return errors.New("no scp source specified")
+	}
+
+	d, err := ioutil.TempDir("", "packer-ansible-download")
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+	defer os.RemoveAll(d)
+
+	if bytes.Contains([]byte{'d'}, opts) {
+		// the only ansible module that supports downloading via scp is fetch,
+		// fetch only supports file downloads as of Ansible 2.1.
+		fmt.Fprintf(out, scpEmptyError)
+		return errors.New("directory downloads not supported")
+	}
+
+	f, err := os.Create(filepath.Join(d, filepath.Base(rest)))
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+	defer f.Close()
+
+	err = comm.Download(rest, f)
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+
+	state := &scpDownloadState{srcRoot: d}
+
+	return state.Protocol(bufio.NewReader(in), out)
+}
+
+func (state *scpDownloadState) FileProtocol(path string, info os.FileInfo, in *bufio.Reader, out io.Writer) error {
+	size := info.Size()
+	perms := fmt.Sprintf("C%04o", info.Mode().Perm())
+	fmt.Fprintln(out, perms, size, info.Name())
+	err := scpResponse(in)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	io.CopyN(out, f, size)
+	fmt.Fprintf(out, scpOK)
+
+	return scpResponse(in)
+}
+
+type scpUploadState struct {
+	comm     packer.Communicator
+	destRoot string // destRoot is the directory on the target
+	srcRoot  string // srcRoot is the directory on the host
+	mtime    time.Time
+	atime    time.Time
+	dir      string // dir is a path relative to the roots
+}
+
+func (scp scpUploadState) DestPath() string {
+	return filepath.Join(scp.destRoot, scp.dir)
+}
+
+func (scp scpUploadState) SrcPath() string {
+	return filepath.Join(scp.srcRoot, scp.dir)
+}
+
+func (state *scpUploadState) Protocol(in *bufio.Reader, out io.Writer) error {
+	for {
+		b, err := in.ReadByte()
+		if err != nil {
+			return err
+		}
+		switch b {
+		case 'T':
+			err := state.TimeProtocol(in, out)
+			if err != nil {
+				return err
+			}
+		case 'C':
+			return state.FileProtocol(in, out)
+		case 'E':
+			state.dir = filepath.Dir(state.dir)
+			fmt.Fprintf(out, scpOK)
+			return nil
+		case 'D':
+			return state.DirProtocol(in, out)
+		default:
+			fmt.Fprintf(out, scpEmptyError)
+			return fmt.Errorf("unexpected message: %c", b)
+		}
+	}
+}
+
+func (state *scpUploadState) FileProtocol(in *bufio.Reader, out io.Writer) error {
+	defer func() {
+		state.mtime = time.Time{}
+	}()
+
+	var mode os.FileMode
+	var size int64
+	var name string
+	_, err := fmt.Fscanf(in, "%04o %d %s\n", &mode, &size, &name)
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return fmt.Errorf("invalid file message: %v", err)
+	}
+	fmt.Fprintf(out, scpOK)
+
+	var fi os.FileInfo = fileInfo{name: name, size: size, mode: mode, mtime: state.mtime}
+
+	err = state.comm.Upload(filepath.Join(state.DestPath(), fi.Name()), io.LimitReader(in, fi.Size()), &fi)
+	if err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+
+	err = scpResponse(in)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, scpOK)
+	return nil
+}
+
+func (state *scpUploadState) TimeProtocol(in *bufio.Reader, out io.Writer) error {
+	var m, a int64
+	if _, err := fmt.Fscanf(in, "%d 0 %d 0\n", &m, &a); err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return err
+	}
+	fmt.Fprintf(out, scpOK)
+
+	state.atime = time.Unix(a, 0)
+	state.mtime = time.Unix(m, 0)
+	return nil
+}
+
+func (state *scpUploadState) DirProtocol(in *bufio.Reader, out io.Writer) error {
+	var mode os.FileMode
+	var length uint
+	var name string
+
+	if _, err := fmt.Fscanf(in, "%04o %d %s\n", &mode, &length, &name); err != nil {
+		fmt.Fprintf(out, scpEmptyError)
+		return fmt.Errorf("invalid directory message: %v", err)
+	}
+	fmt.Fprintf(out, scpOK)
+
+	path := filepath.Join(state.dir, name)
+	if err := os.Mkdir(path, mode); err != nil {
+		return err
+	}
+	state.dir = path
+
+	if state.atime.IsZero() {
+		state.atime = time.Now()
+	}
+	if state.mtime.IsZero() {
+		state.mtime = time.Now()
+	}
+
+	if err := os.Chtimes(path, state.atime, state.mtime); err != nil {
+		return err
+	}
+
+	if err := state.comm.UploadDir(filepath.Dir(state.DestPath()), state.SrcPath(), nil); err != nil {
+		return err
+	}
+
+	state.mtime = time.Time{}
+	state.atime = time.Time{}
+	return state.Protocol(in, out)
+}
+
+type scpDownloadState struct {
+	srcRoot string // srcRoot is the directory on the host
+}
+
+func (state *scpDownloadState) Protocol(in *bufio.Reader, out io.Writer) error {
+	r := bufio.NewReader(in)
+	// read the byte sent by the other side to start the transfer
+	scpResponse(r)
+
+	return filepath.Walk(state.srcRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if path == state.srcRoot {
+			return nil
+		}
+
+		if info.IsDir() {
+			// no need to get fancy; srcRoot should only contain one file, because
+			// Ansible only allows fetching a single file.
+			return errors.New("unexpected directory")
+		}
+
+		return state.FileProtocol(path, info, r, out)
+	})
+}
+
+func scpOptions(s string) (opts []byte, rest string) {
+	end := 0
+	opt := false
+
+Loop:
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch {
+		case b == ' ':
+			opt = false
+			end++
+		case b == '-':
+			opt = true
+			end++
+		case opt:
+			opts = append(opts, b)
+			end++
+		default:
+			break Loop
+		}
+	}
+
+	rest = s[end:]
+	return
+}
+
+func scpResponse(r *bufio.Reader) error {
+	code, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	if code != 0 {
+		message, err := r.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("Error reading error message: %s", err)
+		}
+
+		// 1 is a warning. Anything higher (really just 2) is an error.
+		if code > 1 {
+			return errors.New(string(message))
+		}
+
+		log.Println("WARNING:", err)
+	}
+	return nil
+}
+
+type fileInfo struct {
+	name  string
+	size  int64
+	mode  os.FileMode
+	mtime time.Time
+}
+
+func (fi fileInfo) Name() string      { return fi.name }
+func (fi fileInfo) Size() int64       { return fi.size }
+func (fi fileInfo) Mode() os.FileMode { return fi.mode }
+func (fi fileInfo) ModTime() time.Time {
+	if fi.mtime.IsZero() {
+		return time.Now()
+	}
+	return fi.mtime
+}
+func (fi fileInfo) IsDir() bool      { return fi.mode.IsDir() }
+func (fi fileInfo) Sys() interface{} { return nil }

--- a/test/fixtures/provisioner-ansible/all_options.json
+++ b/test/fixtures/provisioner-ansible/all_options.json
@@ -18,6 +18,7 @@
           "-vvvv", "--private-key", "ansible-test-id"
         ],
         "sftp_command": "/usr/lib/sftp-server -e -l INFO",
+        "use_sftp": true,
         "ansible_env_vars": ["PACKER_ANSIBLE_TEST=1", "ANSIBLE_HOST_KEY_CHECKING=False"],
         "groups": ["PACKER_TEST"],
         "empty_groups": ["PACKER_EMPTY_GROUP"],

--- a/test/fixtures/provisioner-ansible/all_options.json
+++ b/test/fixtures/provisioner-ansible/all_options.json
@@ -3,7 +3,7 @@
     "provisioners": [
       {
         "type": "shell-local",
-        "command": "echo 'TODO(bc): write the public key to $HOME/.ssh/known_hosts and stop using ANSIBLE_HOST_KEY_CHECKING=False'"
+        "command": "echo 'TODO(bhcleek): write the public key to $HOME/.ssh/known_hosts and stop using ANSIBLE_HOST_KEY_CHECKING=False'"
       }, {
         "type": "shell",
         "inline": [
@@ -22,7 +22,7 @@
         "groups": ["PACKER_TEST"],
         "empty_groups": ["PACKER_EMPTY_GROUP"],
         "host_alias": "packer-test",
-        "user": "packer", 
+        "user": "packer",
         "local_port": 2222,
         "ssh_host_key_file": "ansible-server.key",
         "ssh_authorized_key_file": "ansible-test-id.pub"

--- a/test/fixtures/provisioner-ansible/playbook.yml
+++ b/test/fixtures/provisioner-ansible/playbook.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: default
+- hosts: default:packer-test
   gather_facts: no
   tasks:
     - raw: touch /root/ansible-raw-test

--- a/test/fixtures/provisioner-ansible/playbook.yml
+++ b/test/fixtures/provisioner-ansible/playbook.yml
@@ -6,7 +6,7 @@
     - raw: date
     - command: echo "the command module"
     - command: mkdir /tmp/remote-dir
-      args: 
+      args:
         creates: /tmp/remote-dir
     - copy: src=dir/file.txt dest=/tmp/remote-dir/file.txt
     - fetch: src=/tmp/remote-dir/file.txt dest=fetched-dir validate=yes fail_on_missing=yes

--- a/test/fixtures/provisioner-ansible/scp.json
+++ b/test/fixtures/provisioner-ansible/scp.json
@@ -7,10 +7,9 @@
         "extra_arguments": [
           "-vvvv"
         ],
-        "ansible_env_vars": ["ANSIBLE_SCP_IF_SSH=True"],
         "sftp_command": "/usr/bin/false"
       }
-		],
+    ],
     "builders": [
       {
         "type": "googlecompute",

--- a/test/fixtures/provisioner-ansible/scp.json
+++ b/test/fixtures/provisioner-ansible/scp.json
@@ -3,15 +3,20 @@
     "provisioners": [
       {
         "type":  "ansible",
-        "playbook_file": "./playbook.yml"
+        "playbook_file": "./playbook.yml",
+        "extra_arguments": [
+          "-vvvv"
+        ],
+        "ansible_env_vars": ["ANSIBLE_SCP_IF_SSH=True"],
+        "sftp_command": "/usr/bin/false"
       }
-    ],
+		],
     "builders": [
       {
         "type": "googlecompute",
         "account_file": "{{user `account_file`}}",
         "project_id": "{{user `project_id`}}",
-        "image_name": "packerbats-minimal-{{timestamp}}",
+        "image_name": "packerbats-scp-{{timestamp}}",
         "source_image": "debian-7-wheezy-v20141108",
         "zone": "us-central1-a"
       }

--- a/test/fixtures/provisioner-ansible/sftp.json
+++ b/test/fixtures/provisioner-ansible/sftp.json
@@ -1,0 +1,29 @@
+{
+    "variables": {},
+    "provisioners": [
+      {
+        "type": "shell",
+        "inline": [
+          "apt-get update",
+          "apt-get -y install python openssh-sftp-server",
+          "ls -l /usr/lib",
+          "#/usr/lib/sftp-server -?"
+        ]
+      }, {
+        "type":  "ansible",
+        "playbook_file": "./playbook.yml",
+        "sftp_command": "/usr/lib/sftp-server -e -l INFO"
+      }
+		],
+    "builders": [
+      {
+        "type": "googlecompute",
+        "account_file": "{{user `account_file`}}",
+        "project_id": "{{user `project_id`}}",
+
+        "image_name": "packerbats-sftp-{{timestamp}}",
+        "source_image": "debian-7-wheezy-v20141108",
+        "zone": "us-central1-a"
+      }
+    ]
+}

--- a/test/fixtures/provisioner-ansible/sftp.json
+++ b/test/fixtures/provisioner-ansible/sftp.json
@@ -12,9 +12,10 @@
       }, {
         "type":  "ansible",
         "playbook_file": "./playbook.yml",
-        "sftp_command": "/usr/lib/sftp-server -e -l INFO"
+        "sftp_command": "/usr/lib/sftp-server -e -l INFO",
+        "use_sftp": true
       }
-		],
+    ],
     "builders": [
       {
         "type": "googlecompute",

--- a/test/provisioner_ansible.bats
+++ b/test/provisioner_ansible.bats
@@ -56,3 +56,17 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "$(gc_has_image "packerbats-alloptions")" -eq 1 ]
 }
+
+@test "ansible provisioner: build scp.json" {
+    cd $FIXTURE_ROOT
+    run packer build ${USER_VARS} $FIXTURE_ROOT/scp.json
+    [ "$status" -eq 0 ]
+    [ "$(gc_has_image "packerbats-scp")" -eq 1 ]
+}
+
+@test "ansible provisioner: build sftp.json" {
+    cd $FIXTURE_ROOT
+    run packer build ${USER_VARS} $FIXTURE_ROOT/sftp.json
+    [ "$status" -eq 0 ]
+    [ "$(gc_has_image "packerbats-sftp")" -eq 1 ]
+}

--- a/test/provisioner_ansible.bats
+++ b/test/provisioner_ansible.bats
@@ -48,6 +48,7 @@ teardown() {
     run packer build ${USER_VARS} $FIXTURE_ROOT/minimal.json
     [ "$status" -eq 0 ]
     [ "$(gc_has_image "packerbats-minimal")" -eq 1 ]
+    diff -r dir fetched-dir/default/tmp/remote-dir > /dev/null
 }
 
 @test "ansible provisioner: build all_options.json" {
@@ -55,6 +56,7 @@ teardown() {
     run packer build ${USER_VARS} $FIXTURE_ROOT/all_options.json
     [ "$status" -eq 0 ]
     [ "$(gc_has_image "packerbats-alloptions")" -eq 1 ]
+    diff -r dir fetched-dir/packer-test/tmp/remote-dir > /dev/null
 }
 
 @test "ansible provisioner: build scp.json" {
@@ -62,6 +64,7 @@ teardown() {
     run packer build ${USER_VARS} $FIXTURE_ROOT/scp.json
     [ "$status" -eq 0 ]
     [ "$(gc_has_image "packerbats-scp")" -eq 1 ]
+    diff -r dir fetched-dir/default/tmp/remote-dir > /dev/null
 }
 
 @test "ansible provisioner: build sftp.json" {
@@ -69,4 +72,6 @@ teardown() {
     run packer build ${USER_VARS} $FIXTURE_ROOT/sftp.json
     [ "$status" -eq 0 ]
     [ "$(gc_has_image "packerbats-sftp")" -eq 1 ]
+    diff -r dir fetched-dir/default/tmp/remote-dir > /dev/null
 }
+

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -78,9 +78,11 @@ Optional Parameters:
 - `sftp_command` (string) - The command to run on the machine being provisioned
   by Packer to handle the SFTP protocol that Ansible will use to transfer
   files. The command should read and write on stdin and stdout, respectively.
-  SCP can be used instead of SFTP by setting `ANSIBLE_SCP_IF_SSH=True` in
-  `ansible_env_vars`.
   Defaults to `/usr/lib/sftp-server -e`.
+
+- `use_sftp` (boolean) - Whether to use SFTP. When false,
+  `ANSIBLE_SCP_IF_SSH=True` will be automatically added to `ansible_env_vars`.
+  Defaults to false.
 
 - `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
   Usage example:
@@ -90,8 +92,7 @@ Optional Parameters:
 ```
 
 - `ansible_env_vars` (array of strings) - Environment variables to set before
-  running Ansible.  If unset, defaults to `ANSIBLE_HOST_KEY_CHECKING=False`.
-  Set `ANSIBLE_SCP_IF_SSH=True` to use SCP instead of SFTP.
+  running Ansible.
   Usage example:
 
 ```

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -78,6 +78,8 @@ Optional Parameters:
 - `sftp_command` (string) - The command to run on the machine being provisioned
   by Packer to handle the SFTP protocol that Ansible will use to transfer
   files. The command should read and write on stdin and stdout, respectively.
+  SCP can be used instead of SFTP by setting `ANSIBLE_SCP_IF_SSH=True` in
+  `ansible_env_vars`.
   Defaults to `/usr/lib/sftp-server -e`.
 
 - `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
@@ -87,8 +89,9 @@ Optional Parameters:
 "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
 ```
 
-- `ansible_env_vars` (array of strings) - Environment variables to set before running Ansible.
-  If unset, defaults to `ANSIBLE_HOST_KEY_CHECKING=False`.
+- `ansible_env_vars` (array of strings) - Environment variables to set before
+  running Ansible.  If unset, defaults to `ANSIBLE_HOST_KEY_CHECKING=False`.
+  Set `ANSIBLE_SCP_IF_SSH=True` to use SCP instead of SFTP.
   Usage example:
 
 ```
@@ -99,8 +102,6 @@ Optional Parameters:
   packer.
 
 ## Limitations
-
-- The `ansible` provisioner does not support SCP to transfer files.
 
 - Redhat / CentOS builds have been known to fail with the following error due to `sftp_command`, which should be set to `/usr/libexec/openssh/sftp-server -e`:
 


### PR DESCRIPTION
Handle running `scp -t` and `scp -f` exec requests in the ansible-provisioner's SSH server to allow Ansible to use SCP so that SFTP doesn't have to be installed on the node.

Update the BATS tests to test running ansible in SCP mode.

This should make configuring and using the Ansible provisioner easier, because SFTP is no longer required to be installed on the node. Additionally, this makes using the Ansible provisioner with the docker builder or the winrm communicator easier; when `ANSIBLE_SCP_IF_SSH=True` is set, Ansible will communicate with the provisioner using SCP, and the provisioner uses the communicator to transfer files to and from the node.