### PR TITLE
Parallels: Fix style warnings

### DIFF
--- a/builder/parallels/common/artifact.go
+++ b/builder/parallels/common/artifact.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This is the common builder ID to all of these artifacts.
+// BuilderId is the common builder ID to all of these artifacts.
 const BuilderId = "packer.parallels"
 
 // These are the extensions of files and directories that are unnecessary for the function

--- a/builder/parallels/common/artifact.go
+++ b/builder/parallels/common/artifact.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"fmt"
-	"github.com/mitchellh/packer/packer"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/mitchellh/packer/packer"
 )
 
 // This is the common builder ID to all of these artifacts.

--- a/builder/parallels/common/artifact_test.go
+++ b/builder/parallels/common/artifact_test.go
@@ -25,7 +25,7 @@ func TestNewArtifact(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "b"), 0755); err != nil {
+	if err = os.Mkdir(filepath.Join(td, "b"), 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// A driver is able to talk to Parallels and perform certain
+// Driver is the interface that talks to Parallels and performs certain
 // operations with it. Some of the operations on here may seem overly
 // specific, but they were built specifically in mind to handle features
 // of the Parallels builder for Packer, and to abstract differences in

--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -20,7 +20,7 @@ type Driver interface {
 	CompactDisk(string) error
 
 	// Adds new CD/DVD drive to the VM and returns name of this device
-	DeviceAddCdRom(string, string) (string, error)
+	DeviceAddCDROM(string, string) (string, error)
 
 	// Get path to the first virtual disk image
 	DiskPath(string) (string, error)
@@ -38,7 +38,7 @@ type Driver interface {
 	Prlctl(...string) error
 
 	// Get the path to the Parallels Tools ISO for the given flavor.
-	ToolsIsoPath(string) (string, error)
+	ToolsISOPath(string) (string, error)
 
 	// Verify checks to make sure that this driver should function
 	// properly. If there is any indication the driver can't function,
@@ -55,10 +55,10 @@ type Driver interface {
 	SetDefaultConfiguration(string) error
 
 	// Finds the MAC address of the NIC nic0
-	Mac(string) (string, error)
+	MAC(string) (string, error)
 
 	// Finds the IP address of a VM connected that uses DHCP by its MAC address
-	IpAddress(string) (string, error)
+	IPAddress(string) (string, error)
 }
 
 func NewDriver() (Driver, error) {
@@ -66,7 +66,7 @@ func NewDriver() (Driver, error) {
 	var prlctlPath string
 	var prlsrvctlPath string
 	var supportedVersions []string
-	dhcp_lease_file := "/Library/Preferences/Parallels/parallels_dhcp_leases"
+	DHCPLeaseFile := "/Library/Preferences/Parallels/parallels_dhcp_leases"
 
 	if runtime.GOOS != "darwin" {
 		return nil, fmt.Errorf(
@@ -96,22 +96,22 @@ func NewDriver() (Driver, error) {
 	drivers = map[string]Driver{
 		"11": &Parallels11Driver{
 			Parallels9Driver: Parallels9Driver{
-				PrlctlPath:      prlctlPath,
-				PrlsrvctlPath:   prlsrvctlPath,
-				dhcp_lease_file: dhcp_lease_file,
+				PrlctlPath:    prlctlPath,
+				PrlsrvctlPath: prlsrvctlPath,
+				dhcpLeaseFile: DHCPLeaseFile,
 			},
 		},
 		"10": &Parallels10Driver{
 			Parallels9Driver: Parallels9Driver{
-				PrlctlPath:      prlctlPath,
-				PrlsrvctlPath:   prlsrvctlPath,
-				dhcp_lease_file: dhcp_lease_file,
+				PrlctlPath:    prlctlPath,
+				PrlsrvctlPath: prlsrvctlPath,
+				dhcpLeaseFile: DHCPLeaseFile,
 			},
 		},
 		"9": &Parallels9Driver{
-			PrlctlPath:      prlctlPath,
-			PrlsrvctlPath:   prlsrvctlPath,
-			dhcp_lease_file: dhcp_lease_file,
+			PrlctlPath:    prlctlPath,
+			PrlsrvctlPath: prlsrvctlPath,
+			dhcpLeaseFile: DHCPLeaseFile,
 		},
 	}
 

--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -61,6 +61,8 @@ type Driver interface {
 	IPAddress(string) (string, error)
 }
 
+// NewDriver returns a new driver implementation for this version of Parallels
+// Desktop, or an error if the driver couldn't be initialized.
 func NewDriver() (Driver, error) {
 	var drivers map[string]Driver
 	var prlctlPath string

--- a/builder/parallels/common/driver_10.go
+++ b/builder/parallels/common/driver_10.go
@@ -1,11 +1,11 @@
 package common
 
 // Parallels10Driver are inherited from Parallels9Driver.
-// Used for Parallels v 10 & 11
 type Parallels10Driver struct {
 	Parallels9Driver
 }
 
+// SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels10Driver) SetDefaultConfiguration(vmName string) error {
 	commands := make([][]string, 12)
 	commands[0] = []string{"set", vmName, "--cpus", "1"}

--- a/builder/parallels/common/driver_11.go
+++ b/builder/parallels/common/driver_11.go
@@ -12,6 +12,7 @@ type Parallels11Driver struct {
 	Parallels9Driver
 }
 
+// Verify raises an error if the builder could not be used on that host machine.
 func (d *Parallels11Driver) Verify() error {
 
 	stdout, err := exec.Command(d.PrlsrvctlPath, "info", "--license").Output()
@@ -35,6 +36,7 @@ func (d *Parallels11Driver) Verify() error {
 	return nil
 }
 
+// SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels11Driver) SetDefaultConfiguration(vmName string) error {
 	commands := make([][]string, 12)
 	commands[0] = []string{"set", vmName, "--cpus", "1"}

--- a/builder/parallels/common/driver_11.go
+++ b/builder/parallels/common/driver_11.go
@@ -24,13 +24,12 @@ func (d *Parallels11Driver) Verify() error {
 	if matches == nil {
 		return fmt.Errorf(
 			"Could not determine your Parallels Desktop edition using: %s info --license", d.PrlsrvctlPath)
-	} else {
-		switch matches[1] {
-		case "pro", "business":
-			break
-		default:
-			return fmt.Errorf("Packer can be used only with Parallels Desktop 11 Pro or Business edition. You use: %s edition", matches[1])
-		}
+	}
+	switch matches[1] {
+	case "pro", "business":
+		break
+	default:
+		return fmt.Errorf("Packer can be used only with Parallels Desktop 11 Pro or Business edition. You use: %s edition", matches[1])
 	}
 
 	return nil

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/xmlpath.v2"
 )
 
+// Parallels9Driver is a base type for Parallels builders.
 type Parallels9Driver struct {
 	// This is the path to the "prlctl" application.
 	PrlctlPath string
@@ -27,8 +28,8 @@ type Parallels9Driver struct {
 	dhcpLeaseFile string
 }
 
+// Import creates a clone of the source VM and reassigns the MAC address if needed.
 func (d *Parallels9Driver) Import(name, srcPath, dstDir string, reassignMAC bool) error {
-
 	err := d.Prlctl("register", srcPath, "--preserve-uuid")
 	if err != nil {
 		return err
@@ -111,6 +112,7 @@ func getAppPath(bundleID string) (string, error) {
 	return pathOutput, nil
 }
 
+// CompactDisk performs the compation of the specified virtual disk image.
 func (d *Parallels9Driver) CompactDisk(diskPath string) error {
 	prlDiskToolPath, err := exec.LookPath("prl_disk_tool")
 	if err != nil {
@@ -138,6 +140,7 @@ func (d *Parallels9Driver) CompactDisk(diskPath string) error {
 	return nil
 }
 
+// DeviceAddCDROM adds a virtual CDROM device and attaches the specified image.
 func (d *Parallels9Driver) DeviceAddCDROM(name string, image string) (string, error) {
 	command := []string{
 		"set", name,
@@ -161,6 +164,7 @@ func (d *Parallels9Driver) DeviceAddCDROM(name string, image string) (string, er
 	return deviceName, nil
 }
 
+// DiskPath returns a full path to the first virtual disk drive.
 func (d *Parallels9Driver) DiskPath(name string) (string, error) {
 	out, err := exec.Command(d.PrlctlPath, "list", "-i", name).Output()
 	if err != nil {
@@ -178,6 +182,7 @@ func (d *Parallels9Driver) DiskPath(name string) (string, error) {
 	return HDDPath, nil
 }
 
+// IsRunning determines whether the VM is running or not.
 func (d *Parallels9Driver) IsRunning(name string) (bool, error) {
 	var stdout bytes.Buffer
 
@@ -208,6 +213,7 @@ func (d *Parallels9Driver) IsRunning(name string) (bool, error) {
 	return false, nil
 }
 
+// Stop forcibly stops the VM.
 func (d *Parallels9Driver) Stop(name string) error {
 	if err := d.Prlctl("stop", name); err != nil {
 		return err
@@ -219,6 +225,7 @@ func (d *Parallels9Driver) Stop(name string) error {
 	return nil
 }
 
+// Prlctl executes the specified "prlctl" command.
 func (d *Parallels9Driver) Prlctl(args ...string) error {
 	var stdout, stderr bytes.Buffer
 
@@ -241,10 +248,12 @@ func (d *Parallels9Driver) Prlctl(args ...string) error {
 	return err
 }
 
+// Verify raises an error if the builder could not be used on that host machine.
 func (d *Parallels9Driver) Verify() error {
 	return nil
 }
 
+// Version returns the version of Parallels Desktop installed on that host.
 func (d *Parallels9Driver) Version() (string, error) {
 	out, err := exec.Command(d.PrlctlPath, "--version").Output()
 	if err != nil {
@@ -263,6 +272,8 @@ func (d *Parallels9Driver) Version() (string, error) {
 	return version, nil
 }
 
+// SendKeyScanCodes sends the specified scancodes as key events to the VM.
+// It is performed using "Prltype" script (refer to "prltype.go").
 func (d *Parallels9Driver) SendKeyScanCodes(vmName string, codes ...string) error {
 	var stdout, stderr bytes.Buffer
 
@@ -312,6 +323,7 @@ func prepend(head string, tail []string) []string {
 	return tmp
 }
 
+// SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels9Driver) SetDefaultConfiguration(vmName string) error {
 	commands := make([][]string, 7)
 	commands[0] = []string{"set", vmName, "--cpus", "1"}
@@ -331,6 +343,7 @@ func (d *Parallels9Driver) SetDefaultConfiguration(vmName string) error {
 	return nil
 }
 
+// MAC returns the MAC address of the VM's first network interface.
 func (d *Parallels9Driver) MAC(vmName string) (string, error) {
 	var stdout bytes.Buffer
 
@@ -394,6 +407,8 @@ func (d *Parallels9Driver) IPAddress(mac string) (string, error) {
 	return mostRecentIP, nil
 }
 
+// ToolsISOPath returns a full path to the Parallels Tools ISO for the specified guest
+// OS type. The following OS types are supported: "win", "lin", "mac", "other".
 func (d *Parallels9Driver) ToolsISOPath(k string) (string, error) {
 	appPath, err := getAppPath("com.parallels.desktop.console")
 	if err != nil {

--- a/builder/parallels/common/driver_9_test.go
+++ b/builder/parallels/common/driver_9_test.go
@@ -10,7 +10,7 @@ func TestParallels9Driver_impl(t *testing.T) {
 	var _ Driver = new(Parallels9Driver)
 }
 
-func TestIpAddress(t *testing.T) {
+func TestIPAddress(t *testing.T) {
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -18,11 +18,11 @@ func TestIpAddress(t *testing.T) {
 	defer os.Remove(tf.Name())
 
 	d := Parallels9Driver{
-		dhcp_lease_file: tf.Name(),
+		dhcpLeaseFile: tf.Name(),
 	}
 
 	// No lease should be found in an empty file
-	ip, err := d.IpAddress("123456789012")
+	ip, err := d.IPAddress("123456789012")
 	if err == nil {
 		t.Fatalf("Found IP: \"%v\". No IP should be found!\n", ip)
 	}
@@ -35,7 +35,7 @@ func TestIpAddress(t *testing.T) {
 10.211.55.254="1411712008,1800,001c42a51419,01001c42a51419"
 `)
 	ioutil.WriteFile(tf.Name(), c, 0666)
-	ip, err = d.IpAddress("001C4235240c")
+	ip, err = d.IPAddress("001C4235240c")
 	if err != nil {
 		t.Fatalf("Error: %v\n", err)
 	}
@@ -50,7 +50,7 @@ func TestIpAddress(t *testing.T) {
 10.211.55.254="1411712008,1800,001c42a51419,01001c42a51419"
 `)
 	ioutil.WriteFile(tf.Name(), c, 0666)
-	ip, err = d.IpAddress("001c4235240c")
+	ip, err = d.IPAddress("001c4235240c")
 	if err != nil {
 		t.Fatalf("Error: %v\n", err)
 	}

--- a/builder/parallels/common/driver_mock.go
+++ b/builder/parallels/common/driver_mock.go
@@ -9,11 +9,11 @@ type DriverMock struct {
 	CompactDiskPath   string
 	CompactDiskErr    error
 
-	DeviceAddCdRomCalled bool
-	DeviceAddCdRomName   string
-	DeviceAddCdRomImage  string
-	DeviceAddCdRomResult string
-	DeviceAddCdRomErr    error
+	DeviceAddCDROMCalled bool
+	DeviceAddCDROMName   string
+	DeviceAddCDROMImage  string
+	DeviceAddCDROMResult string
+	DeviceAddCDROMErr    error
 
 	DiskPathCalled bool
 	DiskPathName   string
@@ -49,18 +49,18 @@ type DriverMock struct {
 	SetDefaultConfigurationCalled bool
 	SetDefaultConfigurationError  error
 
-	ToolsIsoPathCalled bool
-	ToolsIsoPathFlavor string
-	ToolsIsoPathResult string
-	ToolsIsoPathErr    error
+	ToolsISOPathCalled bool
+	ToolsISOPathFlavor string
+	ToolsISOPathResult string
+	ToolsISOPathErr    error
 
-	MacName   string
-	MacReturn string
-	MacError  error
+	MACName   string
+	MACReturn string
+	MACError  error
 
-	IpAddressMac    string
-	IpAddressReturn string
-	IpAddressError  error
+	IPAddressMAC    string
+	IPAddressReturn string
+	IPAddressError  error
 }
 
 func (d *DriverMock) CompactDisk(path string) error {
@@ -69,11 +69,11 @@ func (d *DriverMock) CompactDisk(path string) error {
 	return d.CompactDiskErr
 }
 
-func (d *DriverMock) DeviceAddCdRom(name string, image string) (string, error) {
-	d.DeviceAddCdRomCalled = true
-	d.DeviceAddCdRomName = name
-	d.DeviceAddCdRomImage = image
-	return d.DeviceAddCdRomResult, d.DeviceAddCdRomErr
+func (d *DriverMock) DeviceAddCDROM(name string, image string) (string, error) {
+	d.DeviceAddCDROMCalled = true
+	d.DeviceAddCDROMName = name
+	d.DeviceAddCDROMImage = image
+	return d.DeviceAddCDROMResult, d.DeviceAddCDROMErr
 }
 
 func (d *DriverMock) DiskPath(name string) (string, error) {
@@ -82,7 +82,7 @@ func (d *DriverMock) DiskPath(name string) (string, error) {
 	return d.DiskPathResult, d.DiskPathErr
 }
 
-func (d *DriverMock) Import(name, srcPath, dstPath string, reassignMac bool) error {
+func (d *DriverMock) Import(name, srcPath, dstPath string, reassignMAC bool) error {
 	d.ImportCalled = true
 	d.ImportName = name
 	d.ImportSrcPath = srcPath
@@ -136,18 +136,18 @@ func (d *DriverMock) SetDefaultConfiguration(name string) error {
 	return d.SetDefaultConfigurationError
 }
 
-func (d *DriverMock) Mac(name string) (string, error) {
-	d.MacName = name
-	return d.MacReturn, d.MacError
+func (d *DriverMock) MAC(name string) (string, error) {
+	d.MACName = name
+	return d.MACReturn, d.MACError
 }
 
-func (d *DriverMock) IpAddress(mac string) (string, error) {
-	d.IpAddressMac = mac
-	return d.IpAddressReturn, d.IpAddressError
+func (d *DriverMock) IPAddress(mac string) (string, error) {
+	d.IPAddressMAC = mac
+	return d.IPAddressReturn, d.IPAddressError
 }
 
-func (d *DriverMock) ToolsIsoPath(flavor string) (string, error) {
-	d.ToolsIsoPathCalled = true
-	d.ToolsIsoPathFlavor = flavor
-	return d.ToolsIsoPathResult, d.ToolsIsoPathErr
+func (d *DriverMock) ToolsISOPath(flavor string) (string, error) {
+	d.ToolsISOPathCalled = true
+	d.ToolsISOPathFlavor = flavor
+	return d.ToolsISOPathResult, d.ToolsISOPathErr
 }

--- a/builder/parallels/common/host_ip.go
+++ b/builder/parallels/common/host_ip.go
@@ -1,6 +1,6 @@
 package common
 
-// Interface to help find the host IP that is available from within
+// HostIPFinder allows to find the host IP that is available from within
 // the Parallels virtual machines.
 type HostIPFinder interface {
 	HostIP() (string, error)

--- a/builder/parallels/common/host_ip_ifconfig.go
+++ b/builder/parallels/common/host_ip_ifconfig.go
@@ -13,6 +13,8 @@ type IfconfigIPFinder struct {
 	Devices []string
 }
 
+// HostIP returns the host's IP address or an error if it could not be found
+// from the `ifconfig` output.
 func (f *IfconfigIPFinder) HostIP() (string, error) {
 	var ifconfigPath string
 

--- a/builder/parallels/common/host_ip_ifconfig.go
+++ b/builder/parallels/common/host_ip_ifconfig.go
@@ -50,5 +50,5 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 			}
 		}
 	}
-	return "", errors.New("IP not found in ifconfig output...")
+	return "", errors.New("IP not found in ifconfig output")
 }

--- a/builder/parallels/common/output_config.go
+++ b/builder/parallels/common/output_config.go
@@ -9,10 +9,12 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// OutputConfig contains the configuration for builder's output.
 type OutputConfig struct {
 	OutputDir string `mapstructure:"output_directory"`
 }
 
+// Prepare configures the output directory or returns an error if it already exists.
 func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {
 	if c.OutputDir == "" {
 		c.OutputDir = fmt.Sprintf("output-%s", pc.PackerBuildName)

--- a/builder/parallels/common/output_config_test.go
+++ b/builder/parallels/common/output_config_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/packer/common"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/packer/common"
 )
 
 func TestOutputConfigPrepare(t *testing.T) {

--- a/builder/parallels/common/prlctl_config.go
+++ b/builder/parallels/common/prlctl_config.go
@@ -4,10 +4,13 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// PrlctlConfig contains the configuration for running "prlctl" commands
+// before the VM start.
 type PrlctlConfig struct {
 	Prlctl [][]string `mapstructure:"prlctl"`
 }
 
+// Prepare sets the default value of "Prlctl" property.
 func (c *PrlctlConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.Prlctl == nil {
 		c.Prlctl = make([][]string, 0)

--- a/builder/parallels/common/prlctl_post_config.go
+++ b/builder/parallels/common/prlctl_post_config.go
@@ -4,10 +4,13 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// PrlctlPostConfig contains the configuration for running "prlctl" commands
+// in the end of artifact build.
 type PrlctlPostConfig struct {
 	PrlctlPost [][]string `mapstructure:"prlctl_post"`
 }
 
+// Prepare sets the default value of "PrlctlPost" property.
 func (c *PrlctlPostConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.PrlctlPost == nil {
 		c.PrlctlPost = make([][]string, 0)

--- a/builder/parallels/common/prlctl_version_config.go
+++ b/builder/parallels/common/prlctl_version_config.go
@@ -4,10 +4,12 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// PrlctlVersionConfig contains the configuration for `prlctl` version.
 type PrlctlVersionConfig struct {
 	PrlctlVersionFile string `mapstructure:"prlctl_version_file"`
 }
 
+// Prepare sets the default value of "PrlctlVersionFile" property.
 func (c *PrlctlVersionConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.PrlctlVersionFile == "" {
 		c.PrlctlVersionFile = ".prlctl_version"

--- a/builder/parallels/common/prltype.go
+++ b/builder/parallels/common/prltype.go
@@ -1,5 +1,7 @@
 package common
 
+// Prltype is a Python scrypt allowin to send scancodes to the VM. It requires
+// the module "prlsdkapi", which is bundled to Parallels Virtualization SDK.
 const Prltype string = `
 import sys
 import prlsdkapi

--- a/builder/parallels/common/run_config.go
+++ b/builder/parallels/common/run_config.go
@@ -7,12 +7,14 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// RunConfig contains the configuration for VM run.
 type RunConfig struct {
 	RawBootWait string `mapstructure:"boot_wait"`
 
 	BootWait time.Duration ``
 }
 
+// Prepare sets the configuration for VM run.
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.RawBootWait == "" {
 		c.RawBootWait = "10s"

--- a/builder/parallels/common/shutdown_config.go
+++ b/builder/parallels/common/shutdown_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// ShutdownConfig contains the configuration for VM shutdown.
 type ShutdownConfig struct {
 	ShutdownCommand    string `mapstructure:"shutdown_command"`
 	RawShutdownTimeout string `mapstructure:"shutdown_timeout"`
@@ -14,6 +15,7 @@ type ShutdownConfig struct {
 	ShutdownTimeout time.Duration ``
 }
 
+// Prepare sets default values to the VM shutdown configuration.
 func (c *ShutdownConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.RawShutdownTimeout == "" {
 		c.RawShutdownTimeout = "5m"

--- a/builder/parallels/common/ssh.go
+++ b/builder/parallels/common/ssh.go
@@ -11,12 +11,12 @@ func CommHost(state multistep.StateBag) (string, error) {
 	vmName := state.Get("vmName").(string)
 	driver := state.Get("driver").(Driver)
 
-	mac, err := driver.Mac(vmName)
+	mac, err := driver.MAC(vmName)
 	if err != nil {
 		return "", err
 	}
 
-	ip, err := driver.IpAddress(mac)
+	ip, err := driver.IPAddress(mac)
 	if err != nil {
 		return "", err
 	}

--- a/builder/parallels/common/ssh.go
+++ b/builder/parallels/common/ssh.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// CommHost returns the VM's IP address which should be used to access it by SSH.
 func CommHost(state multistep.StateBag) (string, error) {
 	vmName := state.Get("vmName").(string)
 	driver := state.Get("driver").(Driver)
@@ -24,6 +25,7 @@ func CommHost(state multistep.StateBag) (string, error) {
 	return ip, nil
 }
 
+// SSHConfigFunc returns SSH credentials to access the VM by SSH.
 func SSHConfigFunc(config SSHConfig) func(multistep.StateBag) (*ssh.ClientConfig, error) {
 	return func(state multistep.StateBag) (*ssh.ClientConfig, error) {
 		auth := []ssh.AuthMethod{

--- a/builder/parallels/common/ssh_config.go
+++ b/builder/parallels/common/ssh_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
+// SSHConfig contains the configuration for SSH communicator.
 type SSHConfig struct {
 	Comm communicator.Config `mapstructure:",squash"`
 
@@ -15,6 +16,7 @@ type SSHConfig struct {
 	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout"`
 }
 
+// Prepare sets the default values for SSH communicator properties.
 func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
 	// TODO: backwards compatibility, write fixer instead
 	if c.SSHWaitTimeout != 0 {

--- a/builder/parallels/common/step_attach_floppy.go
+++ b/builder/parallels/common/step_attach_floppy.go
@@ -35,22 +35,22 @@ func (s *StepAttachFloppy) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Deleting any current floppy disk...")
 	// Delete the floppy disk controller
-	del_command := []string{
+	delCommand := []string{
 		"set", vmName,
 		"--device-del", "fdd0",
 	}
 	// This will almost certainly fail with 'The fdd0 device does not exist.'
-	driver.Prlctl(del_command...)
+	driver.Prlctl(delCommand...)
 
 	ui.Say("Attaching floppy disk...")
 	// Attaching the floppy disk
-	add_command := []string{
+	addCommand := []string{
 		"set", vmName,
 		"--device-add", "fdd",
 		"--image", floppyPath,
 		"--connect",
 	}
-	if err := driver.Prlctl(add_command...); err != nil {
+	if err := driver.Prlctl(addCommand...); err != nil {
 		state.Put("error", fmt.Errorf("Error adding floppy: %s", err))
 		return multistep.ActionHalt
 	}

--- a/builder/parallels/common/step_attach_floppy.go
+++ b/builder/parallels/common/step_attach_floppy.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"log"
 )
 
 // This step attaches a floppy to the virtual machine.

--- a/builder/parallels/common/step_attach_floppy.go
+++ b/builder/parallels/common/step_attach_floppy.go
@@ -20,6 +20,8 @@ type StepAttachFloppy struct {
 	floppyPath string
 }
 
+// Run adds a virtual FDD device to the VM and attaches the image.
+// If the image is not specified, then this step will be skipped.
 func (s *StepAttachFloppy) Run(state multistep.StateBag) multistep.StepAction {
 	// Determine if we even have a floppy disk to attach
 	var floppyPath string
@@ -62,6 +64,7 @@ func (s *StepAttachFloppy) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup removes the virtual FDD device attached to the VM.
 func (s *StepAttachFloppy) Cleanup(state multistep.StateBag) {
 	driver := state.Get("driver").(Driver)
 	vmName := state.Get("vmName").(string)

--- a/builder/parallels/common/step_attach_floppy.go
+++ b/builder/parallels/common/step_attach_floppy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step attaches a floppy to the virtual machine.
+// StepAttachFloppy is a step that attaches a floppy to the virtual machine.
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_attach_floppy_test.go
+++ b/builder/parallels/common/step_attach_floppy_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/multistep"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/multistep"
 )
 
 func TestStepAttachFloppy_impl(t *testing.T) {

--- a/builder/parallels/common/step_attach_parallels_tools.go
+++ b/builder/parallels/common/step_attach_parallels_tools.go
@@ -43,7 +43,7 @@ func (s *StepAttachParallelsTools) Run(state multistep.StateBag) multistep.StepA
 	cdrom, err := driver.DeviceAddCDROM(vmName, parallelsToolsPath)
 
 	if err != nil {
-		err := fmt.Errorf("Error attaching Parallels Tools ISO: %s", err)
+		err = fmt.Errorf("Error attaching Parallels Tools ISO: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/parallels/common/step_attach_parallels_tools.go
+++ b/builder/parallels/common/step_attach_parallels_tools.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"log"
 )
 
 // This step attaches the Parallels Tools as an inserted CD onto
@@ -39,7 +40,7 @@ func (s *StepAttachParallelsTools) Run(state multistep.StateBag) multistep.StepA
 	// Attach the guest additions to the computer
 	ui.Say("Attaching Parallels Tools ISO to the new CD/DVD drive...")
 
-	cdrom, err := driver.DeviceAddCdRom(vmName, parallelsToolsPath)
+	cdrom, err := driver.DeviceAddCDROM(vmName, parallelsToolsPath)
 
 	if err != nil {
 		err := fmt.Errorf("Error attaching Parallels Tools ISO: %s", err)

--- a/builder/parallels/common/step_attach_parallels_tools.go
+++ b/builder/parallels/common/step_attach_parallels_tools.go
@@ -23,6 +23,8 @@ type StepAttachParallelsTools struct {
 	ParallelsToolsMode string
 }
 
+// Run adds a virtual CD-ROM device to the VM and attaches Parallels Tools ISO image.
+// If ISO image is not specified, then this step will be skipped.
 func (s *StepAttachParallelsTools) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
@@ -55,6 +57,7 @@ func (s *StepAttachParallelsTools) Run(state multistep.StateBag) multistep.StepA
 	return multistep.ActionContinue
 }
 
+// Cleanup removes the virtual CD-ROM device attached to the VM.
 func (s *StepAttachParallelsTools) Cleanup(state multistep.StateBag) {
 	if s.cdromDevice == "" {
 		return

--- a/builder/parallels/common/step_attach_parallels_tools.go
+++ b/builder/parallels/common/step_attach_parallels_tools.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step attaches the Parallels Tools as an inserted CD onto
-// the virtual machine.
+// StepAttachParallelsTools is a step that attaches Parallels Tools ISO image
+// as an inserted CD onto the virtual machine.
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_compact_disk.go
+++ b/builder/parallels/common/step_compact_disk.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
 )

--- a/builder/parallels/common/step_compact_disk.go
+++ b/builder/parallels/common/step_compact_disk.go
@@ -21,6 +21,7 @@ type StepCompactDisk struct {
 	Skip bool
 }
 
+// Run runs the compaction of the virtual disk attached to the VM.
 func (s *StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	vmName := state.Get("vmName").(string)
@@ -49,4 +50,5 @@ func (s *StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (*StepCompactDisk) Cleanup(multistep.StateBag) {}

--- a/builder/parallels/common/step_compact_disk.go
+++ b/builder/parallels/common/step_compact_disk.go
@@ -7,8 +7,8 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step removes all empty blocks from expanding Parallels virtual disks
-// and reduces the result disk size
+// StepCompactDisk is a step that removes all empty blocks from expanding
+// Parallels virtual disks and reduces the result disk size
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_compact_disk.go
+++ b/builder/parallels/common/step_compact_disk.go
@@ -34,7 +34,7 @@ func (s *StepCompactDisk) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say("Compacting the disk image")
 	diskPath, err := driver.DiskPath(vmName)
 	if err != nil {
-		err := fmt.Errorf("Error detecting virtual disk path: %s", err)
+		err = fmt.Errorf("Error detecting virtual disk path: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/parallels/common/step_output_dir.go
+++ b/builder/parallels/common/step_output_dir.go
@@ -20,6 +20,7 @@ type StepOutputDir struct {
 	success bool
 }
 
+// Run sets up the output directory.
 func (s *StepOutputDir) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
@@ -48,6 +49,7 @@ func (s *StepOutputDir) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup deletes the output directory.
 func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)

--- a/builder/parallels/common/step_output_dir_test.go
+++ b/builder/parallels/common/step_output_dir_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/multistep"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/multistep"
 )
 
 func testStepOutputDir(t *testing.T) *StepOutputDir {

--- a/builder/parallels/common/step_prepare_parallels_tools.go
+++ b/builder/parallels/common/step_prepare_parallels_tools.go
@@ -2,8 +2,9 @@ package common
 
 import (
 	"fmt"
-	"github.com/mitchellh/multistep"
 	"os"
+
+	"github.com/mitchellh/multistep"
 )
 
 // This step prepares parameters related to Parallels Tools.

--- a/builder/parallels/common/step_prepare_parallels_tools.go
+++ b/builder/parallels/common/step_prepare_parallels_tools.go
@@ -25,7 +25,7 @@ func (s *StepPrepareParallelsTools) Run(state multistep.StateBag) multistep.Step
 		return multistep.ActionContinue
 	}
 
-	path, err := driver.ToolsIsoPath(s.ParallelsToolsFlavor)
+	path, err := driver.ToolsISOPath(s.ParallelsToolsFlavor)
 
 	if err != nil {
 		state.Put("error", err)

--- a/builder/parallels/common/step_prepare_parallels_tools.go
+++ b/builder/parallels/common/step_prepare_parallels_tools.go
@@ -7,7 +7,8 @@ import (
 	"github.com/mitchellh/multistep"
 )
 
-// This step prepares parameters related to Parallels Tools.
+// StepPrepareParallelsTools is a step that prepares parameters related
+// to Parallels Tools.
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_prepare_parallels_tools.go
+++ b/builder/parallels/common/step_prepare_parallels_tools.go
@@ -20,6 +20,7 @@ type StepPrepareParallelsTools struct {
 	ParallelsToolsMode   string
 }
 
+// Run sets the value of "parallels_tools_path".
 func (s *StepPrepareParallelsTools) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 
@@ -46,4 +47,5 @@ func (s *StepPrepareParallelsTools) Run(state multistep.StateBag) multistep.Step
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (s *StepPrepareParallelsTools) Cleanup(multistep.StateBag) {}

--- a/builder/parallels/common/step_prepare_parallels_tools_test.go
+++ b/builder/parallels/common/step_prepare_parallels_tools_test.go
@@ -29,7 +29,7 @@ func TestStepPrepareParallelsTools(t *testing.T) {
 	driver := state.Get("driver").(*DriverMock)
 
 	// Mock results
-	driver.ToolsIsoPathResult = tf.Name()
+	driver.ToolsISOPathResult = tf.Name()
 
 	// Test the run
 	if action := step.Run(state); action != multistep.ActionContinue {
@@ -40,11 +40,11 @@ func TestStepPrepareParallelsTools(t *testing.T) {
 	}
 
 	// Test the driver
-	if !driver.ToolsIsoPathCalled {
+	if !driver.ToolsISOPathCalled {
 		t.Fatal("tools iso path should be called")
 	}
-	if driver.ToolsIsoPathFlavor != "foo" {
-		t.Fatalf("bad: %#v", driver.ToolsIsoPathFlavor)
+	if driver.ToolsISOPathFlavor != "foo" {
+		t.Fatalf("bad: %#v", driver.ToolsISOPathFlavor)
 	}
 
 	// Test the resulting state
@@ -75,8 +75,8 @@ func TestStepPrepareParallelsTools_disabled(t *testing.T) {
 	}
 
 	// Test the driver
-	if driver.ToolsIsoPathCalled {
-		t.Fatal("tools iso path should NOT be called")
+	if driver.ToolsISOPathCalled {
+		t.Fatal("tools ISO path should NOT be called")
 	}
 }
 
@@ -90,7 +90,7 @@ func TestStepPrepareParallelsTools_nonExist(t *testing.T) {
 	driver := state.Get("driver").(*DriverMock)
 
 	// Mock results
-	driver.ToolsIsoPathResult = "foo"
+	driver.ToolsISOPathResult = "foo"
 
 	// Test the run
 	if action := step.Run(state); action != multistep.ActionHalt {
@@ -101,11 +101,11 @@ func TestStepPrepareParallelsTools_nonExist(t *testing.T) {
 	}
 
 	// Test the driver
-	if !driver.ToolsIsoPathCalled {
+	if !driver.ToolsISOPathCalled {
 		t.Fatal("tools iso path should be called")
 	}
-	if driver.ToolsIsoPathFlavor != "foo" {
-		t.Fatalf("bad: %#v", driver.ToolsIsoPathFlavor)
+	if driver.ToolsISOPathFlavor != "foo" {
+		t.Fatalf("bad: %#v", driver.ToolsISOPathFlavor)
 	}
 
 	// Test the resulting state

--- a/builder/parallels/common/step_prlctl.go
+++ b/builder/parallels/common/step_prlctl.go
@@ -13,8 +13,8 @@ type commandTemplate struct {
 	Name string
 }
 
-// This step executes additional prlctl commands as specified by the
-// template.
+// StepPrlctl is a step that executes additional prlctl commands as specified
+// by the template.
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_prlctl.go
+++ b/builder/parallels/common/step_prlctl.go
@@ -48,7 +48,7 @@ func (s *StepPrlctl) Run(state multistep.StateBag) multistep.StepAction {
 			var err error
 			command[i], err = interpolate.Render(arg, &s.Ctx)
 			if err != nil {
-				err := fmt.Errorf("Error preparing prlctl command: %s", err)
+				err = fmt.Errorf("Error preparing prlctl command: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
@@ -57,7 +57,7 @@ func (s *StepPrlctl) Run(state multistep.StateBag) multistep.StepAction {
 
 		ui.Message(fmt.Sprintf("Executing: prlctl %s", strings.Join(command, " ")))
 		if err := driver.Prlctl(command...); err != nil {
-			err := fmt.Errorf("Error executing command: %s", err)
+			err = fmt.Errorf("Error executing command: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/parallels/common/step_prlctl.go
+++ b/builder/parallels/common/step_prlctl.go
@@ -13,7 +13,7 @@ type commandTemplate struct {
 	Name string
 }
 
-// StepPrlctl is a step that executes additional prlctl commands as specified
+// StepPrlctl is a step that executes additional `prlctl` commands as specified.
 // by the template.
 //
 // Uses:
@@ -27,6 +27,7 @@ type StepPrlctl struct {
 	Ctx      interpolate.Context
 }
 
+// Run executes `prlctl` commands.
 func (s *StepPrlctl) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
@@ -67,4 +68,5 @@ func (s *StepPrlctl) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (s *StepPrlctl) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels/common/step_run.go
+++ b/builder/parallels/common/step_run.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"time"
 )
 
 // This step starts the virtual machine.

--- a/builder/parallels/common/step_run.go
+++ b/builder/parallels/common/step_run.go
@@ -22,6 +22,7 @@ type StepRun struct {
 	vmName string
 }
 
+// Run starts the VM.
 func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
@@ -57,6 +58,7 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup stops the VM.
 func (s *StepRun) Cleanup(state multistep.StateBag) {
 	if s.vmName == "" {
 		return

--- a/builder/parallels/common/step_run.go
+++ b/builder/parallels/common/step_run.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step starts the virtual machine.
+// StepRun is a step that starts the virtual machine.
 //
 // Uses:
 //   driver Driver

--- a/builder/parallels/common/step_run.go
+++ b/builder/parallels/common/step_run.go
@@ -30,7 +30,7 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say("Starting the virtual machine...")
 	command := []string{"start", vmName}
 	if err := driver.Prlctl(command...); err != nil {
-		err := fmt.Errorf("Error starting VM: %s", err)
+		err = fmt.Errorf("Error starting VM: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/parallels/common/step_shutdown.go
+++ b/builder/parallels/common/step_shutdown.go
@@ -26,6 +26,7 @@ type StepShutdown struct {
 	Timeout time.Duration
 }
 
+// Run shuts down the VM.
 func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
 	driver := state.Get("driver").(Driver)
@@ -76,4 +77,5 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (s *StepShutdown) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels/common/step_shutdown.go
+++ b/builder/parallels/common/step_shutdown.go
@@ -37,7 +37,7 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 		log.Printf("Executing shutdown command: %s", s.Command)
 		cmd := &packer.RemoteCmd{Command: s.Command}
 		if err := cmd.StartWithUi(comm, ui); err != nil {
-			err := fmt.Errorf("Failed to send shutdown command: %s", err)
+			err = fmt.Errorf("Failed to send shutdown command: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -65,7 +65,7 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 	} else {
 		ui.Say("Halting the virtual machine...")
 		if err := driver.Stop(vmName); err != nil {
-			err := fmt.Errorf("Error stopping VM: %s", err)
+			err = fmt.Errorf("Error stopping VM: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/parallels/common/step_shutdown.go
+++ b/builder/parallels/common/step_shutdown.go
@@ -3,10 +3,11 @@ package common
 import (
 	"errors"
 	"fmt"
-	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/packer"
 	"log"
 	"time"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 // This step shuts down the machine. It first attempts to do so gracefully,

--- a/builder/parallels/common/step_shutdown.go
+++ b/builder/parallels/common/step_shutdown.go
@@ -10,8 +10,8 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step shuts down the machine. It first attempts to do so gracefully,
-// but ultimately forcefully shuts it down if that fails.
+// StepShutdown is a step that shuts down the machine. It first attempts to do
+// so gracefully, but ultimately forcefully shuts it down if that fails.
 //
 // Uses:
 //   communicator packer.Communicator

--- a/builder/parallels/common/step_shutdown_test.go
+++ b/builder/parallels/common/step_shutdown_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/packer"
 	"testing"
 	"time"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 func TestStepShutdown_impl(t *testing.T) {

--- a/builder/parallels/common/step_test.go
+++ b/builder/parallels/common/step_test.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"testing"
 )
 
 func testState(t *testing.T) multistep.StateBag {

--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -13,8 +13,6 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
-const KeyLeftShift uint32 = 0xFFE1
-
 type bootCommandTemplateData struct {
 	HTTPIP   string
 	HTTPPort uint

--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -19,8 +19,8 @@ type bootCommandTemplateData struct {
 	Name     string
 }
 
-// This step "types" the boot command into the VM via the prltype script, built on the
-// Parallels Virtualization SDK - Python API.
+// StepTypeBootCommand is a step that "types" the boot command into the VM via
+// the prltype script, built on the Parallels Virtualization SDK - Python API.
 //
 // Uses:
 //   driver Driver
@@ -48,7 +48,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 		pauseFn = state.Get("pauseFn").(multistep.DebugPauseFn)
 	}
 
-	hostIp := "0.0.0.0"
+	hostIP := "0.0.0.0"
 
 	if len(s.HostInterfaces) > 0 {
 		// Determine the host IP
@@ -61,13 +61,13 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
-		hostIp = ip
+		hostIP = ip
 	}
 
-	ui.Say(fmt.Sprintf("Host IP for the Parallels machine: %s", hostIp))
+	ui.Say(fmt.Sprintf("Host IP for the Parallels machine: %s", hostIP))
 
 	s.Ctx.Data = &bootCommandTemplateData{
-		hostIp,
+		hostIP,
 		httpPort,
 		s.VMName,
 	}
@@ -206,12 +206,12 @@ func scancodes(message string) []string {
 
 	scancodeMap := make(map[rune]uint)
 	for chars, start := range scancodeIndex {
-		var i uint = 0
+		var i uint
 		for len(chars) > 0 {
 			r, size := utf8.DecodeRuneInString(chars)
 			chars = chars[size:]
 			scancodeMap[r] = start + i
-			i += 1
+			i++
 		}
 	}
 

--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -58,7 +58,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 
 		ip, err := ipFinder.HostIP()
 		if err != nil {
-			err := fmt.Errorf("Error detecting host IP: %s", err)
+			err = fmt.Errorf("Error detecting host IP: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -78,7 +78,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 	for i, command := range s.BootCommand {
 		command, err := interpolate.Render(command, &s.Ctx)
 		if err != nil {
-			err := fmt.Errorf("Error preparing boot command: %s", err)
+			err = fmt.Errorf("Error preparing boot command: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -88,7 +88,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 		for _, code := range scancodes(command) {
 			if code == "wait" {
 				if err := driver.SendKeyScanCodes(s.VMName, codes...); err != nil {
-					err := fmt.Errorf("Error sending boot command: %s", err)
+					err = fmt.Errorf("Error sending boot command: %s", err)
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
@@ -100,7 +100,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 
 			if code == "wait5" {
 				if err := driver.SendKeyScanCodes(s.VMName, codes...); err != nil {
-					err := fmt.Errorf("Error sending boot command: %s", err)
+					err = fmt.Errorf("Error sending boot command: %s", err)
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
@@ -112,7 +112,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 
 			if code == "wait10" {
 				if err := driver.SendKeyScanCodes(s.VMName, codes...); err != nil {
-					err := fmt.Errorf("Error sending boot command: %s", err)
+					err = fmt.Errorf("Error sending boot command: %s", err)
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
@@ -136,7 +136,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 
 		log.Printf("Sending scancodes: %#v", codes)
 		if err := driver.SendKeyScanCodes(s.VMName, codes...); err != nil {
-			err := fmt.Errorf("Error sending boot command: %s", err)
+			err = fmt.Errorf("Error sending boot command: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -37,6 +37,7 @@ type StepTypeBootCommand struct {
 	Ctx            interpolate.Context
 }
 
+// Run types the boot command by sending key scancodes into the VM.
 func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction {
 	debug := state.Get("debug").(bool)
 	httpPort := state.Get("http_port").(uint)
@@ -144,6 +145,7 @@ func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (*StepTypeBootCommand) Cleanup(multistep.StateBag) {}
 
 func scancodes(message string) []string {

--- a/builder/parallels/common/step_type_boot_command_test.go
+++ b/builder/parallels/common/step_type_boot_command_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/packer"
 	"strings"
 	"testing"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 func TestStepTypeBootCommand(t *testing.T) {

--- a/builder/parallels/common/step_upload_parallels_tools.go
+++ b/builder/parallels/common/step_upload_parallels_tools.go
@@ -36,6 +36,7 @@ type StepUploadParallelsTools struct {
 	Ctx                     interpolate.Context
 }
 
+// Run uploads the Parallels Tools ISO to the VM.
 func (s *StepUploadParallelsTools) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
 	ui := state.Get("ui").(packer.Ui)
@@ -80,4 +81,5 @@ func (s *StepUploadParallelsTools) Run(state multistep.StateBag) multistep.StepA
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (s *StepUploadParallelsTools) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels/common/step_upload_parallels_tools.go
+++ b/builder/parallels/common/step_upload_parallels_tools.go
@@ -22,7 +22,13 @@ type toolsPathTemplate struct {
 	Flavor string
 }
 
-// This step uploads the guest additions ISO to the VM.
+// StepUploadParallelsTools is a step that uploads the Parallels Tools ISO
+// to the VM.
+//
+// Uses:
+//   communicator packer.Communicator
+//   parallels_tools_path string
+//   ui packer.Ui
 type StepUploadParallelsTools struct {
 	ParallelsToolsFlavor    string
 	ParallelsToolsGuestPath string

--- a/builder/parallels/common/step_upload_parallels_tools.go
+++ b/builder/parallels/common/step_upload_parallels_tools.go
@@ -56,7 +56,7 @@ func (s *StepUploadParallelsTools) Run(state multistep.StateBag) multistep.StepA
 
 	s.ParallelsToolsGuestPath, err = interpolate.Render(s.ParallelsToolsGuestPath, &s.Ctx)
 	if err != nil {
-		err := fmt.Errorf("Error preparing Parallels Tools path: %s", err)
+		err = fmt.Errorf("Error preparing Parallels Tools path: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -65,7 +65,7 @@ func (s *StepUploadParallelsTools) Run(state multistep.StateBag) multistep.StepA
 	ui.Say(fmt.Sprintf("Uploading Parallels Tools for '%s' to path: '%s'",
 		s.ParallelsToolsFlavor, s.ParallelsToolsGuestPath))
 	if err := comm.Upload(s.ParallelsToolsGuestPath, f, nil); err != nil {
-		err := fmt.Errorf("Error uploading Parallels Tools: %s", err)
+		err = fmt.Errorf("Error uploading Parallels Tools: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/parallels/common/step_upload_parallels_tools_test.go
+++ b/builder/parallels/common/step_upload_parallels_tools_test.go
@@ -1,9 +1,10 @@
 package common
 
 import (
+	"testing"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"testing"
 )
 
 func TestStepUploadParallelsTools_impl(t *testing.T) {

--- a/builder/parallels/common/step_upload_version.go
+++ b/builder/parallels/common/step_upload_version.go
@@ -3,9 +3,10 @@ package common
 import (
 	"bytes"
 	"fmt"
+	"log"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"log"
 )
 
 // This step uploads a file containing the Parallels version, which

--- a/builder/parallels/common/step_upload_version.go
+++ b/builder/parallels/common/step_upload_version.go
@@ -9,8 +9,13 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// This step uploads a file containing the Parallels version, which
-// can be useful for various provisioning reasons.
+// StepUploadVersion is a step that uploads a file containing the version of
+// Parallels Desktop, which can be useful for various provisioning reasons.
+//
+// Uses:
+//   communicator packer.Communicator
+//   driver Driver
+//   ui packer.Ui
 type StepUploadVersion struct {
 	Path string
 }

--- a/builder/parallels/common/step_upload_version.go
+++ b/builder/parallels/common/step_upload_version.go
@@ -20,6 +20,7 @@ type StepUploadVersion struct {
 	Path string
 }
 
+// Run uploads a file containing the version of Parallels Desktop.
 func (s *StepUploadVersion) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
 	driver := state.Get("driver").(Driver)
@@ -47,4 +48,5 @@ func (s *StepUploadVersion) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
+// Cleanup does nothing.
 func (s *StepUploadVersion) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels/common/step_upload_version_test.go
+++ b/builder/parallels/common/step_upload_version_test.go
@@ -1,9 +1,10 @@
 package common
 
 import (
+	"testing"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"testing"
 )
 
 func TestStepUploadVersion_impl(t *testing.T) {

--- a/builder/parallels/common/tools_config.go
+++ b/builder/parallels/common/tools_config.go
@@ -15,12 +15,14 @@ const (
 	ParallelsToolsModeUpload         = "upload"
 )
 
+// ToolsConfig contains the builder configuration related to Parallels Tools.
 type ToolsConfig struct {
 	ParallelsToolsFlavor    string `mapstructure:"parallels_tools_flavor"`
 	ParallelsToolsGuestPath string `mapstructure:"parallels_tools_guest_path"`
 	ParallelsToolsMode      string `mapstructure:"parallels_tools_mode"`
 }
 
+// Prepare validates & sets up configuration options related to Parallels Tools.
 func (c *ToolsConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.ParallelsToolsMode == "" {
 		c.ParallelsToolsMode = ParallelsToolsModeUpload

--- a/builder/parallels/common/tools_config.go
+++ b/builder/parallels/common/tools_config.go
@@ -53,7 +53,7 @@ func (c *ToolsConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.ParallelsToolsFlavor == "" {
 		if c.ParallelsToolsMode != ParallelsToolsModeDisable {
-			errs = append(errs, errors.New("parallels_tools_flavor must be specified."))
+			errs = append(errs, errors.New("parallels_tools_flavor must be specified"))
 		}
 	}
 

--- a/builder/parallels/iso/step_attach_iso.go
+++ b/builder/parallels/iso/step_attach_iso.go
@@ -2,10 +2,11 @@ package iso
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/mitchellh/multistep"
 	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	"github.com/mitchellh/packer/packer"
-	"log"
 )
 
 // This step attaches the ISO to the virtual machine.

--- a/builder/parallels/iso/step_attach_iso.go
+++ b/builder/parallels/iso/step_attach_iso.go
@@ -12,7 +12,7 @@ import (
 //
 // Uses:
 //   driver Driver
-//   isoPath string
+//   iso_path string
 //   ui packer.Ui
 //   vmName string
 //

--- a/builder/parallels/iso/step_create_disk.go
+++ b/builder/parallels/iso/step_create_disk.go
@@ -2,10 +2,11 @@ package iso
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/mitchellh/multistep"
 	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	"github.com/mitchellh/packer/packer"
-	"strconv"
 )
 
 // This step creates the virtual disk that will be used as the

--- a/builder/parallels/iso/step_set_boot_order.go
+++ b/builder/parallels/iso/step_set_boot_order.go
@@ -2,6 +2,7 @@ package iso
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/multistep"
 	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	"github.com/mitchellh/packer/packer"

--- a/builder/parallels/pvm/config.go
+++ b/builder/parallels/pvm/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	BootCommand []string `mapstructure:"boot_command"`
 	SourcePath  string   `mapstructure:"source_path"`
 	VMName      string   `mapstructure:"vm_name"`
-	ReassignMac bool     `mapstructure:"reassign_mac"`
+	ReassignMAC bool     `mapstructure:"reassign_mac"`
 
 	ctx interpolate.Context
 }

--- a/builder/parallels/pvm/step_import.go
+++ b/builder/parallels/pvm/step_import.go
@@ -20,7 +20,7 @@ func (s *StepImport) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 
 	ui.Say(fmt.Sprintf("Importing VM: %s", s.SourcePath))
-	if err := driver.Import(s.Name, s.SourcePath, config.OutputDir, config.ReassignMac); err != nil {
+	if err := driver.Import(s.Name, s.SourcePath, config.OutputDir, config.ReassignMAC); err != nil {
 		err := fmt.Errorf("Error importing VM: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/parallels/pvm/step_import.go
+++ b/builder/parallels/pvm/step_import.go
@@ -2,6 +2,7 @@ package pvm
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/multistep"
 	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	"github.com/mitchellh/packer/packer"

--- a/builder/parallels/pvm/step_test.go
+++ b/builder/parallels/pvm/step_test.go
@@ -2,10 +2,11 @@ package pvm
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/mitchellh/multistep"
 	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	"github.com/mitchellh/packer/packer"
-	"testing"
 )
 
 func testState(t *testing.T) multistep.StateBag {


### PR DESCRIPTION
This PR fixes most of style offenses in and warnings in `builder/parallels/**` pointed by [golint](https://github.com/golang/lint), [go vet](https://golang.org/cmd/vet/) and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)

- golint: Add comments for exported methods
- golint: Fix other lint offences
- Remove unused constant "KeyLeftShift" (from `builder/parallels/common/step_type_boot_command.go`)
- go vet: Fix shadowed declarations of variables
- goimports: Organize imports in groups
    https://github.com/golang/go/wiki/CodeReviewComments#imports
- golint: Use a consistent case for initialisms
    https://github.com/golang/go/wiki/CodeReviewComments#initialisms

cc @rickard-von-essen 