### PR TITLE
builder/amazon: Allow use of local SSH Agent

### DIFF
--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -3,12 +3,15 @@ package common
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/multistep"
 	packerssh "github.com/mitchellh/packer/communicator/ssh"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 type ec2Describer interface {
@@ -67,8 +70,26 @@ func SSHHost(e ec2Describer, private bool) func(multistep.StateBag) (string, err
 // SSHConfig returns a function that can be used for the SSH communicator
 // config for connecting to the instance created over SSH using the private key
 // or password.
-func SSHConfig(username, password string) func(multistep.StateBag) (*ssh.ClientConfig, error) {
+func SSHConfig(useAgent bool, username, password string) func(multistep.StateBag) (*ssh.ClientConfig, error) {
 	return func(state multistep.StateBag) (*ssh.ClientConfig, error) {
+		if useAgent {
+			authSock := os.Getenv("SSH_AUTH_SOCK")
+			if authSock == "" {
+				return nil, fmt.Errorf("SSH_AUTH_SOCK is not set")
+			}
+
+			sshAgent, err := net.Dial("unix", authSock)
+			if err != nil {
+				return nil, fmt.Errorf("Cannot connect to SSH Agent socket %q: %s", authSock, err)
+			}
+
+			return &ssh.ClientConfig{
+				User: username,
+				Auth: []ssh.AuthMethod{
+					ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers),
+				},
+			}, nil
+		}
 
 		privateKey, hasKey := state.GetOk("privateKey")
 		if hasKey {

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -25,13 +25,8 @@ type StepKeyPair struct {
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
-	if s.SSHAgentAuth {
-		ui.Say("Using SSH Agent")
-		return multistep.ActionContinue
-	}
-
 	if s.PrivateKeyFile != "" {
-		ui.Say("Using existing ssh private key")
+		ui.Say("Using existing SSH private key")
 		privateKeyBytes, err := ioutil.ReadFile(s.PrivateKeyFile)
 		if err != nil {
 			state.Put("error", fmt.Errorf(
@@ -42,6 +37,17 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 		state.Put("keyPair", s.KeyPairName)
 		state.Put("privateKey", string(privateKeyBytes))
 
+		return multistep.ActionContinue
+	}
+
+	if s.SSHAgentAuth && s.KeyPairName == "" {
+		ui.Say("Using SSH Agent with key pair in Source AMI")
+		return multistep.ActionContinue
+	}
+
+	if s.SSHAgentAuth && s.KeyPairName != "" {
+		ui.Say(fmt.Sprintf("Using SSH Agent for existing key pair %s", s.KeyPairName))
+		state.Put("keyPair", s.KeyPairName)
 		return multistep.ActionContinue
 	}
 

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -13,6 +13,7 @@ import (
 
 type StepKeyPair struct {
 	Debug                bool
+	SSHAgentAuth         bool
 	DebugKeyPath         string
 	TemporaryKeyPairName string
 	KeyPairName          string
@@ -23,6 +24,11 @@ type StepKeyPair struct {
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
+
+	if s.SSHAgentAuth {
+		ui.Say("Using SSH Agent")
+		return multistep.ActionContinue
+	}
 
 	if s.PrivateKeyFile != "" {
 		ui.Say("Using existing ssh private key")

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -148,6 +148,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
+				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,
 				b.config.RunConfig.Comm.SSHPassword),
 		},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -230,6 +230,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
+				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,
 				b.config.RunConfig.Comm.SSHPassword),
 		},

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	SSHPrivateKey         string        `mapstructure:"ssh_private_key_file"`
 	SSHPty                bool          `mapstructure:"ssh_pty"`
 	SSHTimeout            time.Duration `mapstructure:"ssh_timeout"`
+	SSHAgentAuth          bool          `mapstructure:"ssh_agent_auth"`
 	SSHDisableAgent       bool          `mapstructure:"ssh_disable_agent"`
 	SSHHandshakeAttempts  int           `mapstructure:"ssh_handshake_attempts"`
 	SSHBastionHost        string        `mapstructure:"ssh_bastion_host"`

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -194,6 +194,12 @@ builder.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
     must be specified with this.
 
+-   `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
+    authenticate connections to the source instance. No temporary keypair will
+    be created, and the values of `ssh_password` and `ssh_private_key_file` will
+    be ignored. This is suitable for use if the source AMI already has authorized
+    keys configured.
+
 -   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
     IP if available.
 

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -188,17 +188,20 @@ builder.
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
-    used for SSH with the machine. By default, this is blank, and Packer will
+    used for SSH with the machine. The key must match a key pair name loaded
+    up into Amazon EC2.  By default, this is blank, and Packer will
     generate a temporary keypair unless
     [`ssh_password`](/docs/templates/communicator.html#ssh_password) is used.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
-    must be specified with this.
+    or `ssh_agent_auth` must be specified when `ssh_keypair_name` is utilized.
 
 -   `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
     authenticate connections to the source instance. No temporary keypair will
     be created, and the values of `ssh_password` and `ssh_private_key_file` will
-    be ignored. This is suitable for use if the source AMI already has authorized
-    keys configured.
+    be ignored. To use this option with a key pair already configured in the source
+    AMI, leave the `ssh_keypair_name` blank. To associate an existing key pair
+    in AWS with the source instance, set the `ssh_keypair_name` field to the name
+    of the key pair.
 
 -   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
     IP if available.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -210,13 +210,15 @@ builder.
     generate a temporary keypair unless
     [`ssh_password`](/docs/templates/communicator.html#ssh_password) is used.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
-    must be specified when `ssh_keypair_name` is utilized.
+    or `ssh_agent_auth` must be specified when `ssh_keypair_name` is utilized.
 
 -   `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
     authenticate connections to the source instance. No temporary keypair will
     be created, and the values of `ssh_password` and `ssh_private_key_file` will
-    be ignored. This is suitable for use if the source AMI already has authorized
-    keys configured.
+    be ignored. To use this option with a key pair already configured in the source
+    AMI, leave the `ssh_keypair_name` blank. To associate an existing key pair
+    in AWS with the source instance, set the `ssh_keypair_name` field to the name
+    of the key pair.
     
 -   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
     IP if available.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -212,6 +212,12 @@ builder.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
     must be specified when `ssh_keypair_name` is utilized.
 
+-   `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
+    authenticate connections to the source instance. No temporary keypair will
+    be created, and the values of `ssh_password` and `ssh_private_key_file` will
+    be ignored. This is suitable for use if the source AMI already has authorized
+    keys configured.
+    
 -   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
     IP if available.
 


### PR DESCRIPTION
This commit adds an option to use the local SSH Agent to authenticate connections to source instances started by the the EBS and Instance Store builders.

This is of use when the source AMI _already_ has configuration for authorized SSH keys - for example if one uses an SSH certificate authority.

It can also be used with an existing key pair configured in AWS by specifying `ssh_keypair_name` along with `ssh_agent_auth`.
