### PR TITLE
Fix debug logging

### DIFF
--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ const EnvLogFile = "PACKER_LOG_PATH" //Set to a file
 // logOutput determines where we should send logs (if anywhere).
 func logOutput() (logOutput io.Writer, err error) {
 	logOutput = nil
-	if os.Getenv(EnvLog) != "" || os.Getenv(EnvLog) != "0" {
+	if os.Getenv(EnvLog) != "" && os.Getenv(EnvLog) != "0" {
 		logOutput = os.Stderr
 
 		if logPath := os.Getenv(EnvLogFile); logPath != "" {


### PR DESCRIPTION
The change done in #3964 causes the if statement to check if debug logging should be enabled to always pass.