### PR TITLE
post-processor/manifest: fixes interpolation of output

### DIFF
--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -29,6 +29,7 @@ func init() {
 		"parallels-headless":     new(FixerParallelsHeadless),
 		"parallels-deprecations": new(FixerParallelsDeprecations),
 		"sshkeypath":             new(FixerSSHKeyPath),
+		"manifest-filename":      new(FixerManifestFilename),
 	}
 
 	FixerOrder = []string{
@@ -41,5 +42,6 @@ func init() {
 		"parallels-headless",
 		"parallels-deprecations",
 		"sshkeypath",
+		"manifest-filename",
 	}
 }

--- a/fix/fixer_pp_manifest_filename.go
+++ b/fix/fixer_pp_manifest_filename.go
@@ -1,0 +1,60 @@
+package fix
+
+import (
+	"fmt"
+	"github.com/mitchellh/mapstructure"
+)
+
+// FixerManifestFilename renames any Filename to Output
+type FixerManifestFilename struct{}
+
+func (FixerManifestFilename) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+
+	// Our template type we'll use for this fixer only
+	type template struct {
+		PostProcessors []map[string]interface{} `mapstructure:"post-processors"`
+	}
+
+	// Decode the input into our structure, if we can
+	fmt.Println("Got 0")
+	var tpl template
+	if err := mapstructure.Decode(input, &tpl); err != nil {
+		fmt.Println("Got 1")
+		return nil, err
+	}
+	for _, pp := range tpl.PostProcessors {
+		ppTypeRaw, ok := pp["type"]
+		if !ok {
+			continue
+		}
+
+		ppType, ok := ppTypeRaw.(string)
+		if !ok {
+			continue
+		}
+
+		if ppType != "manifest" {
+			continue
+		}
+
+		filenameRaw, ok := pp["filename"]
+		if !ok {
+			continue
+		}
+
+		filename, ok := filenameRaw.(string)
+		if !ok {
+			continue
+		}
+
+		delete(pp, "filename")
+		pp["output"] = filename
+	}
+
+	input["post-processors"] = tpl.PostProcessors
+	return input, nil
+}
+
+func (FixerManifestFilename) Synopsis() string {
+	return `Updates "manifest" post-processor so any "filename" field is renamed to "output".`
+}

--- a/fix/fixer_pp_manifest_filename_test.go
+++ b/fix/fixer_pp_manifest_filename_test.go
@@ -13,19 +13,31 @@ func TestFixerManifestPPFilename_Fix(t *testing.T) {
 	var f FixerManifestFilename
 
 	input := map[string]interface{}{
-		"post-processors": []map[string]interface{}{
-			{
+		"post-processors": []interface{}{
+			map[string]interface{}{
 				"type":     "manifest",
 				"filename": "foo",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"type":     "manifest",
+					"filename": "foo",
+				},
 			},
 		},
 	}
 
 	expected := map[string]interface{}{
-		"post-processors": []map[string]interface{}{
-			{
+		"post-processors": []interface{}{
+			map[string]interface{}{
 				"type":   "manifest",
 				"output": "foo",
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"type":   "manifest",
+					"output": "foo",
+				},
 			},
 		},
 	}

--- a/fix/fixer_pp_manifest_filename_test.go
+++ b/fix/fixer_pp_manifest_filename_test.go
@@ -1,0 +1,41 @@
+package fix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixerManifestPPFilename_Impl(t *testing.T) {
+	var _ Fixer = new(FixerVagrantPPOverride)
+}
+
+func TestFixerManifestPPFilename_Fix(t *testing.T) {
+	var f FixerManifestFilename
+
+	input := map[string]interface{}{
+		"post-processors": []map[string]interface{}{
+			{
+				"type":     "manifest",
+				"filename": "foo",
+			},
+		},
+	}
+
+	expected := map[string]interface{}{
+		"post-processors": []map[string]interface{}{
+			{
+				"type":   "manifest",
+				"output": "foo",
+			},
+		},
+	}
+
+	output, err := f.Fix(input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(output, expected) {
+		t.Fatalf("unexpected: %#v\nexpected: %#v\n", output, expected)
+	}
+}

--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -21,7 +21,7 @@ You can specify manifest more than once and write each build to its own file, or
 
 ### Optional:
 
--   `filename` (string) The manifest will be written to this file. This defaults to `packer-manifest.json`.
+-   `output` (string) The manifest will be written to this file. This defaults to `packer-manifest.json`.
 -   `strip_path` (bool) Write only filename without the path to the manifest file. This defaults to false.
 
 ### Example Configuration
@@ -33,7 +33,7 @@ You can simply add `{"type":"manifest"}` to your post-processor section. Below i
   "post-processors": [
     {
       "type": "manifest",
-      "filename": "manifest.json",
+      "output": "manifest.json",
       "strip_path": true
     }
   ]


### PR DESCRIPTION
Closes #4180
Replaces #4188

* rename filename to output for consistent with other post-processors
* add fixer for above
* interpolate output with variables