### PR TITLE
Closes #3999 - Support VirtualBox Trim/Discard

### DIFF
--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -37,17 +37,19 @@ type Config struct {
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
 
-	BootCommand          []string `mapstructure:"boot_command"`
-	DiskSize             uint     `mapstructure:"disk_size"`
-	KeepRegistered       bool     `mapstructure:"keep_registered"`
-	GuestAdditionsMode   string   `mapstructure:"guest_additions_mode"`
-	GuestAdditionsPath   string   `mapstructure:"guest_additions_path"`
-	GuestAdditionsURL    string   `mapstructure:"guest_additions_url"`
-	GuestAdditionsSHA256 string   `mapstructure:"guest_additions_sha256"`
-	GuestOSType          string   `mapstructure:"guest_os_type"`
-	HardDriveInterface   string   `mapstructure:"hard_drive_interface"`
-	ISOInterface         string   `mapstructure:"iso_interface"`
-	VMName               string   `mapstructure:"vm_name"`
+	BootCommand            []string `mapstructure:"boot_command"`
+	DiskSize               uint     `mapstructure:"disk_size"`
+	KeepRegistered         bool     `mapstructure:"keep_registered"`
+	GuestAdditionsMode     string   `mapstructure:"guest_additions_mode"`
+	GuestAdditionsPath     string   `mapstructure:"guest_additions_path"`
+	GuestAdditionsURL      string   `mapstructure:"guest_additions_url"`
+	GuestAdditionsSHA256   string   `mapstructure:"guest_additions_sha256"`
+	GuestOSType            string   `mapstructure:"guest_os_type"`
+	HardDriveInterface     string   `mapstructure:"hard_drive_interface"`
+	HardDriveNonrotational bool     `mapstructure:"hard_drive_nonrotational"`
+	HardDriveDiscard       bool     `mapstructure:"hard_drive_discard"`
+	ISOInterface           string   `mapstructure:"iso_interface"`
+	VMName                 string   `mapstructure:"vm_name"`
 
 	ctx interpolate.Context
 }

--- a/builder/virtualbox/iso/step_create_disk.go
+++ b/builder/virtualbox/iso/step_create_disk.go
@@ -82,6 +82,16 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 		controllerName = "SCSI Controller"
 	}
 
+	nonrotational := "off"
+	if config.HardDriveNonrotational {
+		nonrotational = "on"
+	}
+
+	discard := "off"
+	if config.HardDriveDiscard {
+		discard = "on"
+	}
+
 	command = []string{
 		"storageattach", vmName,
 		"--storagectl", controllerName,
@@ -89,6 +99,8 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 		"--device", "0",
 		"--type", "hdd",
 		"--medium", path,
+		"--nonrotational", nonrotational,
+		"--discard", discard,
 	}
 	if err := driver.VBoxManage(command...); err != nil {
 		err := fmt.Errorf("Error attaching hard drive: %s", err)

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -153,7 +153,7 @@ builder.
 -   `floppy_dirs` (array of strings) - A list of directories to place onto
     the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when
-    your floppy disk includes drivers or if you just want to organize it's 
+    your floppy disk includes drivers or if you just want to organize its
     contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
 
 -   `format` (string) - Either "ovf" or "ova", this specifies the output format
@@ -195,6 +195,13 @@ builder.
     hard drive is attached to, defaults to "ide". When set to "sata", the drive
     is attached to an AHCI SATA controller. When set to "scsi", the drive is
     attached to an LsiLogic SCSI controller.
+
+-   `hard_drive_nonrotational` (boolean) - Forces some guests (i.e. Windows 7+)
+    to treat disks as SSDs and stops them from performing disk fragmentation.
+
+-   `hard_drive_discard` (boolean) - When this value is set to true, a VDI
+    image will be shrunk in response to the trim command from the guest OS.
+    The size of the cleared area must be at least 1MB.
 
 -   `headless` (boolean) - Packer defaults to building VirtualBox virtual
     machines by launching a GUI that shows the console of the machine
@@ -348,7 +355,7 @@ by the proper key:
 
 -   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
 
--   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key.
 
 -   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
 
@@ -362,9 +369,9 @@ by the proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, 
-otherwise they will be held down until the machine reboots. Use lowercase 
-characters as well inside modifiers. 
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them,
+otherwise they will be held down until the machine reboots. Use lowercase
+characters as well inside modifiers.
 
 For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 


### PR DESCRIPTION
Adds a couple options to enable/disable the `--nonrotational` and `--discard` flags during `VBoxManage storageattach` command execution

I don't really know how to test the impact of these changes, so I haven't written tests yet. Any advice would be helpful. 

Closes #3999 

Cheers

