### PR TITLE
enable support for Google Compute XPN

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`
+	NetworkProjectId     string            `mapstructure:"network_project_id"`
 	OmitExternalIP       bool              `mapstructure:"omit_external_ip"`
 	Preemptible          bool              `mapstructure:"preemptible"`
 	RawStateTimeout      string            `mapstructure:"state_timeout"`

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -67,6 +67,7 @@ type InstanceConfig struct {
 	Metadata            map[string]string
 	Name                string
 	Network             string
+	NetworkProjectId    string
 	OmitExternalIP      bool
 	Preemptible         bool
 	Region              string

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/api/compute/v1"
+
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/version"
@@ -21,7 +23,6 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	"google.golang.org/api/compute/v1"
 )
 
 // driverGCE is a Driver implementation that actually talks to GCE.
@@ -297,8 +298,11 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 	// TODO(mitchellh): deprecation warnings
 
 	// Get the network
+	if c.NetworkProjectId == "" {
+		c.NetworkProjectId = d.projectId
+	}
 	d.ui.Message(fmt.Sprintf("Loading network: %s", c.Network))
-	network, err := d.service.Networks.Get(d.projectId, c.Network).Do()
+	network, err := d.service.Networks.Get(c.NetworkProjectId, c.Network).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +319,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 	subnetworkSelfLink := ""
 	if c.Subnetwork != "" {
 		d.ui.Message(fmt.Sprintf("Loading subnetwork: %s for region: %s", c.Subnetwork, c.Region))
-		subnetwork, err := d.service.Subnetworks.Get(d.projectId, c.Region, c.Subnetwork).Do()
+		subnetwork, err := d.service.Subnetworks.Get(c.NetworkProjectId, c.Region, c.Subnetwork).Do()
 		if err != nil {
 			return nil, err
 		}

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -108,6 +108,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Metadata:            metadata,
 		Name:                name,
 		Network:             c.Network,
+		NetworkProjectId:    c.NetworkProjectId,
 		OmitExternalIP:      c.OmitExternalIP,
 		Preemptible:         c.Preemptible,
 		Region:              c.Region,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -172,6 +172,9 @@ builder.
 -   `network` (string) - The Google Compute network to use for the
     launched instance. Defaults to `"default"`.
 
+-   'network_project_id' (string) - The project ID for the network and subnetwork
+    to use for launched instance. Defaults to `project_id`.
+
 -   `omit_external_ip` (boolean) - If true, the instance will not have an external IP.
     `use_internal_ip` must be true if this property is true.
 
@@ -192,13 +195,13 @@ builder.
 -   `source_image_project_id` (string) - The project ID of the
     project containing the source image.
 
--   `startup_script_file` (string) - The filepath to a startup script to run on 
+-   `startup_script_file` (string) - The filepath to a startup script to run on
     the VM from which the image will be made.
 
 -   `state_timeout` (string) - The time to wait for instance state changes.
     Defaults to `"5m"`.
 
--   `subnetwork` (string) - The Google Compute subnetwork to use for the launced
+-   `subnetwork` (string) - The Google Compute subnetwork to use for the launched
      instance. Only required if the `network` has been created with custom
      subnetting.
      Note, the region of the subnetwork must match the `region` or `zone` in


### PR DESCRIPTION
This change allows you to set a different project ID for the network to be used in creating the Packer instance in Google Compute Engine. This enable support support for the forthcoming XPN feature in GCE. https://cloud.google.com/sdk/gcloud/reference/alpha/compute/xpn/