### PR TITLE
Allow naming of vm imported AMIs

### DIFF
--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -30,8 +30,9 @@ type Config struct {
 	S3Key     string            `mapstructure:"s3_key_name"`
 	SkipClean bool              `mapstructure:"skip_clean"`
 	Tags      map[string]string `mapstructure:"tags"`
+	Name      string            `mapstructure:"ami_name"`
 
-	ctx interpolate.Context
+	ctx       interpolate.Context
 }
 
 type PostProcessor struct {
@@ -205,6 +206,45 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// Pull AMI ID out of the completed job
 	createdami := *import_result.ImportImageTasks[0].ImageId
+
+	if p.config.Name != "" {
+
+		ui.Message(fmt.Sprintf("Starting rename of AMI (%s)", createdami))
+
+		resp, err := ec2conn.CopyImage(&ec2.CopyImageInput{
+			Name: &p.config.Name,
+			SourceImageId: &createdami,
+			SourceRegion: config.Region,
+		})
+
+		if err != nil {
+			return nil, false, fmt.Errorf("Error Copying AMI (%s): %s", createdami, err)
+		}
+
+		ui.Message(fmt.Sprintf("Waiting for AMI rename to complete (may take a while)"))
+
+		stateChange := awscommon.StateChangeConf{
+			Pending:   []string{"pending"},
+			Target:    "available",
+			Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *resp.ImageId),
+		}
+
+		if _, err := awscommon.WaitForState(&stateChange); err != nil {
+			return nil, false, fmt.Errorf("Error waiting for AMI (%s): %s", *resp.ImageId, err)
+		}
+
+		ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: &createdami,
+		})
+
+		if err != nil {
+			return nil, false, fmt.Errorf("Error deregistering existing AMI: %s", err)
+		}
+
+		ui.Message(fmt.Sprintf("AMI rename completed"))
+
+		createdami = *resp.ImageId
+	}
 
 	// If we have tags, then apply them now to both the AMI and snaps
 	// created by the import

--- a/website/source/docs/post-processors/amazon-import.html.md
+++ b/website/source/docs/post-processors/amazon-import.html.md
@@ -46,6 +46,8 @@ Optional:
 
 -   `skip_clean` (boolean) - Whether we should skip removing the OVA file uploaded to S3 after the import process has completed. "true" means that we should leave it in the S3 bucket, "false" means to clean it out. Defaults to "false".
 
+-   `ami_name` (string) - The name of the ami within the console. If not specified, this will default to something like `ami-import-sfwerwf`. Please note, specifying this option will result in a slightly longer execution time.
+
 -   `tags` (object of key/value strings) - Tags applied to the created AMI and
     relevant snapshots.
 


### PR DESCRIPTION
When using the VM Import/Export service your AMIs are given a random name. This looks fairly ugly in the console and doesn't allow you to easily identify them.

There is no parameter to the VM Import command that enables you to set a VM name. The only workaround I know of for this is to copy the AMI and set a name.

This PR introduces a `ami_name` configuration option to the `amazon-import` post processor. If the `ami_name` option is specified the post-processor will execute a CopyImage with the given name and deregister the initial image.

