### PR TITLE
Add default facts for puppet-server provisioner

### DIFF
--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -90,6 +90,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		p.config.StagingDir = "/tmp/packer-puppet-server"
 	}
 
+	if p.config.Facter == nil {
+		p.config.Facter = make(map[string]string)
+	}
+	p.config.Facter["packer_build_name"] = p.config.PackerBuildName
+	p.config.Facter["packer_builder_type"] = p.config.PackerBuilderType
+
 	var errs *packer.MultiError
 	if p.config.ClientCertPath != "" {
 		info, err := os.Stat(p.config.ClientCertPath)

--- a/provisioner/puppet-server/provisioner_test.go
+++ b/provisioner/puppet-server/provisioner_test.go
@@ -91,3 +91,55 @@ func TestProvisionerPrepare_clientCertPath(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestProvisionerPrepare_facterFacts(t *testing.T) {
+	config := testConfig()
+
+	delete(config, "facter")
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Test with malformed fact
+	config["facter"] = "fact=stringified"
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should be an error")
+	}
+
+	// Test with a good one
+	td, err := ioutil.TempDir("", "packer")
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	defer os.RemoveAll(td)
+
+	facts := make(map[string]string)
+	facts["fact_name"] = "fact_value"
+	config["facter"] = facts
+
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Make sure the default facts are present
+	delete(config, "facter")
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if p.config.Facter == nil {
+		t.Fatalf("err: Default facts are not set in the Puppet provisioner!")
+	}
+
+	if _, ok := p.config.Facter["packer_build_name"]; !ok {
+		t.Fatalf("err: packer_build_name fact not set in the Puppet provisioner!")
+	}
+
+	if _, ok := p.config.Facter["packer_builder_type"]; !ok {
+		t.Fatalf("err: packer_builder_type fact not set in the Puppet provisioner!")
+	}
+}

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -94,3 +94,17 @@ listed below:
 		"{{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' {{end}}" +
 		"--detailed-exitcodes
 ```
+
+## Default Facts
+
+In addition to being able to specify custom Facter facts using the `facter`
+configuration, the provisioner automatically defines certain commonly useful
+facts:
+
+-   `packer_build_name` is set to the name of the build that Packer is running.
+    This is most useful when Packer is making multiple builds and you want to
+    distinguish them in your Hiera hierarchy.
+
+-   `packer_builder_type` is the type of the builder that was used to create the
+    machine that Puppet is running on. This is useful if you want to run only
+    certain parts of your Puppet code on systems built with certain builders.


### PR DESCRIPTION
This is a new feature.

Adding default facts to the puppet-server provisioner. New default facts are named packer_build_name and packer_builder_type. This feature was implemented for the puppet-masterless provisioner in #1878.

I was able to build the packer binary with the code changes that I made. I have not tested the changes yet. I am hoping to test the changes in the next day or two. I will also write some unit tests for this change.

Let me know if you see anything glaringly wrong with the proposed changes.