### PR TITLE
Add missing link for new manifest post-processor to sidebar

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -82,6 +82,7 @@
       <li><a href="/docs/post-processors/docker-save.html">Docker Save</a></li>
       <li><a href="/docs/post-processors/docker-tag.html">Docker Tag</a></li>
       <li><a href="/docs/post-processors/shell-local.html">Local Shell</a></li>
+      <li><a href="/docs/post-processors/manifest.html">Manifest</a></li>
       <li><a href="/docs/post-processors/vagrant.html">Vagrant</a></li>
       <li><a href="/docs/post-processors/vagrant-cloud.html">Vagrant Cloud</a></li>
       <li><a href="/docs/post-processors/vsphere.html">vSphere</a></li>


### PR DESCRIPTION
Add a link to the new manifest post-processor that was mentioned in the changelog for Packer 0.11.0.