### PR TITLE
Modified Azure service principal creation script to work with newer version of Azure CLI

### DIFF
--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -161,7 +161,7 @@ createServicePrincipal() {
 	# prior version accepted appId as the only parameter without a switch
 	newer_syntax = false
 	IFS='.' read -ra azureversionsemver <<< "$azureversion"
-	if [[ ${azureversionsemver[0]} -ge 0 && ${azureversionsemver[1]} -ge 10 &&  ${azureversionsemver[2]} -ge 2]]; then	
+	if [ ${azureversionsemver[0]} -ge 0 ] && [ ${azureversionsemver[1]} -ge 10 ] && [ ${azureversionsemver[2]} -ge 2 ]; then	
 		newer_syntax = true
 	fi
 

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -166,9 +166,9 @@ createServicePrincipal() {
 	fi
 
 	if [ "${newer_syntax}" = true ]; then	
-		azure ad sp create -a $azure_client_id
+		azure_object_id=$(azure ad sp create -a $azure_client_id | jq -r .objectId)
 	else 
-		azure ad sp create $azure_client_id	
+		azure_object_id=$(azure ad sp create $azure_client_id | jq -r .objectId)
 	fi
 
 	if [ $? -ne 0 ]; then

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -159,10 +159,10 @@ createServicePrincipal() {
 	echo "==> Creating service principal"
 	# Azure CLI 0.10.2 introduced a breaking change, where appId must be supplied with the -a switch
 	# prior version accepted appId as the only parameter without a switch
-	newer_syntax = false
+	newer_syntax=false
 	IFS='.' read -ra azureversionsemver <<< "$azureversion"
 	if [ ${azureversionsemver[0]} -ge 0 ] && [ ${azureversionsemver[1]} -ge 10 ] && [ ${azureversionsemver[2]} -ge 2 ]; then	
-		newer_syntax = true
+		newer_syntax=true
 	fi
 
 	if [ "${newer_syntax}" = true ]; then	

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -166,9 +166,9 @@ createServicePrincipal() {
 	fi
 
 	if [ "${newer_syntax}" = true ]; then	
-		azure_object_id=$(azure ad sp create -a $azure_client_id | jq -r .objectId)
+		azure_object_id=$(azure ad sp create -a $azure_client_id --json | jq -r .objectId)
 	else 
-		azure_object_id=$(azure ad sp create $azure_client_id | jq -r .objectId)
+		azure_object_id=$(azure ad sp create $azure_client_id --json | jq -r .objectId)
 	fi
 
 	if [ $? -ne 0 ]; then

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -64,7 +64,7 @@ requirements() {
 		echo "jq is missing. Please install jq from"
 		echo "https://stedolan.github.io/jq/"
 	fi
-	
+
 	if [ $found -lt 2 ]; then
 		exit 1
 	fi
@@ -145,10 +145,18 @@ createStorageAccount() {
 	fi
 }
 
+createApplication() {
+	echo "==> Creating application"
+	azure_client_id=$(azure ad app create -n $meta_name -i http://$meta_name --home-page http://$meta_name -p $azure_client_secret --json | jq -r .appId)
+	if [ $? -ne 0 ]; then
+		echo "Error creating application: $meta_name @ http://$meta_name"
+		exit 1
+	fi
+}
+
 createServicePrincipal() {
 	echo "==> Creating service principal"
-	azure_object_id=$(azure ad sp create -n $meta_name --home-page http://$meta_name --identifier-uris http://$meta_name/example -p $azure_client_secret --json | jq -r .objectId)
-	azure_client_id=$(azure ad app show -c $meta_name --json | jq -r .[0].appId)
+	azure ad sp create $azure_client_id
 	if [ $? -ne 0 ]; then
 		echo "Error creating service principal: $azure_client_id"
 		exit 1

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -165,7 +165,7 @@ createServicePrincipal() {
 		newer_syntax = true
 	fi
 
-	if [newer_syntax -eq true ]; then	
+	if [ "${newer_syntax}" = true ]; then	
 		azure ad sp create -a $azure_client_id
 	else 
 		azure ad sp create $azure_client_id	

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -64,28 +64,7 @@ requirements() {
 		echo "jq is missing. Please install jq from"
 		echo "https://stedolan.github.io/jq/"
 	fi
-
-	# azure-cli 0.10.5 includes a breaking change
-	# warn if using an incompatible azure-cli version
-	# This is just a work around until a more appropriate fix is available
-	supported_version=true
-	IFS='.' read -ra azureversionsemver <<< "$azureversion"
-	if [ ${azureversionsemver[0]} -gt 0 ]; then
-		supported_version=false 
-	fi
-	if [ ${azureversionsemver[1]} -gt 10 ]; then 
-		supported_version=false 
-	fi
-	if [ ${azureversionsemver[2]} -gt 4 ]; then 
-		supported_version=false 
-	fi
 	
-	echo "supported_version is $supported_version"
-	if [ "${supported_version}" = false ]; then
-		echo "Error: azure-cli must be 0.10.4 or older, see http://bit.ly/2etirbM"
-		exit 1
-	fi
-
 	if [ $found -lt 2 ]; then
 		exit 1
 	fi

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -11,6 +11,7 @@ azure_subscription_id= # Derived from the account after login
 azure_tenant_id=       # Derived from the account after login
 location=
 azure_object_id=
+azureversion=
 
 showhelp() {
 	echo "azure-setup"
@@ -156,7 +157,20 @@ createApplication() {
 
 createServicePrincipal() {
 	echo "==> Creating service principal"
-	azure ad sp create $azure_client_id
+	# Azure CLI 0.10.2 introduced a breaking change, where appId must be supplied with the -a switch
+	# prior version accepted appId as the only parameter without a switch
+	newer_syntax = false
+	IFS='.' read -ra azureversionsemver <<< "$azureversion"
+	if [[ ${azureversionsemver[0]} -ge 0 && ${azureversionsemver[1]} -ge 10 &&  ${azureversionsemver[2]} -ge 2]]; then	
+		newer_syntax = true
+	fi
+
+	if [newer_syntax -eq true ]; then	
+		azure ad sp create -a $azure_client_id
+	else 
+		azure ad sp create $azure_client_id	
+	fi
+
 	if [ $? -ne 0 ]; then
 		echo "Error creating service principal: $azure_client_id"
 		exit 1

--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -209,6 +209,8 @@ setup() {
 	sleep 5
 	createStorageAccount
 	sleep 5
+	createApplication
+	sleep 5
 	createServicePrincipal
 	sleep 5
 	createPermissions


### PR DESCRIPTION
Modified azure-setup.sh to work with all versions of Azure CLI after Azure CLI introduced breaking changes in 0.10.2 and 0.10.4. Tested with the latest version of Azure CLI (0.10.7)