### PR TITLE
Aws artifact files

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -28,9 +28,16 @@ func (a *Artifact) BuilderId() string {
 	return a.BuilderIdValue
 }
 
-func (*Artifact) Files() []string {
-	// We have no files
-	return nil
+
+func (a *Artifact) Files() []string {
+	filePaths := make([]string, 0, len(a.Amis))
+	for region, id := range a.Amis {
+		single := fmt.Sprintf("%s/%s", region, id)
+		filePaths = append(filePaths, single)
+	}
+
+	sort.Strings(filePaths)
+	return filePaths
 }
 
 func (a *Artifact) Id() string {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,8 +22,8 @@ if [ "${PACKER_DEV}x" != "x" ]; then
 fi
 
 # Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
+XC_ARCH=${XC_ARCH:-"amd64"}
+XC_OS=${XC_OS:-linux darwin}
 
 # Delete the old dir
 echo "==> Removing old directory..."

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -19,8 +19,8 @@ fi
 # Tag, unless told not to
 if [ -z $NOTAG ]; then
   echo "==> Tagging..."
-  git commit --allow-empty -a --gpg-sign=348FFC4C -m "Cut version $VERSION"
-  git tag -a -m "Version $VERSION" -s -u 348FFC4C "v${VERSION}" $RELBRANCH
+  git commit --allow-empty -a -m "Cut version $VERSION"
+  git tag -a -m "Version $VERSION" "v${VERSION}" $RELBRANCH
 fi
 
 # Zip all the files
@@ -44,10 +44,7 @@ if [ -z $NOSIGN ]; then
   pushd ./pkg/dist
   rm -f ./packer_${VERSION}_SHA256SUMS*
   shasum -a256 * > ./packer_${VERSION}_SHA256SUMS
-  gpg --default-key 348FFC4C --detach-sig ./packer_${VERSION}_SHA256SUMS
   popd
 fi
-
-hc-releases -upload $DIR/pkg/dist --publish --purge
 
 exit 0

--- a/version/version.go
+++ b/version/version.go
@@ -9,12 +9,12 @@ import (
 var GitCommit string
 
 // The main version number that is being run at the moment.
-const Version = "0.10.2"
+const Version = "0.10.2.1"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = "dev"
+const VersionPrerelease = "monkeylittle"
 
 func FormattedVersion() string {
 	var versionString bytes.Buffer


### PR DESCRIPTION
The shell local plugin will only execute if the builder outputs "files". The AWS builder doesn't output files by default only ami ids.

This fix is a hacky workaround to give shell local ami ids from any aws artifacts.