### PR TITLE
Closes #3908: Adds snapshot tag overrides

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -262,7 +262,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes: b.config.AMIProductCodes,
 		},
 		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
+			Tags:         b.config.AMITags,
+			SnapshotTags: b.config.SnapshotTags,
 		},
 	)
 

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -20,6 +20,7 @@ type AMIConfig struct {
 	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
+	SnapshotTags            map[string]string `mapstructure:"snapshot_tags"`
 }
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -182,7 +182,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes: b.config.AMIProductCodes,
 		},
 		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
+			Tags:         b.config.AMITags,
+			SnapshotTags: b.config.SnapshotTags,
 		},
 	}
 

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -263,7 +263,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes: b.config.AMIProductCodes,
 		},
 		&awscommon.StepCreateTags{
-			Tags: b.config.AMITags,
+			Tags:         b.config.AMITags,
+			SnapshotTags: b.config.SnapshotTags,
 		},
 	}
 

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -200,6 +200,9 @@ each category, the available configuration keys are alphabetized.
     -   `most_recent` (bool) - Selects the newest created image when true.
          This is most useful for selecting a daily distro build.
 
+-   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
+     They will override AMI tags if already applied to snapshot.
+
 -   `tags` (object of key/value strings) - Tags applied to the AMI.
 
 ## Basic Example

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -172,7 +172,7 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
--   `skip_region_validation` (boolean) - Set to true if you want to skip 
+-   `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option.  Defaults to false.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
@@ -202,6 +202,9 @@ builder.
 
     -   `most_recent` (bool) - Selects the newest created image when true.
          This is most useful for selecting a daily distro build.
+
+-   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
+     They will override AMI tags if already applied to snapshot.
 
 -   `spot_price` (string) - The maximum hourly price to pay for a spot instance
     to create the AMI. Spot instances are a type of instance that EC2 starts

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -188,7 +188,7 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
--   `skip_region_validation` (boolean) - Set to true if you want to skip 
+-   `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option.  Defaults to false.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
@@ -219,6 +219,9 @@ builder.
     -   `most_recent` (bool) - Selects the newest created image when true.
          This is most useful for selecting a daily distro build.
 
+-   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
+     They will override AMI tags if already applied to snapshot.
+
 -   `spot_price` (string) - The maximum hourly price to launch a spot instance
     to create the AMI. It is a type of instances that EC2 starts when the
     maximum price that you specify exceeds the current spot price. Spot price
@@ -247,7 +250,7 @@ builder.
     AMI, leave the `ssh_keypair_name` blank. To associate an existing key pair
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
-    
+
 -   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
     IP if available.
 


### PR DESCRIPTION
This commit adds the ability to configure unique tags on snapshots
that are separate from the tags defined on the AMI. Anything applied
to the AMI will also be applied to the snapshots, but `snapshot_tags`
will override and append tags to the tags already applied to the snapshots

I figured these changes would impact the [tags_acc_test.go](https://github.com/mitchellh/packer/blob/master/builder/amazon/ebs/tags_acc_test.go) file, but when I tried to force the tests to fail, I couldn't. Is there something special I need to do to make those tests run? If so, I'd like to add tests to account for this new code.

Closes #3908 
