### PR TITLE
Openstack reauth

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -61,6 +61,9 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	// Get as much as possible from the end
 	ao, _ := openstack.AuthOptionsFromEnv()
 
+	// Make sure we reauth as needed
+	ao.AllowReauth = true
+
 	// Override values if we have them in our config
 	overrides := []struct {
 		From, To *string

--- a/vendor/github.com/rackspace/gophercloud/openstack/client.go
+++ b/vendor/github.com/rackspace/gophercloud/openstack/client.go
@@ -134,13 +134,17 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 		v3Client.Endpoint = endpoint
 	}
 
+	// copy the auth options to a local variable that we can change. `options`
+	// needs to stay as-is for reauth purposes
+	v3Options := options
+
 	var scope *tokens3.Scope
 	if options.TenantID != "" {
 		scope = &tokens3.Scope{
 			ProjectID: options.TenantID,
 		}
-		options.TenantID = ""
-		options.TenantName = ""
+		v3Options.TenantID = ""
+		v3Options.TenantName = ""
 	} else {
 		if options.TenantName != "" {
 			scope = &tokens3.Scope{
@@ -148,11 +152,11 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 				DomainID:    options.DomainID,
 				DomainName:  options.DomainName,
 			}
-			options.TenantName = ""
+			v3Options.TenantName = ""
 		}
 	}
 
-	result := tokens3.Create(v3Client, options, scope)
+	result := tokens3.Create(v3Client, v3Options, scope)
 
 	token, err := result.ExtractToken()
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -583,10 +583,11 @@
 			"revision": "53d1dc4400e1ebcd37a0e01d8c1fe2f4db3b99d2"
 		},
 		{
-			"checksumSHA1": "Sr9NH+ww7ZTDfFJF8OBqMSeQfiE=",
+			"checksumSHA1": "KgPqSv4WKquMdM3Y0FxKIfqf/tw=",
 			"comment": "v1.0.0-810-g53d1dc4",
 			"path": "github.com/rackspace/gophercloud/openstack",
-			"revision": "53d1dc4400e1ebcd37a0e01d8c1fe2f4db3b99d2"
+			"revision": "69cc33768d3318e48fa47a216722d2737e84158b",
+			"revisionTime": "2016-04-06T18:51:52Z"
 		},
 		{
 			"checksumSHA1": "/K+RHJM5BFeg+3DYsR3WKPh7oVo=",


### PR DESCRIPTION
When using the OpenStack builder, builds exceeding the expiration time of Keystone API Tokens fail. This PR sets AllowReauth to True in the OpenStack builder so that tokens are reissued.

There is then also a bug in the keystone v3auth function used in the version of gophercloud used by packer. This bug has been fixed in later versions of gophercloud. In this PR, I've only included the changes I had to make to get the ReAuth function working with Keystone v3 in my OpenStack environment. It may be a good idea to try to realign packer with upstream gophercloud and test.

Closes #2928
