### PR TITLE
allow ssh communicator's Upload fastpath to execute

### DIFF
--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -44,6 +44,7 @@ type CommunicatorDownloadArgs struct {
 type CommunicatorUploadArgs struct {
 	Path           string
 	ReaderStreamId uint32
+	FileInfo       *fileInfo
 }
 
 type CommunicatorUploadDirArgs struct {
@@ -119,6 +120,10 @@ func (c *communicator) Upload(path string, r io.Reader, fi *os.FileInfo) (err er
 	args := CommunicatorUploadArgs{
 		Path:           path,
 		ReaderStreamId: streamId,
+	}
+
+	if fi != nil && *fi != nil {
+		args.FileInfo = NewFileInfo((*fi).Name(), (*fi).Size(), (*fi).Mode(), (*fi).ModTime())
 	}
 
 	err = c.client.Call("Communicator.Upload", &args, new(interface{}))
@@ -267,7 +272,12 @@ func (c *CommunicatorServer) Upload(args *CommunicatorUploadArgs, reply *interfa
 	}
 	defer readerC.Close()
 
-	err = c.c.Upload(args.Path, readerC, nil)
+	var fi *os.FileInfo
+	if args.FileInfo != nil {
+		fi = new(os.FileInfo)
+		*fi = *args.FileInfo
+	}
+	err = c.c.Upload(args.Path, readerC, fi)
 	return
 }
 

--- a/packer/rpc/fileinfo.go
+++ b/packer/rpc/fileinfo.go
@@ -1,0 +1,29 @@
+package rpc
+
+import (
+	"os"
+	"time"
+)
+
+func NewFileInfo(name string, size int64, mode os.FileMode, mtime time.Time) *fileInfo {
+	return &fileInfo{N: name, S: size, M: mode, T: mtime}
+}
+
+type fileInfo struct {
+	N string
+	S int64
+	M os.FileMode
+	T time.Time
+}
+
+func (fi fileInfo) Name() string      { return fi.N }
+func (fi fileInfo) Size() int64       { return fi.S }
+func (fi fileInfo) Mode() os.FileMode { return fi.M }
+func (fi fileInfo) ModTime() time.Time {
+	if fi.T.IsZero() {
+		return time.Now()
+	}
+	return fi.T
+}
+func (fi fileInfo) IsDir() bool      { return fi.M.IsDir() }
+func (fi fileInfo) Sys() interface{} { return nil }


### PR DESCRIPTION
Add os.FileInfo implementation to packer/rpc, and use it to pass Upload's *os.FileInfo argument through the RPC boundary.

Closes #3870