### PR TITLE
Add tools_upload_flavor/path to vmware-vmx docs

### DIFF
--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -139,6 +139,17 @@ builder.
     slightly larger. If you find this to be the case, you can disable compaction
     using this configuration value.
 
+-   `tools_upload_flavor` (string) - The flavor of the VMware Tools ISO to
+    upload into the VM. Valid values are "darwin", "linux", and "windows". By
+    default, this is empty, which means VMware tools won't be uploaded.
+
+-   `tools_upload_path` (string) - The path in the VM to upload the
+    VMware tools. This only takes effect if `tools_upload_flavor` is non-empty.
+    This is a [configuration
+    template](/docs/templates/configuration-templates.html) that has a single
+    valid variable: `Flavor`, which will be the value of `tools_upload_flavor`.
+    By default the upload path is set to `{{.Flavor}}.iso`.
+
 -   `vm_name` (string) - This is the name of the VMX file for the new virtual
     machine, without the file extension. By default this is "packer-BUILDNAME",
     where "BUILDNAME" is the name of the build.


### PR DESCRIPTION
This is a trivial copy and paste from the vmware-iso docs, since tools_upload_flavor and tools_upload_path seem to just be undocumented but otherwise work as expected.

I've tested that tools_upload_flavor works as expected, but I assume tools_upload_path works as well, since both are only referenced at https://github.com/mitchellh/packer/blob/master/builder/vmware/common/tools_config.go