### PR TITLE
provisioner/shell: treat disconnects as retryable.

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -320,6 +320,10 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 						p.config.RemotePath, err)
 				}
 				cmd.Wait()
+				// treat disconnects as retryable by returning an error
+				if cmd.ExitStatus == packer.CmdDisconnect {
+					return fmt.Errorf("Disconnect while removing temporary script.")
+				}
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
closes #4137 


what was happening is that the cleanup runs immediately after the script it's cleaning reboots the machine, so it connects briefly and is then disconnected. This changes the behavior so we treat disconnects during cleanup as retryable errors. The script will keep retrying until it gets through or the timeout is hit. If your restart takes a while, you may need to increase `start_retry_timeout`.

I don't believe this ever worked correctly. Before it would just fail silently when it got disconnected, so it's likely any cleanup which happened immediately after a reboot wasn't happening