### PR TITLE
Make <code> tags easier to read.

### DIFF
--- a/website/source/assets/stylesheets/_components.scss
+++ b/website/source/assets/stylesheets/_components.scss
@@ -180,6 +180,7 @@ header .header {
         border: 0;
         color: #b1d631;
         font-size: 14px;
+        font-weight: bolder;
       }
 
       a {


### PR DESCRIPTION
I started reading the docs for Packer yesterday, and one thing that annoyed me was that the `<code>` tags for commands were kind of hard to read. The large blocks of code for the JSON examples were OK, but I had to squint a little at the short ones embedded in the prose. There wasn't enough contrast between the dark background and the light, thin strokes of the letters.

So I propose making `<code>` tags bolder. This also changes the large example blocks, but the effect doesn't look bad to me, or affect their readability any.