### PR TITLE
provisioner/ansible: Move info messages to log

### DIFF
--- a/provisioner/ansible/adapter.go
+++ b/provisioner/ansible/adapter.go
@@ -37,7 +37,7 @@ func newAdapter(done <-chan struct{}, l net.Listener, config *ssh.ServerConfig, 
 }
 
 func (c *adapter) Serve() {
-	c.ui.Say(fmt.Sprintf("SSH proxy: serving on %s", c.l.Addr()))
+	log.Printf("SSH proxy: serving on %s", c.l.Addr())
 
 	for {
 		// Accept will return if either the underlying connection is closed or if a connection is made.
@@ -62,7 +62,7 @@ func (c *adapter) Serve() {
 }
 
 func (c *adapter) Handle(conn net.Conn, ui packer.Ui) error {
-	c.ui.Message("SSH proxy: accepted connection")
+	log.Print("SSH proxy: accepted connection")
 	_, chans, reqs, err := ssh.NewServerConn(conn, c.config)
 	if err != nil {
 		return errors.New("failed to handshake")
@@ -160,7 +160,7 @@ func (c *adapter) handleSession(newChannel ssh.NewChannel) error {
 						sftpCmd = "/usr/lib/sftp-server -e"
 					}
 
-					c.ui.Say("starting sftp subsystem")
+					log.Print("starting sftp subsystem")
 					go func() {
 						_ = c.remoteExec(sftpCmd, channel, channel, channel.Stderr())
 						close(done)
@@ -171,7 +171,7 @@ func (c *adapter) handleSession(newChannel ssh.NewChannel) error {
 					req.Reply(false, nil)
 				}
 			default:
-				c.ui.Message(fmt.Sprintf("rejecting %s request", req.Type))
+				log.Printf("rejecting %s request", req.Type)
 				req.Reply(false, nil)
 			}
 		}


### PR DESCRIPTION
Make the ansible provisioner less noisy by moving most messages to the
log instead of ui print outs.

Closes #4117