### PR TITLE
builder/googlecompute: support source image family

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Region               string            `mapstructure:"region"`
 	Scopes               []string          `mapstructure:"scopes"`
 	SourceImage          string            `mapstructure:"source_image"`
+	SourceImageFamily    string            `mapstructure:"source_image_family"`
 	SourceImageProjectId string            `mapstructure:"source_image_project_id"`
 	StartupScriptFile    string            `mapstructure:"startup_script_file"`
 	Subnetwork           string            `mapstructure:"subnetwork"`
@@ -152,9 +153,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		}
 	}
 
-	if c.SourceImage == "" {
+	if c.SourceImage == "" && c.SourceImageFamily == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("a source_image must be specified"))
+			errs, errors.New("a source_image or source_image_family must be specified"))
 	}
 
 	if c.Zone == "" {

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -47,6 +47,17 @@ func TestConfigPrepare(t *testing.T) {
 		},
 
 		{
+			"source_image_family",
+			nil,
+			false,
+		},
+		{
+			"source_image_family",
+			"foo",
+			false,
+		},
+
+		{
 			"zone",
 			nil,
 			true,

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -22,11 +22,14 @@ type Driver interface {
 	// DeleteDisk deletes the disk with the given name.
 	DeleteDisk(zone, name string) (<-chan error, error)
 
-	// GetImage gets an image; tries the default and public projects.
-	GetImage(name string) (*Image, error)
+	// GetImage gets an image; tries the default and public projects. If
+	// fromFamily is true, name designates an image family instead of a
+	// particular image.
+	GetImage(name string, fromFamily bool) (*Image, error)
 
-	// GetImageFromProject gets an image from a specific project.
-	GetImageFromProject(project, name string) (*Image, error)
+	// GetImageFromProject gets an image from a specific project. If fromFamily
+	// is true, name designates an image family instead of a particular image.
+	GetImageFromProject(project, name string, fromFamily bool) (*Image, error)
 
 	// GetInstanceMetadata gets a metadata variable for the instance, name.
 	GetInstanceMetadata(zone, name, key string) (string, error)

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -30,14 +30,16 @@ type DriverMock struct {
 	DeleteDiskErrCh <-chan error
 	DeleteDiskErr   error
 
-	GetImageName   string
-	GetImageResult *Image
-	GetImageErr    error
+	GetImageName       string
+	GetImageFromFamily bool
+	GetImageResult     *Image
+	GetImageErr        error
 
-	GetImageFromProjectProject string
-	GetImageFromProjectName    string
-	GetImageFromProjectResult  *Image
-	GetImageFromProjectErr     error
+	GetImageFromProjectProject    string
+	GetImageFromProjectName       string
+	GetImageFromProjectFromFamily bool
+	GetImageFromProjectResult     *Image
+	GetImageFromProjectErr        error
 
 	GetInstanceMetadataZone   string
 	GetInstanceMetadataName   string
@@ -162,14 +164,16 @@ func (d *DriverMock) DeleteDisk(zone, name string) (<-chan error, error) {
 	return resultCh, d.DeleteDiskErr
 }
 
-func (d *DriverMock) GetImage(name string) (*Image, error) {
+func (d *DriverMock) GetImage(name string, fromFamily bool) (*Image, error) {
 	d.GetImageName = name
+	d.GetImageFromFamily = fromFamily
 	return d.GetImageResult, d.GetImageErr
 }
 
-func (d *DriverMock) GetImageFromProject(project, name string) (*Image, error) {
+func (d *DriverMock) GetImageFromProject(project, name string, fromFamily bool) (*Image, error) {
 	d.GetImageFromProjectProject = project
 	d.GetImageFromProjectName = name
+	d.GetImageFromProjectFromFamily = fromFamily
 	return d.GetImageFromProjectResult, d.GetImageFromProjectErr
 }
 

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -86,6 +86,8 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		return multistep.ActionHalt
 	}
 
+	ui.Say(fmt.Sprintf("Using image: %s", sourceImage.Name))
+
 	if sourceImage.IsWindows() && c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" {
 		state.Put("create_windows_password", true)
 	}

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -58,10 +58,16 @@ func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string)
 }
 
 func getImage(c *Config, d Driver) (*Image, error) {
+	name := c.SourceImageFamily
+	fromFamily := true
+	if c.SourceImage != "" {
+		name = c.SourceImage
+		fromFamily = false
+	}
 	if c.SourceImageProjectId == "" {
-		return d.GetImage(c.SourceImage)
+		return d.GetImage(name, fromFamily)
 	} else {
-		return d.GetImageFromProject(c.SourceImageProjectId, c.SourceImage)
+		return d.GetImageFromProject(c.SourceImageProjectId, c.SourceImage, fromFamily)
 	}
 }
 

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -125,8 +125,11 @@ builder.
 -   `project_id` (string) - The project ID that will be used to launch instances
     and store images.
 
--   `source_image` (string) - The source image to use to create the new
-    image from. Example: `"debian-7-wheezy-v20150127"`
+-   `source_image` or `source_image_family` (string) - The source image or
+    family to use to create the new image from. The image family always returns
+    its latest image that is not deprecated. If both `source_image` and
+    `source_image_family` are specified, `source_image` takes precedence.
+    Example: `"debian-7-wheezy-v20150127"`, `"debian-7"`.
 
 -   `zone` (string) - The zone in which to launch the instance used to create
     the image. Example: `"us-central1-a"`
@@ -147,7 +150,10 @@ builder.
 
 -   `image_description` (string) - The description of the resulting image.
 
--   `image_family` (string) - The name of the image family to which the resulting image belongs. You can create disks by specifying an image family instead of a specific image name. The image family always returns its latest image that is not deprecated.
+-   `image_family` (string) - The name of the image family to which the
+    resulting image belongs. You can create disks by specifying an image family
+    instead of a specific image name. The image family always returns its
+    latest image that is not deprecated.
 
 -   `image_name` (string) - The unique name of the resulting image. Defaults to
     `"packer-{{timestamp}}"`.

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -125,11 +125,14 @@ builder.
 -   `project_id` (string) - The project ID that will be used to launch instances
     and store images.
 
--   `source_image` or `source_image_family` (string) - The source image or
-    family to use to create the new image from. The image family always returns
-    its latest image that is not deprecated. If both `source_image` and
-    `source_image_family` are specified, `source_image` takes precedence.
-    Example: `"debian-7-wheezy-v20150127"`, `"debian-7"`.
+-   `source_image` (string) - The source image to use to create the new image
+    from. You can also specify `source_image_family` instead. If both
+    `source_image` and `source_image_family` are specified, `source_image`
+    takes precedence. Example: `"debian-8-jessie-v20161027"`
+
+-   `source_image_family` (string) - The source image family to use to create
+    the new image from. The image family always returns its latest image that
+    is not deprecated. Example: `"debian-8"`.
 
 -   `zone` (string) - The zone in which to launch the instance used to create
     the image. Example: `"us-central1-a"`


### PR DESCRIPTION
Add `source_image_family` for the googlecompute builder.

In #4110 @vbatoufflet suggested to not add a new config key, but instead try image name first, and then image family if the named image doesn't exist. However, that is ambiguous, since the same identifier can be used for images and families. Also, if `source_image_project_id` isn't specified, packer tries a few global projects by default, and if an image exists in project A and an image family in project B, the image in project A will always win.

Closes #4100