### PR TITLE
googlecompute: conditionally omit the wait for startup script.

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -72,10 +72,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			WinRMConfig: winrmConfig,
 		},
 		new(common.StepProvision),
-		new(StepWaitInstanceStartup),
-		new(StepTeardownInstance),
-		new(StepCreateImage),
 	}
+	if _, exists := b.config.Metadata[StartupScriptKey]; exists || b.config.StartupScriptFile != "" {
+		steps = append(steps, new(StepWaitStartupScript))
+	}
+	steps = append(steps, new(StepTeardownInstance), new(StepCreateImage))
 
 	// Run the steps.
 	b.runner = common.NewRunner(steps, b.config.PackerConfig, ui)

--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -12,19 +12,19 @@ const StartupScriptStatusDone string = "done"
 const StartupScriptStatusError string = "error"
 const StartupScriptStatusNotDone string = "notdone"
 
-var StartupScriptLinux string = fmt.Sprintf(`#!/bin/bash
+var StartupScriptLinux string = fmt.Sprintf(`#!/usr/bin/env bash
 echo "Packer startup script starting."
 RETVAL=0
 BASEMETADATAURL=http://metadata/computeMetadata/v1/instance/
 
 GetMetadata () {
-	echo "$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/${1} 2> /dev/null)"
+  echo "$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/${1} 2> /dev/null)"
 }
 
 ZONE=$(GetMetadata zone | grep -oP "[^/]*$")
 
 SetMetadata () {
-	gcloud compute instances add-metadata ${HOSTNAME} --metadata ${1}=${2} --zone ${ZONE}
+  gcloud compute instances add-metadata ${HOSTNAME} --metadata ${1}=${2} --zone ${ZONE}
 }
 
 STARTUPSCRIPT=$(GetMetadata attributes/%s)

--- a/builder/googlecompute/step_wait_startup_script.go
+++ b/builder/googlecompute/step_wait_startup_script.go
@@ -9,11 +9,11 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-type StepWaitInstanceStartup int
+type StepWaitStartupScript int
 
 // Run reads the instance metadata and looks for the log entry
 // indicating the startup script finished.
-func (s *StepWaitInstanceStartup) Run(state multistep.StateBag) multistep.StepAction {
+func (s *StepWaitStartupScript) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
@@ -55,4 +55,4 @@ func (s *StepWaitInstanceStartup) Run(state multistep.StateBag) multistep.StepAc
 }
 
 // Cleanup.
-func (s *StepWaitInstanceStartup) Cleanup(state multistep.StateBag) {}
+func (s *StepWaitStartupScript) Cleanup(state multistep.StateBag) {}

--- a/builder/googlecompute/step_wait_startup_script_test.go
+++ b/builder/googlecompute/step_wait_startup_script_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestStepWaitInstanceStartup(t *testing.T) {
+func TestStepWaitStartupScript(t *testing.T) {
 	state := testState(t)
-	step := new(StepWaitInstanceStartup)
+	step := new(StepWaitStartupScript)
 	c := state.Get("config").(*Config)
 	d := state.Get("driver").(*DriverMock)
 

--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -110,7 +110,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			&googlecompute.StepCreateInstance{
 				Debug: p.config.PackerDebug,
 			},
-			new(googlecompute.StepWaitInstanceStartup),
+			new(googlecompute.StepWaitStartupScript),
 			new(googlecompute.StepTeardownInstance),
 		}
 


### PR DESCRIPTION
Added logic to skip StepWaitStartupScript if no startup-script was provided.

Test:
go test builder/googlecompute

Closes #4095 