### PR TITLE
ssh: Remove ssh_username default value

### DIFF
--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -113,14 +113,6 @@ func TestRunConfigPrepare_SSHPort(t *testing.T) {
 	}
 }
 
-func TestRunConfigPrepare_SSHUsername(t *testing.T) {
-	c := testConfig()
-	c.Comm.SSHUsername = ""
-	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
-	}
-}
-
 func TestRunConfigPrepare_UserData(t *testing.T) {
 	c := testConfig()
 	tf, err := ioutil.TempFile("", "packer")

--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -76,10 +76,6 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 		c.AsyncTimeout = 30 * time.Minute
 	}
 
-	if c.Comm.SSHUsername == "" {
-		c.Comm.SSHUsername = "root"
-	}
-
 	if c.InstanceName == "" {
 		c.InstanceName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
 	}

--- a/builder/cloudstack/config_test.go
+++ b/builder/cloudstack/config_test.go
@@ -151,6 +151,7 @@ func testConfig(config map[string]interface{}) map[string]interface{} {
 		"api_url":          "https://cloudstack.com/client/api",
 		"api_key":          "some-api-key",
 		"secret_key":       "some-secret-key",
+		"ssh_username":     "root",
 		"cidr_list":        []interface{}{"0.0.0.0/0"},
 		"network":          "c5ed8a14-3f21-4fa9-bd74-bb887fc0ed0d",
 		"service_offering": "a29c52b1-a83d-4123-a57d-4548befa47a0",

--- a/builder/digitalocean/builder_test.go
+++ b/builder/digitalocean/builder_test.go
@@ -10,10 +10,11 @@ import (
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"api_token": "bar",
-		"region":    "nyc2",
-		"size":      "512mb",
-		"image":     "foo",
+		"api_token":    "bar",
+		"region":       "nyc2",
+		"size":         "512mb",
+		"ssh_username": "root",
+		"image":        "foo",
 	}
 }
 
@@ -148,39 +149,6 @@ func TestBuilderPrepare_Image(t *testing.T) {
 
 	if b.config.Image != expected {
 		t.Errorf("found %s, expected %s", b.config.Image, expected)
-	}
-}
-
-func TestBuilderPrepare_SSHUsername(t *testing.T) {
-	var b Builder
-	config := testConfig()
-
-	// Test default
-	warnings, err := b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if b.config.Comm.SSHUsername != "root" {
-		t.Errorf("invalid: %s", b.config.Comm.SSHUsername)
-	}
-
-	// Test set
-	config["ssh_username"] = "foo"
-	b = Builder{}
-	warnings, err = b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if b.config.Comm.SSHUsername != "foo" {
-		t.Errorf("invalid: %s", b.config.Comm.SSHUsername)
 	}
 }
 

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -77,12 +77,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.DropletName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
 	}
 
-	if c.Comm.SSHUsername == "" {
-		// Default to "root". You can override this if your
-		// SourceImage has a different user account then the DO default
-		c.Comm.SSHUsername = "root"
-	}
-
 	if c.StateTimeout == 0 {
 		// Default to 6 minute timeouts waiting for
 		// desired state. i.e waiting for droplet to become active

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -130,10 +130,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.RawStateTimeout = "5m"
 	}
 
-	if c.Comm.SSHUsername == "" {
-		c.Comm.SSHUsername = "root"
-	}
-
 	if es := c.Comm.Prepare(&c.ctx); len(es) > 0 {
 		errs = packer.MultiErrorAppend(errs, es...)
 	}

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -217,6 +217,7 @@ func testConfig(t *testing.T) map[string]interface{} {
 		"account_file": testAccountFile(t),
 		"project_id":   "hashicorp",
 		"source_image": "foo",
+		"ssh_username": "root",
 		"image_family": "bar",
 		"zone":         "us-east1-a",
 	}

--- a/builder/null/config_test.go
+++ b/builder/null/config_test.go
@@ -71,20 +71,6 @@ func TestConfigPrepare_host(t *testing.T) {
 	testConfigOk(t, warns, errs)
 }
 
-func TestConfigPrepare_sshUsername(t *testing.T) {
-	raw := testConfig()
-
-	// No ssh_username
-	delete(raw, "ssh_username")
-	_, warns, errs := NewConfig(raw)
-	testConfigErr(t, warns, errs)
-
-	// Good ssh_username
-	raw["ssh_username"] = "good"
-	_, warns, errs = NewConfig(raw)
-	testConfigOk(t, warns, errs)
-}
-
 func TestConfigPrepare_sshCredential(t *testing.T) {
 	raw := testConfig()
 

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -35,10 +35,6 @@ type RunConfig struct {
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
-	// Defaults
-	if c.Comm.SSHUsername == "" {
-		c.Comm.SSHUsername = "root"
-	}
 
 	if c.UseFloatingIp && c.FloatingIpPool == "" {
 		c.FloatingIpPool = "public"

--- a/builder/openstack/run_config_test.go
+++ b/builder/openstack/run_config_test.go
@@ -70,11 +70,3 @@ func TestRunConfigPrepare_SSHPort(t *testing.T) {
 		t.Fatalf("invalid value: %d", c.Comm.SSHPort)
 	}
 }
-
-func TestRunConfigPrepare_SSHUsername(t *testing.T) {
-	c := testRunConfig()
-	c.Comm.SSHUsername = ""
-	if err := c.Prepare(nil); len(err) != 0 {
-		t.Fatalf("err: %s", err)
-	}
-}

--- a/builder/parallels/common/ssh_config_test.go
+++ b/builder/parallels/common/ssh_config_test.go
@@ -77,25 +77,6 @@ func TestSSHConfigPrepare_SSHPrivateKey(t *testing.T) {
 	}
 }
 
-func TestSSHConfigPrepare_SSHUser(t *testing.T) {
-	var c *SSHConfig
-	var errs []error
-
-	c = testSSHConfig()
-	c.Comm.SSHUsername = ""
-	errs = c.Prepare(testConfigTemplate(t))
-	if len(errs) == 0 {
-		t.Fatalf("should have error")
-	}
-
-	c = testSSHConfig()
-	c.Comm.SSHUsername = "exists"
-	errs = c.Prepare(testConfigTemplate(t))
-	if len(errs) > 0 {
-		t.Fatalf("should not have error: %#v", errs)
-	}
-}
-
 const testPem = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAxd4iamvrwRJvtNDGQSIbNvvIQN8imXTRWlRY62EvKov60vqu

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -488,31 +488,6 @@ func TestBuilderPrepare_SSHPrivateKey(t *testing.T) {
 	}
 }
 
-func TestBuilderPrepare_SSHUser(t *testing.T) {
-	var b Builder
-	config := testConfig()
-
-	config["ssh_username"] = ""
-	b = Builder{}
-	warns, err := b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err == nil {
-		t.Fatal("should have error")
-	}
-
-	config["ssh_username"] = "exists"
-	b = Builder{}
-	warns, err = b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-}
-
 func TestBuilderPrepare_SSHWaitTimeout(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/virtualbox/common/ssh_config_test.go
+++ b/builder/virtualbox/common/ssh_config_test.go
@@ -108,25 +108,6 @@ func TestSSHConfigPrepare_SSHPrivateKey(t *testing.T) {
 	}
 }
 
-func TestSSHConfigPrepare_SSHUser(t *testing.T) {
-	var c *SSHConfig
-	var errs []error
-
-	c = testSSHConfig()
-	c.Comm.SSHUsername = ""
-	errs = c.Prepare(testConfigTemplate(t))
-	if len(errs) == 0 {
-		t.Fatalf("should have error")
-	}
-
-	c = testSSHConfig()
-	c.Comm.SSHUsername = "exists"
-	errs = c.Prepare(testConfigTemplate(t))
-	if len(errs) > 0 {
-		t.Fatalf("should not have error: %#v", errs)
-	}
-}
-
 const testPem = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAxd4iamvrwRJvtNDGQSIbNvvIQN8imXTRWlRY62EvKov60vqu

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -146,7 +146,7 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 	// Validation
 	var errs []error
 	if c.SSHUsername == "" {
-		errs = append(errs, errors.New("An ssh_username must be specified"))
+		errs = append(errs, errors.New("An ssh_username must be specified\n  Note: some builders used to default ssh_username to \"root\"."))
 	}
 
 	if c.SSHPrivateKey != "" {

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -70,7 +70,7 @@ The SSH communicator has the following options:
     host.
 
   * `ssh_disable_agent` (boolean) - If true, SSH agent forwarding will be
-    disabled.
+    disabled. Defaults to false.
 
   * `ssh_file_transfer_method` (`scp` or `sftp`) - How to transfer files, Secure
     copy (default) or SSH File Transfer Protocol.
@@ -96,7 +96,8 @@ The SSH communicator has the following options:
     Packer uses this to determine when the machine has booted so this is
     usually quite long. Example value: "10m"
 
-  * `ssh_username` (string) - The username to connect to SSH with.
+  * `ssh_username` (string) - The username to connect to SSH with. Required
+    if using SSH.
 
 ## WinRM Communicator
 


### PR DESCRIPTION
This sets `ssh_username` ~~default value to `root`~~. Require that the user sets `ssh_username` if `ssh` is used.

This changes the cloud builders which had `root` as default, with the exception of `amzure-arm`.

`profitbricks` will be cleaned up in #4169.

I'll open a separate issue for `azure-arm`, see #4174.