### PR TITLE
Add `puppet_bin_dir` parameter / `PuppetBinDir` template variable

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -97,7 +97,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = "cd {{.WorkingDir}} && " +
 			"{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
-			"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet apply " +
+			"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet apply " +
 			"--verbose --modulepath='{{.ModulePath}}' " +
 			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -28,6 +28,31 @@ func TestProvisioner_Impl(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_puppetBinDir(t *testing.T) {
+	config := testConfig()
+
+	delete(config, "puppet_bin_dir")
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Test with a good one
+	tf, err := ioutil.TempFile("", "packer")
+	if err != nil {
+		t.Fatalf("error tempfile: %s", err)
+	}
+	defer os.Remove(tf.Name())
+
+	config["puppet_bin_dir"] = tf.Name()
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestProvisionerPrepare_hieraConfigPath(t *testing.T) {
 	config := testConfig()
 

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -227,7 +227,7 @@ func (p *Provisioner) uploadDirectory(ui packer.Ui, comm packer.Communicator, ds
 
 func (p *Provisioner) commandTemplate() string {
 	return "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
-		"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet agent " +
+		"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet agent " +
 		"--onetime --no-daemonize " +
 		"{{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}}" +
 		"{{if ne .Options \"\"}}{{.Options}} {{end}}" +

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -45,6 +45,10 @@ type Config struct {
 	// permissions in this directory.
 	StagingDir string `mapstructure:"staging_dir"`
 
+	// The directory that contains the puppet binary.
+	// E.g. if it can't be found on the standard path.
+	PuppetBinDir string `mapstructure:"puppet_bin_dir"`
+
 	// If true, packer will ignore all exit-codes from a puppet run
 	IgnoreExitCodes bool `mapstructure:"ignore_exit_codes"`
 }
@@ -60,6 +64,7 @@ type ExecuteTemplate struct {
 	PuppetNode           string
 	PuppetServer         string
 	Options              string
+	PuppetBinDir         string
 	Sudo                 bool
 }
 
@@ -160,6 +165,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		PuppetNode:           p.config.PuppetNode,
 		PuppetServer:         p.config.PuppetServer,
 		Options:              p.config.Options,
+		PuppetBinDir:         p.config.PuppetBinDir,
 		Sudo:                 !p.config.PreventSudo,
 	}
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
@@ -221,7 +227,8 @@ func (p *Provisioner) uploadDirectory(ui packer.Ui, comm packer.Communicator, ds
 
 func (p *Provisioner) commandTemplate() string {
 	return "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
-		"puppet agent --onetime --no-daemonize " +
+		"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet agent " +
+		"--onetime --no-daemonize " +
 		"{{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}}" +
 		"{{if ne .Options \"\"}}{{.Options}} {{end}}" +
 		"{{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}}" +

--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -86,6 +86,11 @@ Optional parameters:
 This option was deprecated in puppet 3.6, and removed in puppet 4.0. If you have
 multiple manifests you should use `manifest_file` instead.
 
+-   `puppet_bin_dir` (string) - The path to the binary for running `puppet apply`.
+    Usually, this would be found via the `$PATH` or `%PATH%` environment variable,
+    but some builders (notably, the Docker one) do not run profile-setup scripts,
+    therefore the Path is usually empty.
+
 -   `module_paths` (array of strings) - This is an array of paths to module
     directories on your local filesystem. These will be uploaded to the
     remote machine. By default, this is empty.
@@ -114,7 +119,8 @@ readability) to execute Puppet:
 
 ``` {.liquid}
 cd {{.WorkingDir}} && \
-{{.FacterVars}}{{if .Sudo}} sudo -E {{end}}puppet apply \
+{{.FacterVars}}{{if .Sudo}} sudo -E {{end}} \
+{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet apply \
   --verbose \
   --modulepath='{{.ModulePath}}' \
   {{if ne .HieraConfigPath ""}}--hiera_config='{{.HieraConfigPath}}' {{end}} \

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -75,6 +75,11 @@ listed below:
     to create directories and write into this folder. If the permissions are not
     correct, use a shell provisioner prior to this to configure it properly.
 
+-   `puppet_bin_dir` (string) - The path to the binary for running `puppet apply`.
+    Usually, this would be found via the `$PATH` or `%PATH%` environment variable,
+    but some builders (notably, the Docker one) do not run profile-setup scripts,
+    therefore the Path is usually empty.
+
 -   `execute_command` (string) - This is optional. The command used to execute Puppet. This has
     various [configuration template
     variables](/docs/templates/configuration-templates.html) available. See


### PR DESCRIPTION
For the puppet-masterless and puppet-server provisioners, there are situations where the the `$PATH` (or `%PATH%`) variable doesn't include a valid path to the `puppet` binary for running `puppet apply`. One example of this is when using a Docker builder.

In order to support this, add a `puppet_bin_dir` parameter, which maps to the `PuppetBinDir` template variable inside the default string/expansion for the `execute_command` parameter.