### PR TITLE
Packer v0.11.0 requires "ec2:DescribeSecurityGroups" permissions to work

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -101,6 +101,7 @@ Packer to work:
         "ec2:DescribeSubnets",
         "ec2:CreateSecurityGroup",
         "ec2:DeleteSecurityGroup",
+        "ec2:DescribeSecurityGroups",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CreateImage",
         "ec2:CopyImage",


### PR DESCRIPTION
Without the "ec2:DescribeSecurityGroups" permission, you would get the following error:

```
2016/10/25 16:03:28 ui: ==> aws: Creating temporary security group for this instance...
2016/10/25 16:03:28 packer.exe: 2016/10/25 16:03:28 Temporary group name: packer 580f7440-2135-068c-99b7-35595a7522d1
2016/10/25 16:03:28 ui: ==> aws: Authorizing access to port 22 the temporary security group...
2016/10/25 16:03:28 packer.exe: 2016/10/25 16:03:28 [DEBUG] Describing tempSecurityGroup to ensure it is available: sg-38e0355e
2016/10/25 16:03:29 packer.exe: 2016/10/25 16:03:29 [DEBUG] Error in querying security group UnauthorizedOperation: You are not authorized to perform this operation.
2016/10/25 16:03:29 packer.exe: 	status code: 403, request id: bc664eff-cc01-42c1-8408-23493c11d92d
```