### PR TITLE
Added KMS CMK support to EBS builder

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -58,8 +58,8 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 		c.AMIRegions = regions
 	}
 
-	if len(c.AMIUsers) > 0 && c.AMIEncryptBootVolume {
-		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume"))
+	if len(c.AMIUsers) > 0 && len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume {
+		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume unless key is specified with kms_key_id"))
 	}
 
 	if len(errs) > 0 {

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -21,6 +21,7 @@ type AMIConfig struct {
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
+	AMIKmsKeyId             string            `mapstructure:"kms_key_id"`
 	SnapshotTags            map[string]string `mapstructure:"snapshot_tags"`
 }
 

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -59,7 +59,7 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if len(c.AMIUsers) > 0 && len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume {
-		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume unless key is specified with kms_key_id"))
+		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume unless kms_key_id is provided"))
 	}
 
 	if len(errs) > 0 {

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -58,8 +58,8 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 		c.AMIRegions = regions
 	}
 
-	if len(c.AMIUsers) > 0 && len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume {
-		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume unless kms_key_id is provided"))
+	if len(c.AMIUsers) > 0 && c.AMIEncryptBootVolume {
+		errs = append(errs, fmt.Errorf("Cannot share AMI with encrypted boot volume"))
 	}
 
 	if len(errs) > 0 {

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -66,11 +66,11 @@ func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 
 	c.AMIKmsKeyId = ""
 	if err := c.Prepare(nil); err == nil {
-		t.Fatal("shouldn't be able to share ami with encrypted boot volume unless kms_key_id is provided")
+		t.Fatal("shouldn't be able to share ami with encrypted boot volume")
 	}
 
 	c.AMIKmsKeyId = "89c3fb9a-de87-4f2a-aedc-fddc5138193c"
-	if err := c.Prepare(nil); err != nil {
-		t.Fatal("should be able to share ami with encrypted boot volume if kms_key_id is provided")
+	if err := c.Prepare(nil); err == nil {
+		t.Fatal("shouldn't be able to share ami with encrypted boot volume")
 	}
 }

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -66,11 +66,11 @@ func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 
 	c.AMIKmsKeyId = ""
 	if err := c.Prepare(nil); err == nil {
-		t.Fatal("shouldn't be able to share ami with encrypted boot volume unless the kms_key_id param is provided")
+		t.Fatal("shouldn't be able to share ami with encrypted boot volume unless kms_key_id is provided")
 	}
 
 	c.AMIKmsKeyId = "89c3fb9a-de87-4f2a-aedc-fddc5138193c"
 	if err := c.Prepare(nil); err != nil {
-		t.Fatal("should be able to share ami with encrypted boot volume if the kms_key_id param is provided")
+		t.Fatal("should be able to share ami with encrypted boot volume if kms_key_id is provided")
 	}
 }

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -59,11 +59,18 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 
 }
 
-func TestAMIConfigPrepare_EncryptBoot(t *testing.T) {
+func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 	c := testAMIConfig()
 	c.AMIUsers = []string{"testAccountID"}
 	c.AMIEncryptBootVolume = true
+
+	c.AMIKmsKeyId = ""
 	if err := c.Prepare(nil); err == nil {
-		t.Fatal("should have error")
+		t.Fatal("shouldn't be able to share ami with encrypted boot volume unless the kms_key_id param is provided")
+	}
+
+	c.AMIKmsKeyId = "89c3fb9a-de87-4f2a-aedc-fddc5138193c"
+	if err := c.Prepare(nil); err != nil {
+		t.Fatal("should be able to share ami with encrypted boot volume if the kms_key_id param is provided")
 	}
 }

--- a/builder/amazon/ebs/step_encrypted_ami.go
+++ b/builder/amazon/ebs/step_encrypted_ami.go
@@ -2,6 +2,7 @@ package ebs
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -23,7 +24,7 @@ func (s *stepCreateEncryptedAMICopy) Run(state multistep.StateBag) multistep.Ste
 	// Encrypt boot not set, so skip step
 	if !config.AMIConfig.AMIEncryptBootVolume {
 		if kmsKeyId != "" {
-			ui.Say(fmt.Sprintf("Ignoring KMS Key ID: %s, encrypted=false", kmsKeyId))
+			log.Printf(fmt.Sprintf("Ignoring KMS Key ID: %s, encrypted=false", kmsKeyId))
 		}
 		return multistep.ActionContinue
 	}

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -77,6 +77,8 @@ builder.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
+    -   `kms_key_id` (string) - The ID of the KMS key to use for volume encryption
+
     -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -77,8 +77,6 @@ builder.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
-    -   `kms_key_id` (string) - The ID of the KMS key to use for volume encryption
-
     -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
@@ -163,6 +161,8 @@ builder.
 -   `encrypt_boot` (boolean) - Instruct packer to automatically create a copy of the
     AMI with an encrypted boot volume (discarding the initial unencrypted AMI in the
     process). Default `false`.
+
+-   `kms_key_id` (string) - The ID of the KMS key to use for boot volume encryption.
 
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)


### PR DESCRIPTION
Added the `kms_key_id` parameter. This supports supplying a customer master key (CMK) when encrypting the EBS volume.

The parameter is optional and only takes effect when `encrypted` is true. When `encrypted` is true but `kms_key_id` is missing the `aws/ebs` key will be used.
