### PR TITLE
Add support for us-east-2 (Ohio) AWS region

### DIFF
--- a/builder/amazon/common/regions.go
+++ b/builder/amazon/common/regions.go
@@ -12,6 +12,7 @@ func listEC2Regions() []string {
 		"eu-west-1",
 		"sa-east-1",
 		"us-east-1",
+		"us-east-2",
 		"us-gov-west-1",
 		"us-west-1",
 		"us-west-2",


### PR DESCRIPTION
AWS's us-east-2 (Ohio) Region was announced today. This commit adds it to the list of valid regions.

Announcement: https://aws.amazon.com/blogs/aws/now-open-aws-us-east-ohio-region/