### PR TITLE
Fix for #3875 - Azure documentation updates

### DIFF
--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -95,7 +95,7 @@ Your storage account (below) will need to use the same `GROUPNAME` and `LOCATION
 We will need to create a storage account where your Packer artifacts will be stored. We will create a `LRS` storage account which is the least expensive price/GB at the time of writing.
 
     azure storage account create -g GROUPNAME \
-        -l LOCATION --type LRS STORAGENAME
+        -l LOCATION --sku-name LRS --kind storage STORAGENAME
 
 -> `LRS` is meant as a literal "LRS" and not as a variable.
 

--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -68,7 +68,7 @@ Login using the Azure CLI
 
 Get your account information
 
-    azure account list --json | jq .[].name
+    azure account list --json | jq '.[].name'
     azure account set ACCOUNTNAME
     azure account show --json | jq ".[] | .id"
 


### PR DESCRIPTION
Fixed some issues with the Azure setup documentation:
- Added quotes to the JQ line when obtaining account info
- Updated the line to create the storage account

Closes #3875 
