### PR TITLE
continue add support for file-provisioner to allow directory downloa…

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -109,7 +109,7 @@ func (p *Provisioner) ProvisionDownload(ui packer.Ui, comm packer.Communicator) 
 			}
 		}
 		// if the config.Destination was a dir, download the dir
-		if !strings.HasSuffix(p.config.Destination, "/") {
+		if strings.HasSuffix(p.config.Destination, "/") {
 			return comm.DownloadDir(src, p.config.Destination, nil)
 		}
 

--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -192,5 +192,9 @@ func TestProvisionDownloadMkdirAll(t *testing.T) {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("stat of download dir should not error: %s", err)
 		}
+
+		if _, err := os.Stat(config["destination"].(string)); err != nil {
+			t.Fatalf("stat of destination file should not error: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
as described in the [file-provisioner ](https://www.packer.io/docs/provisioners/file.html) , we can use file-upload，directory-upload，file-download，but when i try to use **directory-download**， packer returns errors：


details :
- the log : [packer.err.log] (https://gist.github.com/pengkh/15eb85a8290865d4d4873a34e1f1387a)
- the build.json file fragment : [simplest example template and scripts](https://gist.github.com/pengkh/84b1a85dfea9ec690e1df1be2f30ae7a)


the relative issue / pr / commit :
#3251
#1909
e83ae18ba4b2c8e74661c24c4676ac8e1d5ec087

I find the commit e83ae18ba4b2c8e74661c24c4676ac8e1d5ec087 is unfinished work of scp protocol implementation，so I do the remaining job，with help of  [the scp protocol reference] (https://blogs.oracle.com/janp/entry/how_the_scp_protocol_works) .