### PR TITLE
googlecompute-export: Fixed scopes to run gcloud, gsutil in startup script

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -79,6 +79,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			Zone:                 zone,
 			Network:              "default",
 			RawStateTimeout:      "5m",
+			Scopes: []string{
+				"https://www.googleapis.com/auth/userinfo.email",
+				"https://www.googleapis.com/auth/compute",
+				"https://www.googleapis.com/auth/devstorage.full_control",
+			},
 		}
 		exporterConfig.CalcTimeout()
 


### PR DESCRIPTION
I tried googlecompute-exporter, but it did not work.

`packer build template.json` outputs:

```
==> googlecompute: Running post-processor: googlecompute-export
==> googlecompute (googlecompute-export): Starting googlecompute-export...
==> googlecompute (googlecompute-export): Exporting image to destinations: [gs://example-bucket-name/images/test-debian.tar.gz]
==> googlecompute (googlecompute-export): Creating temporary SSH key for instance...
==> googlecompute (googlecompute-export): Creating instance...
    googlecompute (googlecompute-export): Loading zone: asia-east1-a
    googlecompute (googlecompute-export): Loading machine type: n1-standard-4
    googlecompute (googlecompute-export): Loading network: default
    googlecompute (googlecompute-export): Requesting instance creation...
    googlecompute (googlecompute-export): Waiting for creation operation to complete...
    googlecompute (googlecompute-export): Instance has been created!
==> googlecompute (googlecompute-export): Waiting for any running startup script to finish...
==> googlecompute (googlecompute-export): Startup script not finished yet. Waiting...
==> googlecompute (googlecompute-export): Startup script not finished yet. Waiting...
==> googlecompute (googlecompute-export): Startup script not finished yet. Waiting...
==> googlecompute (googlecompute-export): Startup script not finished yet. Waiting...
(snip)
```

Startup script log (/var/log/syslog) in Exporter VM:

```
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Executing user-provided startup script...
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: ####### Export configuration #######
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Image name - test-debian-v20161110-084640
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Instance name - test-debian-v20161110-084640-exporter
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Instance zone - asia-east1-a
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Disk name - test-debian-v20161110-084640-exporter-toexport
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Export paths - gs://example-bucket-name/images/test-debian.tar.gz
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: ####################################
Nov 10 08:50:10 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Creating disk from image to be exported...
Nov 10 08:50:11 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: ERROR: gcloud crashed (UnicodeEncodeError): 'ascii' codec can't encode character u'\u2019' in position 1438: ordinal not in range(128)
Nov 10 08:50:11 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: If you would like to report this issue, please run the following command:
Nov 10 08:50:11 test-debian-v20161110-084640-exporter startup-script: INFO startup-script:   gcloud feedback
Nov 10 08:50:11 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Failed to create disk.
Nov 10 08:50:11 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Uploading exporter log to gs://example-bucket-name/images/test-debian.tar.gz.exporter.log...
Nov 10 08:50:12 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Failure: Could not reach metadata service: Forbidden.
Nov 10 08:50:12 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Packer startup script done.
Nov 10 08:50:12 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: ERROR: gcloud crashed (UnicodeEncodeError): 'ascii' codec can't encode character u'\u2019' in position 1438: ordinal not in range(128)
Nov 10 08:50:12 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: If you would like to report this issue, please run the following command:
Nov 10 08:50:12 test-debian-v20161110-084640-exporter startup-script: INFO startup-script:   gcloud feedback
Nov 10 08:50:22 test-debian-v20161110-084640-exporter startup-script: INFO startup-script: Return code 1.
Nov 10 08:50:22 test-debian-v20161110-084640-exporter startup-script: INFO Finished running startup scripts.
```

The error message `Failure: Could not reach metadata service: Forbidden.` means
exporter VM instance does not have required scopes to run gcloud, gsutil command in startup script.

Maybe, this is caused by #4043. Sorry.
(Another problem is googlecompute-export has no tests...)

I Added the required scopes to fix this problem, and it works on my box.
