### PR TITLE
azure: Allow user to override size of OS disk

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -81,7 +81,8 @@ type Config struct {
 	VirtualNetworkResourceGroupName string `mapstructure:"virtual_network_resource_group_name"`
 
 	// OS
-	OSType string `mapstructure:"os_type"`
+	OSType       string `mapstructure:"os_type"`
+	OSDiskSizeGB int32  `mapstructure:"os_disk_size_gb"`
 
 	// Runtime Values
 	UserName               string

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -55,6 +55,10 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		builder.SetMarketPlaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion)
 	}
 
+	if config.OSDiskSizeGB > 0 {
+		builder.SetOSDiskSizeGB(config.OSDiskSizeGB)
+	}
+
 	if config.VirtualNetworkName != "" {
 		builder.SetVirtualNetwork(
 			config.VirtualNetworkResourceGroupName,

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -3,10 +3,10 @@ package template
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/go-autorest/autorest/to"
-	"strings"
 )
 
 const (
@@ -124,6 +124,18 @@ func (s *TemplateBuilder) SetImageUrl(imageUrl string, osType compute.OperatingS
 	profile.OsDisk.Image = &compute.VirtualHardDisk{
 		URI: to.StringPtr(imageUrl),
 	}
+
+	return nil
+}
+
+func (s *TemplateBuilder) SetOSDiskSizeGB(diskSizeGB int32) error {
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+
+	profile := resource.Properties.StorageProfile
+	profile.OsDisk.DiskSizeGB = to.Int32Ptr(diskSizeGB)
 
 	return nil
 }

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
@@ -87,6 +87,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
+            "diskSizeGB": 100,
             "image": {
               "uri": "http://azure/custom.vhd"
             },

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -73,6 +73,7 @@ func TestBuildLinux02(t *testing.T) {
 
 	testSubject.BuildLinux("--test-ssh-authorized-key--")
 	testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux)
+	testSubject.SetOSDiskSizeGB(100)
 
 	err = testSubject.SetVirtualNetwork("--virtual-network-resource-group--", "--virtual-network--", "--subnet-name--")
 	if err != nil {

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -86,6 +86,9 @@ builder.
     automatically configure authentication credentials for the provisioned machine. For
     `Linux` this configures an SSH authorized key. For `Windows` this
     configures a WinRM certificate.
+    
+-   `os_disk_size_gb` (int32) Specify the size of the OS disk in GB (gigabytes).  Values of zero or less than zero are 
+    ignored.
 
 -   `virtual_network_name` (string) Use a pre-existing virtual network for the VM.  This option enables private
     communication with the VM, no public IP address is **used** or **provisioned**.  This value should only be set if


### PR DESCRIPTION
The user can override the size of the OS disk by setting the configuration value os_disk_size_gb appropriately.

Closes #3965 