### PR TITLE
disable log also for PACKER_LOG=0

### DIFF
--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ const EnvLogFile = "PACKER_LOG_PATH" //Set to a file
 // logOutput determines where we should send logs (if anywhere).
 func logOutput() (logOutput io.Writer, err error) {
 	logOutput = nil
-	if os.Getenv(EnvLog) != "" {
+	if os.Getenv(EnvLog) != "" || os.Getenv(EnvLog) != "0" {
 		logOutput = os.Stderr
 
 		if logPath := os.Getenv(EnvLogFile); logPath != "" {

--- a/website/source/docs/other/debugging.html.md
+++ b/website/source/docs/other/debugging.html.md
@@ -45,7 +45,7 @@ or may not appear to work correctly. In these cases, it is sometimes helpful to
 see more details about what Packer is actually doing.
 
 Packer has detailed logs which can be enabled by setting the `PACKER_LOG`
-environmental variable to any value like this
+environmental variable to any value but `""` (empty string) and `"0"` like this
 `PACKER_LOG=1 packer build <config.json>`. This will cause detailed logs to
 appear on stderr. The logs contain log messages from Packer as well as any
 plugins that are being used. Log messages from plugins are prefixed by their

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -15,7 +15,7 @@ each can be found below:
     the configuration file is basic JSON. See the [core configuration
     page](/docs/other/core-configuration.html).
 
--   `PACKER_LOG` - Setting this to any value will enable the logger. See the
+-   `PACKER_LOG` - Setting this to any value beside "" (empty string) and "0" will enable the logger. See the
     [debugging page](/docs/other/debugging.html).
 
 -   `PACKER_LOG_PATH` - The location of the log file. Note: `PACKER_LOG` must be


### PR DESCRIPTION
I think it makes sense if logs are disabled also for PACKER_LOG variable equal to 0. Not only when "" (empty string) or unset.