### PR TITLE
builder/googlecompute: -force option

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -49,10 +49,11 @@ type Config struct {
 	UseInternalIP        bool              `mapstructure:"use_internal_ip"`
 	Zone                 string            `mapstructure:"zone"`
 
-	Account         AccountFile
-	privateKeyBytes []byte
-	stateTimeout    time.Duration
-	ctx             interpolate.Context
+	Account            AccountFile
+	privateKeyBytes    []byte
+	stateTimeout       time.Duration
+	imageAlreadyExists bool
+	ctx                interpolate.Context
 }
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {

--- a/builder/googlecompute/step_check_existing_image.go
+++ b/builder/googlecompute/step_check_existing_image.go
@@ -19,14 +19,15 @@ func (s *StepCheckExistingImage) Run(state multistep.StateBag) multistep.StepAct
 
 	if !c.PackerForce {
 		ui.Say("Checking image does not exist...")
-		c.imageAlreadyExists = d.ImageExists(c.ImageName)
-		if c.imageAlreadyExists {
-			err := fmt.Errorf("Image %s already exists.\n"+
-				"Use the force flag to delete it prior to building.", c.ImageName)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
+	}
+
+	c.imageAlreadyExists = d.ImageExists(c.ImageName)
+	if !c.PackerForce && c.imageAlreadyExists {
+		err := fmt.Errorf("Image %s already exists.\n"+
+			"Use the force flag to delete it prior to building.", c.ImageName)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
 	}
 	return multistep.ActionContinue
 }

--- a/builder/googlecompute/step_check_existing_image.go
+++ b/builder/googlecompute/step_check_existing_image.go
@@ -17,10 +17,7 @@ func (s *StepCheckExistingImage) Run(state multistep.StateBag) multistep.StepAct
 	d := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 
-	if !c.PackerForce {
-		ui.Say("Checking image does not exist...")
-	}
-
+	ui.Say("Checking image does not exist...")
 	c.imageAlreadyExists = d.ImageExists(c.ImageName)
 	if !c.PackerForce && c.imageAlreadyExists {
 		err := fmt.Errorf("Image %s already exists.\n"+

--- a/builder/googlecompute/step_check_existing_image.go
+++ b/builder/googlecompute/step_check_existing_image.go
@@ -17,15 +17,17 @@ func (s *StepCheckExistingImage) Run(state multistep.StateBag) multistep.StepAct
 	d := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("Checking image does not exist...")
-	exists := d.ImageExists(c.ImageName)
-	if exists {
-		err := fmt.Errorf("Image %s already exists", c.ImageName)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	if !c.PackerForce {
+		ui.Say("Checking image does not exist...")
+		c.imageAlreadyExists = d.ImageExists(c.ImageName)
+		if c.imageAlreadyExists {
+			err := fmt.Errorf("Image %s already exists.\n"+
+				"Use the force flag to delete it prior to building.", c.ImageName)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	}
-
 	return multistep.ActionContinue
 }
 

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -22,6 +22,19 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 
+	if config.PackerForce && config.imageAlreadyExists {
+		ui.Say("Deleting previous image...")
+
+		errCh := driver.DeleteImage(config.ImageName)
+		err := <-errCh
+		if err != nil {
+			err := fmt.Errorf("Error deleting image: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
 	ui.Say("Creating image...")
 
 	imageCh, errCh := driver.CreateImage(


### PR DESCRIPTION
Make the use of `-force` possible with Google Compute builder: the old image will be deleted before building the new one.

Relates to #2993 

