### PR TITLE
Supress plugin discovery from plugins, which is redundant and noisy in the logs

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -46,6 +47,12 @@ func decodeConfig(r io.Reader, c *config) error {
 // Hence, the priority order is the reverse of the search order - i.e., the
 // CWD has the highest priority.
 func (c *config) Discover() error {
+	// If we are already inside a plugin process we should not need to
+	// discover anything.
+	if os.Getenv(plugin.MagicCookieKey) != "" {
+		return nil
+	}
+
 	// First, look in the same directory as the executable.
 	exePath, err := osext.Executable()
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ func decodeConfig(r io.Reader, c *config) error {
 func (c *config) Discover() error {
 	// If we are already inside a plugin process we should not need to
 	// discover anything.
-	if os.Getenv(plugin.MagicCookieKey) != "" {
+	if os.Getenv(plugin.MagicCookieKey) == plugin.MagicCookieValue {
 		return nil
 	}
 


### PR DESCRIPTION
This one has been bothering me for a bit. Copying more or less the same fix I applied in Terraform.