### PR TITLE
change chef-solo provisioner staging directory

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -29,12 +29,12 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: guestOSTypeConfig{
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-solo --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
 		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
-		stagingDir:     "/tmp/packer-chef-client",
+		stagingDir:     "/tmp/packer-chef-solo",
 	},
 	provisioner.WindowsOSType: guestOSTypeConfig{
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
 		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\"",
-		stagingDir:     "C:/Windows/Temp/packer-chef-client",
+		stagingDir:     "C:/Windows/Temp/packer-chef-solo",
 	},
 }
 


### PR DESCRIPTION
My first thought was to change the docs to reflect the code, and not the other way around, but in this case I think it's proper to change the code. Having `packer-chef-client` be the staging directory when running chef-solo is misleading, and since it's a temporary directory, it shouldn't matter what it's named

replaces #3486 