### PR TITLE
builder/cloudstack: use the private port for the firewall rules

### DIFF
--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -125,8 +125,8 @@ func (s *stepSetupNetworking) Run(state multistep.StateBag) multistep.StepAction
 		p.SetAclid(network.Aclid)
 		p.SetAction("allow")
 		p.SetCidrlist(config.CIDRList)
-		p.SetStartport(s.publicPort)
-		p.SetEndport(s.publicPort)
+		p.SetStartport(s.privatePort)
+		p.SetEndport(s.privatePort)
 		p.SetTraffictype("ingress")
 
 		// Create the network ACL rule.
@@ -146,8 +146,8 @@ func (s *stepSetupNetworking) Run(state multistep.StateBag) multistep.StepAction
 
 		// Configure the firewall rule.
 		p.SetCidrlist(config.CIDRList)
-		p.SetStartport(s.publicPort)
-		p.SetEndport(s.publicPort)
+		p.SetStartport(s.privatePort)
+		p.SetEndport(s.privatePort)
 
 		fwRule, err := client.Firewall.CreateFirewallRule(p)
 		if err != nil {


### PR DESCRIPTION
Small bugfix to make sure the firewall is configured correctly. Because of how CloudStack configures the firewall on the router VM, we need to allow traffic to the private port instead of the public port in order to be able to actually make the connection.