### PR TITLE
fix panic when reconnecting over ssh

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -267,7 +267,7 @@ func (c *comm) reconnect() (err error) {
 		c.conn = nil
 
 		log.Printf("reconnection error: %s", err)
-		return
+		return err
 	}
 
 	log.Printf("handshaking with SSH")


### PR DESCRIPTION
resolves #3699 

Noticed that if we fail to reconnect, we set `comm.client` to nil, but silently return.