### PR TITLE
command/push: Fix variable pushes to Atlas

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/atlas-go/archive"
 	"github.com/hashicorp/atlas-go/v1"
-	"github.com/mitchellh/packer/helper/flag-kv"
 	"github.com/mitchellh/packer/template"
 )
 
@@ -43,14 +42,14 @@ func (c *PushCommand) Run(args []string) int {
 	var name string
 	var create bool
 
-	f := c.Meta.FlagSet("push", FlagSetVars)
-	f.Usage = func() { c.Ui.Error(c.Help()) }
-	f.StringVar(&token, "token", "", "token")
-	f.StringVar(&message, "m", "", "message")
-	f.StringVar(&message, "message", "", "message")
-	f.StringVar(&name, "name", "", "name")
-	f.BoolVar(&create, "create", false, "create (deprecated)")
-	if err := f.Parse(args); err != nil {
+	flags := c.Meta.FlagSet("push", FlagSetVars)
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	flags.StringVar(&token, "token", "", "token")
+	flags.StringVar(&message, "m", "", "message")
+	flags.StringVar(&message, "message", "", "message")
+	flags.StringVar(&name, "name", "", "name")
+	flags.BoolVar(&create, "create", false, "create (deprecated)")
+	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 
@@ -58,9 +57,9 @@ func (c *PushCommand) Run(args []string) int {
 		c.Ui.Say("[DEPRECATED] -m/-message is deprecated and will be removed in a future Packer release")
 	}
 
-	args = f.Args()
+	args = flags.Args()
 	if len(args) != 1 {
-		f.Usage()
+		flags.Usage()
 		return 1
 	}
 
@@ -190,15 +189,7 @@ func (c *PushCommand) Run(args []string) int {
 	}
 
 	// Collect the variables from CLI args and any var files
-	uploadOpts.Vars = make(map[string]string)
-	if vs := f.Lookup("var"); vs != nil {
-		flags := vs.Value.(*kvflag.Flag)
-		vars := map[string]string(*flags)
-
-		for k, v := range vars {
-			uploadOpts.Vars[k] = v
-		}
-	}
+	uploadOpts.Vars = core.Context().UserVariables
 
 	// Add the upload metadata
 	metadata := make(map[string]interface{})
@@ -332,6 +323,17 @@ func (c *PushCommand) upload(
 		Name:   bc.Name,
 		Builds: make([]atlas.BuildConfigBuild, 0, len(opts.Builds)),
 	}
+
+	// Build the BuildVars struct
+
+	buildVars := atlas.BuildVars{}
+	for k, v := range opts.Vars {
+		buildVars = append(buildVars, atlas.BuildVar{
+			Key:   k,
+			Value: v,
+		})
+	}
+
 	for name, info := range opts.Builds {
 		version.Builds = append(version.Builds, atlas.BuildConfigBuild{
 			Name:     name,
@@ -343,7 +345,7 @@ func (c *PushCommand) upload(
 	// Start the upload
 	doneCh, errCh := make(chan struct{}), make(chan error)
 	go func() {
-		err := c.client.UploadBuildConfigVersion(&version, opts.Metadata, opts.Vars, r, r.Size)
+		err := c.client.UploadBuildConfigVersion(&version, opts.Metadata, buildVars, r, r.Size)
 		if err != nil {
 			errCh <- err
 			return

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -204,8 +204,10 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	args := []string{
+		"-var-file", filepath.Join(testFixture("push-vars"), "vars.json"),
 		"-var", "name=foo/bar",
 		"-var", "one=two",
+		"-var", "overridden=yes",
 		filepath.Join(testFixture("push-vars"), "template.json"),
 	}
 	if code := c.Run(args); code != 0 {
@@ -217,8 +219,11 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"name": "foo/bar",
-		"one":  "two",
+		"bar":        "baz",
+		"name":       "foo/bar",
+		"null":       "",
+		"one":        "two",
+		"overridden": "yes",
 	}
 	if !reflect.DeepEqual(actualOpts.Vars, expected) {
 		t.Fatalf("bad: %#v", actualOpts.Vars)

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -205,15 +205,23 @@ func TestPush_vars(t *testing.T) {
 
 	args := []string{
 		"-var", "name=foo/bar",
+		"-var", "one=two",
 		filepath.Join(testFixture("push-vars"), "template.json"),
 	}
 	if code := c.Run(args); code != 0 {
 		fatalCommand(t, c.Meta)
 	}
 
-	expected := "foo/bar"
-	if actualOpts.Slug != expected {
+	if actualOpts.Slug != "foo/bar" {
 		t.Fatalf("bad: %#v", actualOpts.Slug)
+	}
+
+	expected := map[string]string{
+		"name": "foo/bar",
+		"one":  "two",
+	}
+	if !reflect.DeepEqual(actualOpts.Vars, expected) {
+		t.Fatalf("bad: %#v", actualOpts.Vars)
 	}
 }
 

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -192,7 +192,6 @@ func TestPush_vars(t *testing.T) {
 	var actualOpts *uploadOpts
 	uploadFn := func(r io.Reader, opts *uploadOpts) (<-chan struct{}, <-chan error, error) {
 		actualOpts = opts
-		fmt.Printf("opts: %#v\n", opts)
 
 		doneCh := make(chan struct{})
 		close(doneCh)

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -192,6 +192,7 @@ func TestPush_vars(t *testing.T) {
 	var actualOpts *uploadOpts
 	uploadFn := func(r io.Reader, opts *uploadOpts) (<-chan struct{}, <-chan error, error) {
 		actualOpts = opts
+		fmt.Printf("opts: %#v\n", opts)
 
 		doneCh := make(chan struct{})
 		close(doneCh)
@@ -204,9 +205,9 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	args := []string{
-		"-var-file", filepath.Join(testFixture("push-vars"), "vars.json"),
 		"-var", "name=foo/bar",
 		"-var", "one=two",
+		"-var-file", filepath.Join(testFixture("push-vars"), "vars.json"),
 		"-var", "overridden=yes",
 		filepath.Join(testFixture("push-vars"), "template.json"),
 	}
@@ -215,7 +216,7 @@ func TestPush_vars(t *testing.T) {
 	}
 
 	if actualOpts.Slug != "foo/bar" {
-		t.Fatalf("bad: %#v", actualOpts.Slug)
+		t.Fatalf("bad slug: %s", actualOpts.Slug)
 	}
 
 	expected := map[string]string{
@@ -226,7 +227,7 @@ func TestPush_vars(t *testing.T) {
 		"overridden": "yes",
 	}
 	if !reflect.DeepEqual(actualOpts.Vars, expected) {
-		t.Fatalf("bad: %#v", actualOpts.Vars)
+		t.Fatalf("bad vars: got %#v\n expected %#v\n", actualOpts.Vars, expected)
 	}
 }
 

--- a/command/test-fixtures/push-vars/vars.json
+++ b/command/test-fixtures/push-vars/vars.json
@@ -1,0 +1,5 @@
+{
+  "null": null,
+  "bar": "baz",
+  "overridden": "no"
+}

--- a/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
@@ -13,6 +13,13 @@ type bcWrapper struct {
 	BuildConfig *BuildConfig `json:"build_configuration"`
 }
 
+// Atlas expects a list of key/value vars
+type BuildVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+type BuildVars []BuildVar
+
 // BuildConfig represents a Packer build configuration.
 type BuildConfig struct {
 	// User is the namespace under which the build config lives
@@ -126,7 +133,7 @@ func (c *Client) CreateBuildConfig(user, name string) (*BuildConfig, error) {
 //
 // Actual API: "Create Build Config Version"
 func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[string]interface{},
-	data io.Reader, size int64) error {
+	vars BuildVars, data io.Reader, size int64) error {
 
 	log.Printf("[INFO] uploading build configuration version %s (%d bytes), with metadata %q",
 		v.Slug(), size, metadata)
@@ -137,6 +144,7 @@ func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[st
 	var bodyData bcCreateWrapper
 	bodyData.Version.Builds = v.Builds
 	bodyData.Version.Metadata = metadata
+	bodyData.Version.Vars = vars
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return err
@@ -179,5 +187,6 @@ type bcCreateWrapper struct {
 	Version struct {
 		Metadata map[string]interface{} `json:"metadata,omitempty"`
 		Builds   []BuildConfigBuild     `json:"builds"`
+		Vars     BuildVars              `json:"packer_vars,omitempty"`
 	} `json:"version"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -342,15 +342,15 @@
 			"checksumSHA1": "FUiF2WLrih0JdHsUTMMDz3DRokw=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/archive",
-			"revision": "a32da833807becb5b150e125c859e01b707e74ca",
-			"revisionTime": "2016-10-12T21:43:57Z"
+			"revision": "c1efcbcec751e3dd01d7078099451db31cbf0d24",
+			"revisionTime": "2016-10-31T14:24:30Z"
 		},
 		{
-			"checksumSHA1": "aD7uHoVmfg2T9mpnVZ5dWe6rGtY=",
+			"checksumSHA1": "lrfddRS4/LDKnF0sAbyZ59eUSjo=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/v1",
-			"revision": "a32da833807becb5b150e125c859e01b707e74ca",
-			"revisionTime": "2016-10-12T21:43:57Z"
+			"revision": "1792bd8de119ba49b17fd8d3c3c1f488ec613e62",
+			"revisionTime": "2016-11-07T20:49:10Z"
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -342,8 +342,8 @@
 			"checksumSHA1": "FUiF2WLrih0JdHsUTMMDz3DRokw=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/archive",
-			"revision": "c1efcbcec751e3dd01d7078099451db31cbf0d24",
-			"revisionTime": "2016-10-31T14:24:30Z"
+			"revision": "1792bd8de119ba49b17fd8d3c3c1f488ec613e62",
+			"revisionTime": "2016-11-07T20:49:10Z"
 		},
 		{
 			"checksumSHA1": "lrfddRS4/LDKnF0sAbyZ59eUSjo=",


### PR DESCRIPTION
Replaces #3076 

this PR will

- [ ] enforce -var precedence over -var-file variables
- [x] use new variable format in https://github.com/hashicorp/atlas-go/pull/58