### PR TITLE
Fixed inconsistency between vagrant-libvirt driver and packer QEMU ac…

### DIFF
--- a/post-processor/vagrant/libvirt.go
+++ b/post-processor/vagrant/libvirt.go
@@ -38,7 +38,9 @@ func (p *LibVirtProvider) Process(ui packer.Ui, artifact packer.Artifact, dir st
 	// Convert domain type to libvirt driver
 	var driver string
 	switch domainType {
-	case "kvm", "qemu":
+	case "none", "tcg":
+		driver = "qemu"
+	case "kvm":
 		driver = domainType
 	default:
 		return "", nil, fmt.Errorf("Unknown libvirt domain type: %s", domainType)


### PR DESCRIPTION
Small change to fix an inconsistency between the drivers that vagrant-libvirt accepts (qemu and kvm) and the relevant accelerators that Packer accepts (none, tcg and kvm)