### PR TITLE
Note more secure ways to pass credentials.

### DIFF
--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -113,6 +113,12 @@ With a properly validated template. It is time to build your first image. This
 is done by calling `packer build` with the template file. The output should look
 similar to below. Note that this process typically takes a few minutes.
 
+-&gt; **Note:** For the tutorial it is convenient to use the credentials in the
+command line. However, it is potentially insecure. [Learn how to set this
+securely](/docs/builders/amazon.html#specifying-amazon-credentials). For
+example, with a credentials profile, you can do this:
+`AWS_PROFILE=testing packer build example.json`.
+
 -&gt; **Note:** When using packer on Windows, replace the single-quotes in the 
 command below with double-quotes.
 

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -114,10 +114,8 @@ is done by calling `packer build` with the template file. The output should look
 similar to below. Note that this process typically takes a few minutes.
 
 -&gt; **Note:** For the tutorial it is convenient to use the credentials in the
-command line. However, it is potentially insecure. [Learn how to set this
-securely](/docs/builders/amazon.html#specifying-amazon-credentials). For
-example, with a credentials profile, you can do this:
-`AWS_PROFILE=testing packer build example.json`.
+command line. However, it is potentially insecure. See our documentation for
+other ways to [specify Amazon credentials](/docs/builders/amazon.html#specifying-amazon-credentials).
 
 -&gt; **Note:** When using packer on Windows, replace the single-quotes in the 
 command below with double-quotes.


### PR DESCRIPTION
Link to the documentation for new users who want to use AWS's existing credential infrastructure to stay secure.

The first thing I thought when I saw the example command was "There has to be a safer way to do this." There is, so put it in the intro to save Packer newbies some time.