### PR TITLE
Added vsphere-esx hosts to supported machine types in vagrant post pr…

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -23,6 +23,7 @@ var builtins = map[string]string{
 	"mitchellh.amazon.instance": "aws",
 	"mitchellh.virtualbox":      "virtualbox",
 	"mitchellh.vmware":          "vmware",
+	"mitchellh.vmware-esx":      "vmware",
 	"pearkes.digitalocean":      "digitalocean",
 	"packer.parallels":          "parallels",
 	"MSOpenTech.hyperv":         "hyperv",


### PR DESCRIPTION
It was not possible to build vagrant boxes from a VMWare ESX built VM as the mapping didn't exist in the vagrant post processor, only regular VMWare machines, causing this error:

`Post-processor failed: Unknown artifact type, can't build box: mitchellh.vmware-esx`

Following this modification, these machines can be vagrant packaged:

`rhel-7-workstation (vagrant): Creating Vagrant box for 'vmware' provider`