### PR TITLE
builder/amazon: Crashes when multiple EBS vols are used

### DIFF
--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -68,7 +68,8 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	snapshots := make(map[string][]string)
 	for _, blockDeviceMapping := range imagesResp.Images[0].BlockDeviceMappings {
-		if blockDeviceMapping.Ebs != nil {
+		if blockDeviceMapping.Ebs != nil && blockDeviceMapping.Ebs.SnapshotId != nil {
+
 			snapshots[*ec2conn.Config.Region] = append(snapshots[*ec2conn.Config.Region], *blockDeviceMapping.Ebs.SnapshotId)
 		}
 	}


### PR DESCRIPTION
If you use a new EBS vol (which hasn't any snapshot) Packer crashes when
creating the AMI.

Closes #4303