### PR TITLE
builder/amazon: crash on tagging snapshot when snapshot_tags is unset

### DIFF
--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -96,10 +96,12 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 			}
 
 			// Override tags on snapshots
-			_, err = regionconn.CreateTags(&ec2.CreateTagsInput{
-				Resources: snapshotIds,
-				Tags:      snapshotTags,
-			})
+			if len(snapshotTags) > 0 {
+				_, err = regionconn.CreateTags(&ec2.CreateTagsInput{
+					Resources: snapshotIds,
+					Tags:      snapshotTags,
+				})
+			}
 			if err == nil {
 				return true, nil
 			}


### PR DESCRIPTION
Closes #4238