### PR TITLE
builder/amazon: add retry login when creating tags.

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/version"
 
@@ -458,7 +459,7 @@ type stateRefreshFunc func() (string, error)
 // waitForState will spin in a loop forever waiting for state to
 // reach a certain target.
 func waitForState(errCh chan<- error, target string, refresh stateRefreshFunc) error {
-	err := Retry(2, 2, 0, func() (bool, error) {
+	err := common.Retry(2, 2, 0, func() (bool, error) {
 		state, err := refresh()
 		if err != nil {
 			return false, err

--- a/builder/googlecompute/step_wait_instance_startup.go
+++ b/builder/googlecompute/step_wait_instance_startup.go
@@ -1,10 +1,11 @@
 package googlecompute
 
-import(
+import (
 	"errors"
 	"fmt"
 
 	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 )
 
@@ -17,11 +18,11 @@ func (s *StepWaitInstanceStartup) Run(state multistep.StateBag) multistep.StepAc
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	instanceName := state.Get("instance_name").(string)
-	
+
 	ui.Say("Waiting for any running startup script to finish...")
 
 	// Keep checking the serial port output to see if the startup script is done.
-	err := Retry(10, 60, 0, func() (bool, error) {
+	err := common.Retry(10, 60, 0, func() (bool, error) {
 		status, err := driver.GetInstanceMetadata(config.Zone,
 			instanceName, StartupScriptStatusKey)
 

--- a/common/retry.go
+++ b/common/retry.go
@@ -1,4 +1,4 @@
-package googlecompute
+package common
 
 import (
 	"fmt"
@@ -25,20 +25,20 @@ func Retry(initialInterval float64, maxInterval float64, numTries uint, function
 	done := false
 	interval := initialInterval
 	for i := uint(0); !done && (numTries == 0 || i < numTries); i++ {
-	done, err = function()
+		done, err = function()
 		if err != nil {
 			return err
 		}
-    
+
 		if !done {
 			// Retry after delay. Calculate next delay.
 			time.Sleep(time.Duration(interval) * time.Second)
-			interval = math.Min(interval * 2, maxInterval)
+			interval = math.Min(interval*2, maxInterval)
 		}
 	}
 
 	if !done {
-	  return RetryExhaustedError
+		return RetryExhaustedError
 	}
 	return nil
 }

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -1,4 +1,4 @@
-package googlecompute
+package common
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func TestRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Passing function should not have returned a retry error. Error: %s", err)
 	}
-  
+
 	// Test that a failing function gets retried (once in this example).
 	numTries = 0
 	results := []bool{false, true}
@@ -33,7 +33,7 @@ func TestRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Successful retried function should not have returned a retry error. Error: %s", err)
 	}
-	
+
 	// Test that a function error gets returned, and the function does not get called again.
 	numTries = 0
 	funcErr := fmt.Errorf("This function had an error!")
@@ -47,7 +47,7 @@ func TestRetry(t *testing.T) {
 	if err != funcErr {
 		t.Fatalf("Errant function did not return the right error %s. Error: %s", funcErr, err)
 	}
-	
+
 	// Test when a function exhausts its retries.
 	numTries = 0
 	expectedTries := uint(3)


### PR DESCRIPTION
Builds off of #3408, but reuses a retrier we've been using for builder/googlecompute.

If this gets merged it'll supersede the above PR