### PR TITLE
builder/amazon: Allow using ssh_private_key_file and ssh_password

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -44,14 +44,14 @@ type RunConfig struct {
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
-	// If we are not given an explicit ssh_keypair_name,
-	// then create a temporary one, but only if the
-	// temporary_key_pair_name has not been provided.
-	if c.SSHKeyPairName == "" {
-		if c.TemporaryKeyPairName == "" {
-			c.TemporaryKeyPairName = fmt.Sprintf(
-				"packer_%s", uuid.TimeOrderedUUID())
-		}
+	// If we are not given an explicit ssh_keypair_name or
+	// ssh_private_key_file, then create a temporary one, but only if the
+	// temporary_key_pair_name has not been provided and we are not using
+	// ssh_password.
+	if c.SSHKeyPairName == "" && c.TemporaryKeyPairName == "" &&
+		c.Comm.SSHPrivateKey == "" && c.Comm.SSHPassword == "" {
+
+		c.TemporaryKeyPairName = fmt.Sprintf("packer_%s", uuid.TimeOrderedUUID())
 	}
 
 	if c.WindowsPasswordTimeout == 0 {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -148,7 +148,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHUsername),
+				b.config.RunConfig.Comm.SSHUsername,
+				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
 		&stepStopInstance{

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -230,7 +230,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHUsername),
+				b.config.RunConfig.Comm.SSHUsername,
+				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
 		&StepUploadX509Cert{},

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -185,7 +185,8 @@ builder.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. By default, this is blank, and Packer will
-    generate a temporary keypair.
+    generate a temporary keypair unless
+    [`ssh_password`](/docs/templates/communicator.html#ssh_password) is used.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
     must be specified with this.
 

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -60,9 +60,6 @@ builder.
 -   `source_ami` (string) - The initial AMI used as a base for the newly
     created machine.
 
--   `ssh_username` (string) - The username to use in order to communicate over
-    SSH to the running machine.
-
 ### Optional:
 
 -   `ami_block_device_mappings` (array of block device mappings) - Add the block

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -74,9 +74,6 @@ builder.
 -   `source_ami` (string) - The initial AMI used as a base for the newly
     created machine.
 
--   `ssh_username` (string) - The username to use in order to communicate over
-    SSH to the running machine.
-
 -   `x509_cert_path` (string) - The local path to a valid X509 certificate for
     your AWS account. This is used for bundling the AMI. This X509 certificate
     must be registered with your account from the security credentials page in

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -207,7 +207,8 @@ builder.
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. The key must match a key pair name loaded
     up into Amazon EC2.  By default, this is blank, and Packer will
-    generate a temporary keypair.
+    generate a temporary keypair unless
+    [`ssh_password`](/docs/templates/communicator.html#ssh_password) is used.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
     must be specified when `ssh_keypair_name` is utilized.
 


### PR DESCRIPTION
This adds support for using amazon-ebs/amazon-instance builder without
a keypair. If a `ssh_private_key_file` is supplied without a
`ssh_keypair_name` no temporary ssh keypair is created. If `ssh_password`
is used no temporary ssh keypair is created and the password is used when
trying to connect.

Closes #2301
Closes #3156