### PR TITLE
azure: fix error message

### DIFF
--- a/builder/azure/arm/resource_resolver.go
+++ b/builder/azure/arm/resource_resolver.go
@@ -76,7 +76,7 @@ func findVirtualNetworkResourceGroup(client *AzureClient, name string) (string, 
 	}
 
 	if len(resourceGroupNames) > 1 {
-		return "", fmt.Errorf("Found multiple resource groups with a virtual network called %q, please use virtual_network_resource_group_name to disambiguate", name)
+		return "", fmt.Errorf("Found multiple resource groups with a virtual network called %q, please use virtual_network_subnet_name and virtual_network_resource_group_name to disambiguate", name)
 	}
 
 	return resourceGroupNames[0], nil
@@ -93,7 +93,7 @@ func findVirtualNetworkSubnet(client *AzureClient, resourceGroupName string, nam
 	}
 
 	if len(*subnets.Value) > 1 {
-		return "", fmt.Errorf("Found multiple subnets in the resource group %q associated with the  virtual network called %q, please use virtual_network_subnet_name to disambiguate", resourceGroupName, name)
+		return "", fmt.Errorf("Found multiple subnets in the resource group %q associated with the  virtual network called %q, please use virtual_network_subnet_name and virtual_network_resource_group_name to disambiguate", resourceGroupName, name)
 	}
 
 	subnet := (*subnets.Value)[0]


### PR DESCRIPTION
There have been two issues raised where the user followed the error message, but they needed to add yet another config value to disambiguate the VNET.  It would be better if the message over corrected, and asked the user to specify everything to ensure complete disambiguation.

Closes #3934 