### PR TITLE
amazon - Snapshot permissions correctly applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ BUG FIXES:
     is specified [GH-3568]
   * builder/amazon: Use `temporary_key_pair_name` when specified. [GH-3739]
   * builder/amazon: Add 0.5 cents to discovered spot price. [GH-3662]
+  * builder/amazon: User and group permissions now applied to snapshot [GH-3344]
   * builder/azure: check for empty resource group [GH-3606]
   * builder/azure: fix token validity test [GH-3609]
   * builder/virtualbox: Respect `ssh_host` [GH-3617]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ BUG FIXES:
     is specified [GH-3568]
   * builder/amazon: Use `temporary_key_pair_name` when specified. [GH-3739]
   * builder/amazon: Add 0.5 cents to discovered spot price. [GH-3662]
-  * builder/amazon: User and group permissions now applied to snapshot [GH-3344]
   * builder/azure: check for empty resource group [GH-3606]
   * builder/azure: fix token validity test [GH-3609]
   * builder/virtualbox: Respect `ssh_host` [GH-3617]

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -21,6 +21,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 	amis := state.Get("amis").(map[string]string)
+	snapshots := state.Get("snapshots").(map[string][]string)
 
 	// Determine if there is any work to do.
 	valid := false
@@ -33,46 +34,71 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		return multistep.ActionContinue
 	}
 
-	// Construct the modify image attribute requests we're going to make.
-	// We need to make each separately since the EC2 API only allows changing
-	// one type at a kind currently.
+	// Construct the modify image and snapshot attribute requests we're going
+	// to make. We need to make each separately since the EC2 API only allows
+	// changing one type at a kind currently.
 	options := make(map[string]*ec2.ModifyImageAttributeInput)
 	if s.Description != "" {
 		options["description"] = &ec2.ModifyImageAttributeInput{
 			Description: &ec2.AttributeValue{Value: &s.Description},
 		}
 	}
+	snapshotOptions := make(map[string]*ec2.ModifySnapshotAttributeInput)
 
 	if len(s.Groups) > 0 {
 		groups := make([]*string, len(s.Groups))
-		adds := make([]*ec2.LaunchPermission, len(s.Groups))
+
+		addsImage := make([]*ec2.LaunchPermission, len(s.Groups))
 		addGroups := &ec2.ModifyImageAttributeInput{
 			LaunchPermission: &ec2.LaunchPermissionModifications{},
 		}
 
+		addsSnapshot := make([]*ec2.CreateVolumePermission, len(s.Groups))
+		addSnapshotGroups := &ec2.ModifySnapshotAttributeInput{
+			CreateVolumePermission: &ec2.CreateVolumePermissionModifications{},
+		}
+
 		for i, g := range s.Groups {
 			groups[i] = aws.String(g)
-			adds[i] = &ec2.LaunchPermission{
+			addsImage[i] = &ec2.LaunchPermission{
+				Group: aws.String(g),
+			}
+
+			addsSnapshot[i] = &ec2.CreateVolumePermission{
 				Group: aws.String(g),
 			}
 		}
-		addGroups.UserGroups = groups
-		addGroups.LaunchPermission.Add = adds
 
+		addGroups.UserGroups = groups
+		addGroups.LaunchPermission.Add = addsImage
 		options["groups"] = addGroups
+
+		addSnapshotGroups.GroupNames = groups
+		addSnapshotGroups.CreateVolumePermission.Add = addsSnapshot
+		snapshotOptions["groups"] = addSnapshotGroups
 	}
 
 	if len(s.Users) > 0 {
 		users := make([]*string, len(s.Users))
-		adds := make([]*ec2.LaunchPermission, len(s.Users))
+		addsImage := make([]*ec2.LaunchPermission, len(s.Users))
+		addsSnapshot := make([]*ec2.CreateVolumePermission, len(s.Users))
 		for i, u := range s.Users {
 			users[i] = aws.String(u)
-			adds[i] = &ec2.LaunchPermission{UserId: aws.String(u)}
+			addsImage[i] = &ec2.LaunchPermission{UserId: aws.String(u)}
+			addsSnapshot[i] = &ec2.CreateVolumePermission{UserId: aws.String(u)}
 		}
+
 		options["users"] = &ec2.ModifyImageAttributeInput{
 			UserIds: users,
 			LaunchPermission: &ec2.LaunchPermissionModifications{
-				Add: adds,
+				Add: addsImage,
+			},
+		}
+
+		snapshotOptions["users"] = &ec2.ModifySnapshotAttributeInput{
+			UserIds: users,
+			CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
+				Add: addsSnapshot,
 			},
 		}
 	}
@@ -87,6 +113,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		}
 	}
 
+	// Modifying image attributes
 	for region, ami := range amis {
 		ui.Say(fmt.Sprintf("Modifying attributes on AMI (%s)...", ami))
 		awsConfig := aws.Config{
@@ -104,6 +131,30 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
+			}
+		}
+	}
+
+	// Modifying snapshot attributes
+	for region, region_snapshots := range snapshots {
+		for _, snapshot := range region_snapshots {
+			ui.Say(fmt.Sprintf("Modifying attributes on snapshot (%s)...", snapshot))
+			awsConfig := aws.Config{
+				Credentials: ec2conn.Config.Credentials,
+				Region:      aws.String(region),
+			}
+			session := session.New(&awsConfig)
+			regionconn := ec2.New(session)
+			for name, input := range snapshotOptions {
+				ui.Message(fmt.Sprintf("Modifying: %s", name))
+				input.SnapshotId = &snapshot
+				_, err := regionconn.ModifySnapshotAttribute(input)
+				if err != nil {
+					err := fmt.Errorf("Error modify snapshot attributes: %s", err)
+					state.Put("error", err)
+					ui.Error(err.Error())
+					return multistep.ActionHalt
+				}
 			}
 		}
 	}

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -66,6 +66,14 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 	s.image = imagesResp.Images[0]
 
+	snapshots := make(map[string][]string)
+	for _, blockDeviceMapping := range imagesResp.Images[0].BlockDeviceMappings {
+		if blockDeviceMapping.Ebs != nil {
+			snapshots[*ec2conn.Config.Region] = append(snapshots[*ec2conn.Config.Region], *blockDeviceMapping.Ebs.SnapshotId)
+		}
+	}
+	state.Put("snapshots", snapshots)
+
 	return multistep.ActionContinue
 }
 

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -123,7 +123,9 @@ Packer to work:
         "ec2:DescribeImageAttribute",
         "ec2:CopyImage",
         "ec2:DescribeRegions",
-        "ec2:ModifyInstanceAttribute"
+        "ec2:ModifyInstanceAttribute",
+        "ec2:DescribeSecurityGroups",
+        "ec2:ModifySnapshotAttribute"
       ],
       "Resource" : "*"
   }]


### PR DESCRIPTION
This change to the amazon builder will apply user and group permissions on the AMI's snapshot.

In the current state, packer-created AMIs are not usable from other accounts without manual intervention, as the permission to launch the AMI from a different account is given only to the AMI and not to its snapshot.

Closes #3344
