### PR TITLE
fixes identifier for launch_device_mappings

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -345,4 +345,4 @@ termination of the instance building the new image. Packer will attempt to clean
 up all residual volumes that are not designated by the user to remain after
 termination. If you need to preserve those source volumes, you can overwrite the
 termination setting by specifying `delete_on_termination=false` in the
-`launch_device_mappings` block for the device.
+`launch_block_device_mappings` block for the device.


### PR DESCRIPTION
Hi!

I believe the **Note** to reference an incorrect variable: `launch_device_mappings `; this should be `launch_block_device_mappings` as far as I can tell from the [code](https://github.com/mitchellh/packer/search?utf8=%E2%9C%93&q=launch_block_device_mappings).