### PR TITLE
WIP: Add support for ENA in addition to SR-IOV networking #3688

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -212,9 +212,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if !b.config.FromScratch {
 		steps = append(steps,
 			&awscommon.StepSourceAMIInfo{
-				SourceAmi:          b.config.SourceAmi,
-				EnhancedNetworking: b.config.AMIEnhancedNetworking,
-				AmiFilters:         b.config.SourceAmiFilter,
+				SourceAmi:              b.config.SourceAmi,
+				EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
+				AmiFilters:             b.config.SourceAmiFilter,
 			},
 			&StepCheckRootDevice{},
 		)

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -76,8 +76,13 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
-	if config.AMIEnhancedNetworking {
+	if config.AMIEnhancedNetworkingType == "sriov" {
 		registerOpts.SriovNetSupport = aws.String("simple")
+	}
+
+	// Set EnaSupport
+	if config.AMIEnhancedNetworkingType == "ena" {
+		registerOpts.EnaSupport = aws.Bool(true)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -8,23 +8,23 @@ import (
 
 // AMIConfig is for common configuration related to creating AMIs.
 type AMIConfig struct {
-	AMIName                 string            `mapstructure:"ami_name"`
-	AMIDescription          string            `mapstructure:"ami_description"`
-	AMIVirtType             string            `mapstructure:"ami_virtualization_type"`
-	AMIUsers                []string          `mapstructure:"ami_users"`
-	AMIGroups               []string          `mapstructure:"ami_groups"`
-	AMIProductCodes         []string          `mapstructure:"ami_product_codes"`
-	AMIRegions              []string          `mapstructure:"ami_regions"`
-	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
-	AMITags                 map[string]string `mapstructure:"tags"`
-	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
-	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
-	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
-	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
-	AMIKmsKeyId             string            `mapstructure:"kms_key_id"`
-	SnapshotTags            map[string]string `mapstructure:"snapshot_tags"`
-	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
-	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
+	AMIName                   string            `mapstructure:"ami_name"`
+	AMIDescription            string            `mapstructure:"ami_description"`
+	AMIVirtType               string            `mapstructure:"ami_virtualization_type"`
+	AMIUsers                  []string          `mapstructure:"ami_users"`
+	AMIGroups                 []string          `mapstructure:"ami_groups"`
+	AMIProductCodes           []string          `mapstructure:"ami_product_codes"`
+	AMIRegions                []string          `mapstructure:"ami_regions"`
+	AMISkipRegionValidation   bool              `mapstructure:"skip_region_validation"`
+	AMITags                   map[string]string `mapstructure:"tags"`
+	AMIEnhancedNetworkingType string            `mapstructure:"enhanced_networking_type"`
+	AMIForceDeregister        bool              `mapstructure:"force_deregister"`
+	AMIForceDeleteSnapshot    bool              `mapstructure:"force_delete_snapshot"`
+	AMIEncryptBootVolume      bool              `mapstructure:"encrypt_boot"`
+	AMIKmsKeyId               string            `mapstructure:"kms_key_id"`
+	SnapshotTags              map[string]string `mapstructure:"snapshot_tags"`
+	SnapshotUsers             []string          `mapstructure:"snapshot_users"`
+	SnapshotGroups            []string          `mapstructure:"snapshot_groups"`
 }
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/amazon/common/step_modify_ebs_instance.go
+++ b/builder/amazon/common/step_modify_ebs_instance.go
@@ -9,7 +9,7 @@ import (
 )
 
 type StepModifyEBSBackedInstance struct {
-	EnableEnhancedNetworking bool
+	EnhancedNetworkingType string
 }
 
 func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.StepAction {
@@ -17,16 +17,32 @@ func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.St
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packer.Ui)
 
+	// Set EnaSupport to true.
+	if s.EnhancedNetworkingType == "ena" {
+		ui.Say("Enabling ENA support...")
+		truthy := true
+		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
+			InstanceId: instance.InstanceId,
+			EnaSupport: &ec2.AttributeBooleanValue{Value: &truthy},
+		})
+		if err != nil {
+			err := fmt.Errorf("Error enabling ENA support on %s: %s", *instance.InstanceId, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
-	if s.EnableEnhancedNetworking {
-		ui.Say("Enabling Enhanced Networking...")
+	if s.EnhancedNetworkingType == "sriov" {
+		ui.Say("Enabling SR-IOV support...")
 		simple := "simple"
 		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 			InstanceId:      instance.InstanceId,
 			SriovNetSupport: &ec2.AttributeValue{Value: &simple},
 		})
 		if err != nil {
-			err := fmt.Errorf("Error enabling Enhanced Networking on %s: %s", *instance.InstanceId, err)
+			err := fmt.Errorf("Error enabling SR-IOV support on %s: %s", *instance.InstanceId, err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -17,9 +17,9 @@ import (
 // Produces:
 //   source_image *ec2.Image - the source AMI info
 type StepSourceAMIInfo struct {
-	SourceAmi          string
-	EnhancedNetworking bool
-	AmiFilters         AmiFilterOptions
+	SourceAmi              string
+	EnhancedNetworkingType string
+	AmiFilters             AmiFilterOptions
 }
 
 // Build a slice of AMI filter options from the filters provided.
@@ -103,7 +103,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Enhanced Networking (SriovNetSupport) can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5
-	if s.EnhancedNetworking && *image.VirtualizationType != "hvm" {
+	if (s.EnhancedNetworkingType == "sriov" || s.EnhancedNetworkingType == "ena") && *image.VirtualizationType != "hvm" {
 		err := fmt.Errorf("Cannot enable enhanced networking, source AMI '%s' is not HVM", s.SourceAmi)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -101,9 +101,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:              b.config.SourceAmi,
+			EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
+			AmiFilters:             b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -163,7 +163,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
 		},
 		&awscommon.StepDeregisterAMI{
 			ForceDeregister:     b.config.AMIForceDeregister,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -25,8 +25,8 @@ type Config struct {
 	awscommon.AccessConfig `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
 
-	VolumeMappings        []BlockDevice `mapstructure:"ebs_volumes"`
-	AMIEnhancedNetworking bool          `mapstructure:"enhanced_networking"`
+	VolumeMappings            []BlockDevice `mapstructure:"ebs_volumes"`
+	AMIEnhancedNetworkingType string        `mapstructure:"enhanced_networking_type"`
 
 	ctx interpolate.Context
 }
@@ -95,9 +95,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:              b.config.SourceAmi,
+			EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
+			AmiFilters:             b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -154,7 +154,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
 		},
 	}
 

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -191,9 +191,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:              b.config.SourceAmi,
+			EnhancedNetworkingType: b.config.AMIEnhancedNetworkingType,
+			AmiFilters:             b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -30,8 +30,13 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
-	if config.AMIEnhancedNetworking {
+	if config.AMIEnhancedNetworkingType == "sriov" {
 		registerOpts.SriovNetSupport = aws.String("simple")
+	}
+
+	// Set EnaSupport to true.
+	if config.AMIEnhancedNetworkingType == "ena" {
+		registerOpts.EnaSupport = aws.Bool(true)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)


### PR DESCRIPTION
Amazon added a new Elastic Network Adapter (ENA) that requires different flags on instances and images.  I needed support for this, so whipped up this quick patch.   There are some things missing, like tests and backwards compatibility, which I'll gladly tackle.  I wanted to get some eyeballs on this first, as it makes some changes to packer configurations (based on suggestions in #3688).

This change removes the `enhanced_networking` setting and replaces it with `enhanced_networking_type`.  Valid options are `sriov` and `ena`.  Note there is no validation yet either, probably something worth adding.
