### PR TITLE
builder/amazon: Fix doc of EBS Volume builder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
     CloudStack taking either an ISO or existing template as input. [GH-3909]
 * **New builder:** "profitbricks" Builder for creating images in the
     ProfitBricks cloud. [GH-3660]
-* **New Builder:** "amazon-ebs-volume" Can create Amazon EBS volumes which are
+* **New Builder:** "amazon-ebsvolume" Can create Amazon EBS volumes which are
     preinitialized with a filesystem and data. [GH-4088]
 
 

--- a/website/source/docs/builders/amazon-ebs-volume.html.md
+++ b/website/source/docs/builders/amazon-ebs-volume.html.md
@@ -1,6 +1,6 @@
 ---
 description: |
-    The `amazon-ebs-volume` Packer builder is like the EBS builder, but is
+    The `amazon-ebsvolume` Packer builder is like the EBS builder, but is
     intended to create EBS volumes rather than a machine image.
 layout: docs
 page_title: 'Amazon EBS Volume Builder'
@@ -8,9 +8,9 @@ page_title: 'Amazon EBS Volume Builder'
 
 # EBS Volume Builder
 
-Type: `amazon-ebs-volume`
+Type: `amazon-ebsvolume`
 
-The `amazon-ebs-volume` Packer builder is able to create Amazon Elastic Block
+The `amazon-ebsvolume` Packer builder is able to create Amazon Elastic Block
 Store volumes which are prepopulated with filesystems or data. 
 
 This builder builds EBS volumes by launching an EC2 instance from a source AMI,
@@ -202,7 +202,7 @@ builder.
 
 ```
 {
-   "type" : "amazon-ebsinit",
+   "type" : "amazon-ebsvolume",
    "secret_key" : "YOUR SECRET KEY HERE",
    "access_key" : "YOUR KEY HERE",
    "region" : "us-east-1",

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -37,7 +37,7 @@ generally recommends EBS-backed images nowadays.
 Packer is able to create Amazon EBS Volumes which are preinitialized with a
 filesystem and data. 
 
--   [amazon-ebs](/docs/builders/amazon-ebsv-volume.html) - Create EBS volumes
+-   [amazon-ebsvolume](/docs/builders/amazon-ebsv-volume.html) - Create EBS volumes
     by launching a source AMI with block devices mapped. Provision the instance,
     then destroy it, retaining the EBS volumes.
 


### PR DESCRIPTION
This PR fixes the name of the Amazon EBS Volume builders in a variety of places to match the version it was actually merged as.