### PR TITLE
Saltstack bootstrapping: fallback on wget if curl failed for any reason

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -167,7 +167,8 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say("Provisioning with Salt...")
 	if !p.config.SkipBootstrap {
 		cmd := &packer.RemoteCmd{
-			Command: fmt.Sprintf("curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh"),
+			// Fallback on wget if curl failed for any reason (such as not being installed)
+			Command: fmt.Sprintf("curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh || wget -O /tmp/install_salt.sh https://bootstrap.saltstack.com"),
 		}
 		ui.Message(fmt.Sprintf("Downloading saltstack bootstrap to /tmp/install_salt.sh"))
 		if err = cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
The https://github.com/mitchellh/packer/pull/1787/commits/eb725844156c6b306969e69faf2fd69706e267ff change replaced `wget` by `curl` for `bootstrap-salt.sh` script downloading.

However, `curl` may not available on the source image used, as is the case with the official debian jessie EC2 images: 
https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie

What I propose is to implement a fallback on `wget` if the `curl` command failed for any reason,
such as not being installed.

The bootstrapping script already does that in fact: https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L735

An alternative may be to download the bootstrapping script locally then upload it the virtual machine (the EC2 instance in my case).

Best regards,
Patrick.