### PR TITLE
builder/cloudstack: do not create a random public port

### DIFF
--- a/builder/cloudstack/step_create_instance.go
+++ b/builder/cloudstack/step_create_instance.go
@@ -32,6 +32,10 @@ func (s *stepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 	p.SetName(config.InstanceName)
 	p.SetDisplayname("Created by Packer")
 
+	if config.Keypair != "" {
+		p.SetKeypair(config.Keypair)
+	}
+
 	// If we use an ISO, configure the disk offering.
 	if config.SourceISO != "" {
 		p.SetDiskofferingid(config.DiskOffering)
@@ -58,10 +62,6 @@ func (s *stepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 	// If there is a project supplied, set the project id.
 	if config.Project != "" {
 		p.SetProjectid(config.Project)
-	}
-
-	if config.Keypair != "" {
-		p.SetKeypair(config.Keypair)
 	}
 
 	if config.UserData != "" {


### PR DESCRIPTION
This is meant to be a gentle solution for a very specific use case, but is causing more issues then it solves.

If you have a port conflict when trying to use an already associated public IP, the easiest way around it is to let the builder associate a new temporary public IP address.