### PR TITLE
Match title capitalization of compress to other post-processors

### DIFF
--- a/website/source/docs/post-processors/compress.html.md
+++ b/website/source/docs/post-processors/compress.html.md
@@ -3,7 +3,7 @@ description: |
     The Packer compress post-processor takes an artifact with files (such as from
     VMware or VirtualBox) and compresses the artifact into a single archive.
 layout: docs
-page_title: 'compress Post-Processor'
+page_title: 'Compress Post-Processor'
 ...
 
 # Compress Post-Processor


### PR DESCRIPTION
Doc only change.  Just a minor consistency change to the capitalization of the title of the compress post-processor web page.

Please add the Docs and Enhancement labels.