### PR TITLE
Docs: add QCOW2 format support for `iso_url`

### DIFF
--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -105,6 +105,9 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 -   `iso_url` (string) - A URL to the ISO containing the installation image.
     This URL can be either an HTTP URL or a file URL (or path to a file). If
     this is an HTTP URL, Packer will download it and cache it between runs.
+    This can also be a URL to an IMG or QCOW2 file, in which case QEMU will
+    boot directly from it. When passing a path to an IMG or QCOW2 file, you 
+    should set `disk_image` to "true".
 
 -   `ssh_username` (string) - The username to use to SSH into the machine once
     the OS is installed.


### PR DESCRIPTION
Took some digging to realize that `iso_url` can actually take in a qcow2 or img format. This is fantastic and works great out of the box. I feel like adding the extra 2 lines of docs will help future users looking for this.

Can probably be used to close #1366 