### PR TITLE
update windows build script for go compatibility

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -70,7 +70,7 @@ echo "==> Building..."
 gox.exe `
   -os="${XC_OS}" `
   -arch="${XC_ARCH}" `
-  -ldflags "-X github.com/mitchellh/packer/version.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" `
+  -ldflags "-X github.com/mitchellh/packer/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY}" `
   -output "pkg/{{.OS}}_{{.Arch}}/packer" `
   .
 


### PR DESCRIPTION
go changed the way -X options work. this brings the windows build script inline with linux