### PR TITLE
add zone id when associate ip address in cloudstack

### DIFF
--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -73,6 +73,10 @@ func (s *stepSetupNetworking) Run(state multistep.StateBag) multistep.StepAction
 			p.SetNetworkid(network.Id)
 		}
 
+		if config.Zone != "" {
+			p.SetZoneid(config.Zone)
+		}
+
 		// Associate a new public IP address.
 		ipAddr, err := client.Address.AssociateIpAddress(p)
 		if err != nil {


### PR DESCRIPTION
fix failed ip address associate use cloudstack builder

add zone parameter
