### PR TITLE
fix wait boot_command regex.

### DIFF
--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -144,7 +144,7 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<rightShift>"] = 0xFFE2
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
-	waitRe := regexp.MustCompile(`^<wait([0-9]+[hms])>`)
+	waitRe := regexp.MustCompile(`^<wait([0-9hms]+)>`)
 
 	// TODO(mitchellh): Ripe for optimizations of some point, perhaps.
 	for len(original) > 0 {


### PR DESCRIPTION
Previous regex matched at end of line, which meant we lost everything on the line if there was a wait at the end. This forces it to match the front of the line.

Resolves #4268