### PR TITLE
Properly cleanup AWS temporary key pairs

### DIFF
--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -95,7 +95,7 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 	// If no key name is set, then we never created it, so just return
 	// If we used an SSH private key file, do not go about deleting
 	// keypairs
-	if s.PrivateKeyFile != "" || s.KeyPairName == "" {
+	if s.PrivateKeyFile != "" || s.KeyPairName != "" {
 		return
 	}
 


### PR DESCRIPTION
Closes #4057 - Amazon key pair no longer cleaned up at end of build