### PR TITLE
Add "iso_target_extension" option for all local *-iso builders

### DIFF
--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -314,7 +314,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Description:  "ISO",
 			ResultKey:    "iso_path",
 			Url:          b.config.ISOUrls,
-			Extension:    "iso",
+			Extension:    b.config.TargetExtension,
 			TargetPath:   b.config.TargetPath,
 		},
 		&common.StepCreateFloppy{

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -139,7 +139,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Checksum:     b.config.ISOChecksum,
 			ChecksumType: b.config.ISOChecksumType,
 			Description:  "ISO",
-			Extension:    "iso",
+			Extension:    b.config.TargetExtension,
 			ResultKey:    "iso_path",
 			TargetPath:   b.config.TargetPath,
 			Url:          b.config.ISOUrls,

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -348,7 +348,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Checksum:     b.config.ISOChecksum,
 			ChecksumType: b.config.ISOChecksumType,
 			Description:  "ISO",
-			Extension:    "iso",
+			Extension:    b.config.TargetExtension,
 			ResultKey:    "iso_path",
 			TargetPath:   b.config.TargetPath,
 			Url:          b.config.ISOUrls,

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -187,7 +187,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Checksum:     b.config.ISOChecksum,
 			ChecksumType: b.config.ISOChecksumType,
 			Description:  "ISO",
-			Extension:    "iso",
+			Extension:    b.config.TargetExtension,
 			ResultKey:    "iso_path",
 			TargetPath:   b.config.TargetPath,
 			Url:          b.config.ISOUrls,

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -222,7 +222,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Checksum:     b.config.ISOChecksum,
 			ChecksumType: b.config.ISOChecksumType,
 			Description:  "ISO",
-			Extension:    "iso",
+			Extension:    b.config.TargetExtension,
 			ResultKey:    "iso_path",
 			TargetPath:   b.config.TargetPath,
 			Url:          b.config.ISOUrls,

--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -21,6 +21,7 @@ type ISOConfig struct {
 	ISOChecksumType string   `mapstructure:"iso_checksum_type"`
 	ISOUrls         []string `mapstructure:"iso_urls"`
 	TargetPath      string   `mapstructure:"iso_target_path"`
+	TargetExtension string   `mapstructure:"iso_target_extension"`
 	RawSingleISOUrl string   `mapstructure:"iso_url"`
 }
 
@@ -118,6 +119,11 @@ func (c *ISOConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs [
 			c.ISOUrls[i] = url
 		}
 	}
+
+	if c.TargetExtension == "" {
+		c.TargetExtension = "iso"
+	}
+	c.TargetExtension = strings.ToLower(c.TargetExtension)
 
 	// Warnings
 	if c.ISOChecksumType == "none" {

--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -284,3 +284,35 @@ func TestISOConfigPrepare_ISOUrl(t *testing.T) {
 		t.Fatalf("bad: %#v", i.ISOUrls)
 	}
 }
+
+func TestISOConfigPrepare_TargetExtension(t *testing.T) {
+	i := testISOConfig()
+
+	// Test the default value
+	warns, err := i.Prepare(nil)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if i.TargetExtension != "iso" {
+		t.Fatalf("should've found \"iso\" got: %s", i.TargetExtension)
+	}
+
+	// Test the lowercased value
+	i = testISOConfig()
+	i.TargetExtension = "DMG"
+	warns, err = i.Prepare(nil)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if i.TargetExtension != "dmg" {
+		t.Fatalf("should've lowercased: %s", i.TargetExtension)
+	}
+}

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -152,6 +152,9 @@ builder.
     to force the HTTP server to be on one port, make this minimum and maximum
     port the same. By default the values are 8000 and 9000, respectively.
 
+-   `iso_target_extension` (string) - The extension of the iso file after
+    download. This defaults to "iso".
+
 -   `iso_target_path` (string) - The path where the iso should be saved after
     download. By default will go in the packer cache, with a hash of the
     original filename as its name.

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -197,6 +197,9 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 -   `iso_skip_cache` (boolean) - Use iso from provided url. Qemu must support
     curl block device. This defaults to `false`.
 
+-   `iso_target_extension` (string) - The extension of the iso file after
+    download. This defaults to "iso".
+
 -   `iso_target_path` (string) - The path where the iso should be saved after
     download. By default will go in the packer cache, with a hash of the
     original filename as its name.

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -230,6 +230,9 @@ builder.
     to, defaults to "ide". When set to "sata", the drive is attached to an AHCI
     SATA controller.
 
+-   `iso_target_extension` (string) - The extension of the iso file after
+    download. This defaults to "iso".
+
 -   `iso_target_path` (string) - The path where the iso should be saved
     after download. By default will go in the packer cache, with a hash of the
     original filename as its name.

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -161,6 +161,9 @@ builder.
     to force the HTTP server to be on one port, make this minimum and maximum
     port the same. By default the values are 8000 and 9000, respectively.
 
+-   `iso_target_extension` (string) - The extension of the iso file after
+    download. This defaults to "iso".
+
 -   `iso_target_path` (string) - The path where the iso should be saved after
     download. By default will go in the packer cache, with a hash of the
     original filename as its name.


### PR DESCRIPTION
The newly added option `iso_target_extension` allows setting the extension of the ISO file after download.Defaults to `"iso"`. 
It makes sense for building Mac OS X guests, where the
bootable image is actually a DMG, not an ISO.
In particular, it is important for `parallels-iso` builder to set the right extension.

Closes #4248