### PR TITLE
Only treat ssh exit errors as errors

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -115,13 +115,14 @@ func (c *comm) Start(cmd *packer.RemoteCmd) (err error) {
 			switch err.(type) {
 			case *ssh.ExitError:
 				exitStatus = err.(*ssh.ExitError).ExitStatus()
-				log.Printf("Remote command exited with '%d': %s", exitStatus, cmd.Command)
+				log.Printf("Remote command exited with '%d': %s",
+					exitStatus, cmd.Command)
 			case *ssh.ExitMissingError:
-				log.Printf("Remote command exited without exit status or exit signal.")
-				exitStatus = -1
+				log.Printf("Remote command exited without exit status or " +
+					"exit signal. If your ssh server restarted intentionally, " +
+					"you can safely ignore this. Continuing.")
 			default:
-				log.Printf("Error occurred waiting for ssh session: %s", err.Error())
-				exitStatus = -1
+				log.Printf("Error occurred waiting for ssh session: %s. Continuing.", err.Error())
 			}
 		}
 		cmd.SetExited(exitStatus)


### PR DESCRIPTION
Fixes #4006 

#3966 was written because there was a report that packer continued building even though there was an apparent error.

the apparent error happened to be sshd shutting down as the result of a package update.

I believe continuing on was the expected behavior, even if it wasn't obvious what was going on. Failing the build was too aggressive, but I believe more information for the user is the right approach.

There's been [some talk](https://github.com/mitchellh/packer/issues/4006#issuecomment-253862616) of adding an option to decide if a step should fail if ssh disconnects. Will create a ticket for that, since I want to get this fix out right away