### PR TITLE
Added support for passing arguments to salt-call.

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -55,6 +55,9 @@ type Config struct {
 	// Set the logging level for the salt-call run
 	LogLevel string `mapstructure:"log_level"`
 
+	// Arguments to pass to salt-call
+	SaltCallArgs string `mapstructure:"salt_call_args"`
+
 	// Command line args passed onto salt-call
 	CmdArgs string ""
 
@@ -141,6 +144,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	} else {
 		cmd_args.WriteString(" -l ")
 		cmd_args.WriteString(p.config.LogLevel)
+	}
+
+	if p.config.SaltCallArgs != "" {
+		cmd_args.WriteString(" ")
+		cmd_args.WriteString(p.config.SaltCallArgs)
 	}
 
 	p.config.CmdArgs = cmd_args.String()

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -76,3 +76,8 @@ Optional:
     fails. Set this option to true to ignore Salt failures.
 
 -   `log_level` (string) - Set the logging level for the `salt-call` run.
+
+-   `salt_call_args` (string) - Additional arguments to pass directly to `salt-call`. See
+    [salt-call](https://docs.saltstack.com/ref/cli/salt-call.html) documentation for more
+    information. By default no additional arguments (besides the ones Packer generates)
+    are passed to `salt-call`.


### PR DESCRIPTION
Adds the ability to pass custom arguments to `salt-call`. Just like it is already possible to pass custom arguments to the SaltStack `bootstrap.sh` script. This is an modernized (naming of parameters more in sync with the other Packer Salt parameters) version of #2488 and also adds documentation which was missing in #2488.

This modification allows "powerusers" to use niche functionality with `salt-call` without making things more difficult (by adding clutter) for 99.9% of the users.

Let me know if this needs any changes in order to merge this!