### PR TITLE
Adds ability to download remote files with file provisioner

### DIFF
--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -40,29 +40,32 @@ func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 
 func TestProvisionerPrepare_InvalidSource(t *testing.T) {
 	var p Provisioner
+
 	config := testConfig()
 	config["source"] = "/this/should/not/exist"
-
 	errs := p.Prepare(config)
 	if errs == nil {
 		t.Fatalf("should require existing file or directory")
 	}
-	config["source"] = nil
+}
+
+func TestProvisionerPrepare_ValidURL(t *testing.T) {
+	var p Provisioner
+
+	// Set up caching directory
+	packerCache := "packer_cache"
+	os.Mkdir(packerCache, 0760)
+	defer os.RemoveAll(packerCache)
 
 	// Set up test server
 	ts := httptest.NewServer(http.FileServer(http.Dir("./../../common/test-fixtures/root")))
 	defer ts.Close()
 
+	config := testConfig()
 	config["sources"] = []string{ts.URL + "/basic.txt"}
-	errs = p.Prepare(config)
+	errs := p.Prepare(config)
 	if errs != nil {
-		t.Fatalf("file should have been downloaded and existed locally")
-	}
-
-	config["sources"] = []string{ts.URL + "/should_not_exist.txt"}
-	errs = p.Prepare(config)
-	if errs == nil {
-		t.Fatalf("should require url with downloadable file")
+		t.Fatalf("file should have been downloaded and exist locally: %s", errs)
 	}
 }
 

--- a/website/source/docs/provisioners/file.html.md
+++ b/website/source/docs/provisioners/file.html.md
@@ -38,6 +38,9 @@ The available configuration options are listed below. All elements are required.
     directory, the existence of a trailing slash is important. Read below on
     uploading directories.
 
+-   `sources` (array of strings) - A list of paths or directories to upload to
+    the machine. This is similar to the `source` option.
+
 -   `destination` (string) - The path where the file will be uploaded to in
     the machine. This value must be a writable location and any parent
     directories must already exist.

--- a/website/source/docs/provisioners/file.html.md
+++ b/website/source/docs/provisioners/file.html.md
@@ -30,16 +30,15 @@ The file provisioner can upload both single files and complete directories.
 
 ## Configuration Reference
 
-The available configuration options are listed below. All elements are required.
+The available configuration options are listed below.
+
+### Required
 
 -   `source` (string) - The path to a local file or directory to upload to
     the machine. The path can be absolute or relative. If it is relative, it is
     relative to the working directory when Packer is executed. If this is a
     directory, the existence of a trailing slash is important. Read below on
     uploading directories.
-
--   `sources` (array of strings) - A list of paths or directories to upload to
-    the machine. This is similar to the `source` option.
 
 -   `destination` (string) - The path where the file will be uploaded to in
     the machine. This value must be a writable location and any parent
@@ -48,6 +47,16 @@ The available configuration options are listed below. All elements are required.
 -   `direction` (string) - The direction of the file transfer. This defaults to
     "upload." If it is set to "download" then the file "source" in the machine
     will be downloaded locally to "destination"
+
+### Optional
+
+-   `checksum` (string) - The checksum for the file. The checksum is only used
+    when a remote url is defined for the `source`. The type of the checksum is
+    specified with `checksum_type`, documented below.
+
+-   `checksum_type` (string) - The type of the checksum specified in `checksum`.
+    Valid values are "", "md5", "sha1", "sha256", or "sha512" currently.
+    Setting `checksum_type` to "" or not setting at all will skip checksumming.
 
 ## Directory Uploads
 


### PR DESCRIPTION
I'm struggling with this one. The point was to add the functionality that enables users to add urls to their sources list when using the "direction" => "upload" functionality, except I can't seem to get the downloads to work correctly yet. The file is created, but nothing is written to it. 

Once the bug is worked out, this PR would close #351 

I've commented what I think the problem areas are. Am I doing something obviously wrong? I'm brand new to golang, so I'm hoping this is the case. Cheers!
