### PR TITLE
googlecompute builder: support custom scopes

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	Preemptible          bool              `mapstructure:"preemptible"`
 	RawStateTimeout      string            `mapstructure:"state_timeout"`
 	Region               string            `mapstructure:"region"`
+	Scopes               []string          `mapstructure:"scopes"`
 	SourceImage          string            `mapstructure:"source_image"`
 	SourceImageProjectId string            `mapstructure:"source_image_project_id"`
 	StartupScriptFile    string            `mapstructure:"startup_script_file"`
@@ -141,6 +142,14 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.ProjectId == "" {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("a project_id must be specified"))
+	}
+
+	if c.Scopes == nil {
+		c.Scopes = []string{
+			"https://www.googleapis.com/auth/userinfo.email",
+			"https://www.googleapis.com/auth/compute",
+			"https://www.googleapis.com/auth/devstorage.full_control",
+		}
 	}
 
 	if c.SourceImage == "" {

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -128,6 +128,21 @@ func TestConfigPrepare(t *testing.T) {
 			"foo bar",
 			true,
 		},
+		{
+			"scopes",
+			[]string{},
+			false,
+		},
+		{
+			"scopes",
+			[]string{"https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/sqlservice.admin"},
+			false,
+		},
+		{
+			"scopes",
+			[]string{"https://www.googleapis.com/auth/cloud-platform"},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -67,6 +67,7 @@ type InstanceConfig struct {
 	OmitExternalIP      bool
 	Preemptible         bool
 	Region              string
+	Scopes              []string
 	ServiceAccountEmail string
 	Subnetwork          string
 	Tags                []string

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -377,12 +377,8 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			&compute.ServiceAccount{
-				Email: c.ServiceAccountEmail,
-				Scopes: []string{
-					"https://www.googleapis.com/auth/userinfo.email",
-					"https://www.googleapis.com/auth/compute",
-					"https://www.googleapis.com/auth/devstorage.full_control",
-				},
+				Email:  c.ServiceAccountEmail,
+				Scopes: c.Scopes,
 			},
 		},
 		Tags: &compute.Tags{

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -100,6 +100,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Preemptible:         c.Preemptible,
 		Region:              c.Region,
 		ServiceAccountEmail: c.Account.ClientEmail,
+		Scopes:              c.Scopes,
 		Subnetwork:          c.Subnetwork,
 		Tags:                c.Tags,
 		Zone:                c.Zone,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -172,10 +172,15 @@ builder.
     to the region hosting the specified `zone`.
 
 -   `scopes` (array of strings) - The service account scopes for launched instance.
-    Defaults to
-    `["https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/devstorage.full_control"]`.
+    Defaults to:
 
--   `source_image_project_id` (string) - The project ID of the 
+``` {.json}
+[ "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/compute",
+  "https://www.googleapis.com/auth/devstorage.full_control" ]
+```
+
+-   `source_image_project_id` (string) - The project ID of the
     project containing the source image.
 
 -   `startup_script_file` (string) - The filepath to a startup script to run on 
@@ -194,10 +199,10 @@ builder.
 
 -   `use_internal_ip` (boolean) - If true, use the instance's internal IP
     instead of its external IP during building.
-    
+
 ## Startup Scripts
 
-Startup scripts can be a powerful tool for configuring the instance from which the image is made. 
+Startup scripts can be a powerful tool for configuring the instance from which the image is made.
 The builder will wait for a startup script to terminate. A startup script can be provided via the
 `startup_script_file` or 'startup-script' instance creation `metadata` field. Therefore, the build
 time will vary depending on the duration of the startup script. If `startup_script_file` is set,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -171,6 +171,10 @@ builder.
 -   `region` (string) - The region in which to launch the instance. Defaults to
     to the region hosting the specified `zone`.
 
+-   `scopes` (array of strings) - The service account scopes for launched instance.
+    Defaults to
+    `["https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/devstorage.full_control"]`.
+
 -   `source_image_project_id` (string) - The project ID of the 
     project containing the source image.
 


### PR DESCRIPTION
Launch instance with custom scopes like this:

```json
  "builders": [
    {
      "type": "googlecompute",
      "project_id": "your-project-id",
      "source_image": "debian-8-jessie-v20161020",
      "zone": "asia-east1-a",
      "image_name": "example-image-v{{isotime \"20060102-150405\"}}",
      "machine_type": "n1-standard-1",
      "ssh_username": "packer",
      "scopes": [
        "https://www.googleapis.com/auth/userinfo.email",
        "https://www.googleapis.com/auth/compute",
        "https://www.googleapis.com/auth/devstorage.full_control",
        "https://www.googleapis.com/auth/logging.write",
        "https://www.googleapis.com/auth/monitoring.write",
        "https://www.googleapis.com/auth/sqlservice.admin"
      ]
    }
  ],
```

Closes #3230