### PR TITLE
Fix the reference to the "Dockerfiles" section

### DIFF
--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -21,7 +21,7 @@ Dockerfiles, Packer is able to provision containers with portable scripts or
 configuration management systems that are not tied to Docker in any way. It also
 has a simpler mental model: you provision containers much the same way you
 provision a normal virtualized or dedicated server. For more information, read
-the section on [Dockerfiles](#toc_8).
+the section on [Dockerfiles](#dockerfiles).
 
 The Docker builder must run on a machine that has Docker installed. Therefore
 the builder only works on machines that support Docker (modern Linux machines).
@@ -274,6 +274,8 @@ shown below:
 ```
 
 [Learn how to set Amazon AWS credentials.](/docs/builders/amazon.html#specifying-amazon-credentials)
+
+<span id="dockerfiles"></span>
 
 ## Dockerfiles
 


### PR DESCRIPTION
Add an explicit span with an id, and point to that. This should make it possible to actually click on the reference and end up in the right place.
