### PR TITLE
VIP: VMware shutdown fails

### DIFF
--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -57,18 +57,6 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
-		// Wait for the command to run
-		cmd.Wait()
-
-		// If the command failed to run, notify the user in some way.
-		// Ignores disconnect errors.
-		if cmd.ExitStatus != packer.CmdDisconnect && cmd.ExitStatus != 0 {
-			state.Put("error", fmt.Errorf(
-				"Shutdown command has non-zero exit status.\n\nStdout: %s\n\nStderr: %s",
-				stdout.String(), stderr.String()))
-			return multistep.ActionHalt
-		}
-
 		log.Printf("Shutdown stdout: %s", stdout.String())
 		log.Printf("Shutdown stderr: %s", stderr.String())
 

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -57,6 +57,11 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
+		// Wait for the command to run so we can print std{err,out}
+		// We don't care if the command errored, since we'll notice
+		// if the vm didn't shut down.
+		cmd.Wait()
+
 		log.Printf("Shutdown stdout: %s", stdout.String())
 		log.Printf("Shutdown stderr: %s", stderr.String())
 

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -61,7 +61,8 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 		cmd.Wait()
 
 		// If the command failed to run, notify the user in some way.
-		if cmd.ExitStatus != 0 {
+		// Ignores disconnect errors.
+		if cmd.ExitStatus != packer.CmdDisconnect && cmd.ExitStatus != 0 {
 			state.Put("error", fmt.Errorf(
 				"Shutdown command has non-zero exit status.\n\nStdout: %s\n\nStderr: %s",
 				stdout.String(), stderr.String()))


### PR DESCRIPTION
WIP. should resolve issue reported in #4034

I looked at how all the other shutdown steps did this:
- https://github.com/mitchellh/packer/blob/master/builder/digitalocean/step_shutdown.go
- https://github.com/mitchellh/packer/blob/master/builder/parallels/common/step_shutdown.go
- https://github.com/mitchellh/packer/blob/master/builder/qemu/step_shutdown.go
- https://github.com/mitchellh/packer/blob/master/builder/virtualbox/common/step_shutdown.go
- https://github.com/mitchellh/packer/blob/master/builder/vmware/common/step_shutdown.go

and saw none of them actually wait for the remote command to end gracefully.

vmware's step shut down should exit quietly if the vm shut down successfully. If it didn't it'll still timeout.
