### PR TITLE
builders/openstack: fix for finding resource by ID.

### DIFF
--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -64,6 +64,7 @@ func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction
 		AvailabilityZone: s.AvailabilityZone,
 		UserData:         userData,
 		ConfigDrive:      &s.ConfigDrive,
+		ServiceClient:    computeClient,
 	}
 
 	var serverOptsExt servers.CreateOptsBuilder


### PR DESCRIPTION
Pass server serviceClient to create params so it can look up resources by ID.
Resolves #4299