### PR TITLE
Update AWS SDK

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -80,138 +80,138 @@
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awserr",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/defaults",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/request",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/session",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/endpoints",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/signer/v4",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/waiter",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ec2",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3/s3iface",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3/s3manager",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sts",
-			"Comment": "v1.1.2",
-			"Rev": "8041be5461786460d86b4358305fbdf32d37cfb2"
+			"Comment": "v1.4.8",
+			"Rev": "2c129c11a732646f1411de34ad4833f50503f344"
 		},
 		{
 			"ImportPath": "github.com/bgentry/speakeasy",


### PR DESCRIPTION
I want to run Packer in ECS and use IAM roles for tasks which [is only supported in the Go 1.2.5 and above client](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html#task-iam-roles-minimum-sdk)

This change enables the use of IAM Roles for Tasks by updating to the latest version of the AWS SDK.