### PR TITLE
builder/amazon-ebs: show ami id found from filter

### DIFF
--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -96,7 +96,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 		image = imageResp.Images[0]
 	}
 
-	log.Printf(fmt.Sprintf("Got Image %v", image))
+	ui.Message(fmt.Sprintf("Found Image ID: %s", *image.ImageId))
 
 	// Enhanced Networking (SriovNetSupport) can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5


### PR DESCRIPTION
Closes #4094 

output looks like

```
amazon-ebs output will be in this color.

==> amazon-ebs: Prevalidating AMI Name...
    amazon-ebs: Found Image ID: ami-40d28157
==> amazon-ebs: Creating temporary keypair: packer_58191674-acf3-518b-22b6-7108409feebd
==> amazon-ebs: Creating temporary security group for this instance...
==> amazon-ebs: Authorizing access to port 22 the temporary security group...
==> amazon-ebs: Launching a source AWS instance...
    amazon-ebs: Instance ID: i-0e5c732450d9d3491
==> amazon-ebs: Waiting for instance (i-0e5c732450d9d3491) to become ready...
```