### PR TITLE
Fixes #4081: Fix broken README link for 'compile Packer yourself'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ will get you up and running quickly, at the sacrifice of not explaining some
 key points.
 
 First, [download a pre-built Packer binary](http://www.packer.io/downloads.html)
-for your operating system or [compile Packer yourself](#developing-packer).
+for your operating system or [compile Packer yourself](CONTRIBUTING.md#setting-up-go-to-work-on-packer).
 
 After Packer is installed, create your first template, which tells Packer
 what platforms to build images for and how you want to build them. In our


### PR DESCRIPTION
Basically, the link is outdated as of https://github.com/mitchellh/packer/commit/f5777bca7bd278ede327e07cb1c4828a5cd4f96f#diff-04c6e90faac2675aa89e2176d2eec7d8

Closes #4081