### PR TITLE
Fixed some issues with creating floppy disks with directories named "." or filenames with a "\" in them.

### DIFF
--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -214,7 +214,7 @@ func (s *StepCreateFloppy) Add(dircache directoryCache, src string) error {
 		d,err := dircache("")
 		if err != nil { return err }
 
-		entry,err := d.AddFile(path.Base(src))
+		entry,err := d.AddFile(path.Base(filepath.ToSlash(src)))
 		if err != nil { return err }
 
 		fatFile,err := entry.File()
@@ -235,9 +235,9 @@ func (s *StepCreateFloppy) Add(dircache directoryCache, src string) error {
 			_,err = dircache(filepath.ToSlash(base))
 			return err
 		}
-		directory,filename := filepath.Split(pathname)
+		directory,filename := filepath.Split(filepath.ToSlash(pathname))
 
-		base,err := removeBase(basedirectory, directory)
+		base,err := removeBase(basedirectory, filepath.FromSlash(directory))
 		if err != nil { return err }
 
 		inputF, err := os.Open(pathname)
@@ -308,7 +308,8 @@ func fsDirectoryCache(rootDirectory fs.Directory) directoryCache {
 	Input,Output,Error := make(chan string),make(chan fs.Directory),make(chan error)
 	go func(Error chan error) {
 		for {
-			input := path.Clean(<-Input)
+			input := <-Input
+			if len(input) > 0 { input = path.Clean(input) }
 
 			// found a directory, so yield it
 			res,ok := cache[input]


### PR DESCRIPTION
Fixed a bug due to some missing filepath.ToSlash calls in StepCreateFloppy.Add.
    If backslashes were in a filename (such as when running from Windows),
    this would cause the backslashes to be included in the filenames in the
    created floppy disk which caused havoc when Windows tried to parse it.

Fixed a bug in fsDirectoryCache when using path.Clean() to normalize the
    input directory properly. This would cause an error where a new directory
    "." would be created instead of it correctly returning the root directory.

Fixes issue #3977.