### PR TITLE
Add -NoProfile switch for PowerShell execution

### DIFF
--- a/common/powershell/powershell.go
+++ b/common/powershell/powershell.go
@@ -138,15 +138,17 @@ func saveScript(fileContents string) (string, error) {
 }
 
 func createArgs(filename string, params ...string) []string {
-	args := make([]string, len(params)+4)
+	args := make([]string, len(params)+5)
 	args[0] = "-ExecutionPolicy"
 	args[1] = "Bypass"
 
-	args[2] = "-File"
-	args[3] = filename
+	args[2] = "-NoProfile"
+
+	args[3] = "-File"
+	args[4] = filename
 
 	for key, value := range params {
-		args[key+4] = value
+		args[key+5] = value
 	}
 
 	return args


### PR DESCRIPTION
If you have a PowerShell profile script that creates any output, then that output gets picked up by packer with unexpected results.

**C:\Users\<username>\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1**

    Write-Host "`n`t`"Never send a human to do a machine's job.`"`n"


**packerlog.txt**

    2016/12/22 11:19:57 [INFO] Packer version: 0.12.1
    2016/12/22 11:19:57 Packer Target OS/Arch: windows amd64
    2016/12/22 11:19:57 Built with Go Version: go1.7.3    
    ...skipped some lines...
    2016/12/22 11:19:57 Preparing build: hyperv-iso
    2016/12/22 11:19:57 packer.exe: 2016/12/22 11:19:57 DiskSize: 20480
    2016/12/22 11:19:57 packer.exe: 2016/12/22 11:19:57 RamSize: 2048
    2016/12/22 11:19:57 packer.exe: 2016/12/22 11:19:57 VMName: packer-hyperv-iso
    2016/12/22 11:19:59 packer.exe: 2016/12/22 11:19:59 Using switch "Never send a human to do a machine's job."
    ...skipped some lines...
    2016/12/22 11:20:00 packer.exe: 2016/12/22 11:20:00 Enter method: verifyPSVersion
    2016/12/22 11:20:00 packer.exe: 2016/12/22 11:20:00 $host.version.Major output: "Never send a human to do a machine's job."
    2016/12/22 11:20:00 packer.exe: 
    2016/12/22 11:20:00 packer.exe: 5
    2016/12/22 11:20:00 ui error: Build 'hyperv-iso' errored: Failed creating Hyper-V driver: strconv.ParseInt: parsing "\"Never send a human to do a machine's job.\"\n\n5": invalid syntax

I think it makes more sense to use a clean PowerShell session without any customisations that the user might have.


PowerShell version

    Name                           Value
    ----                           -----
    PSVersion                      5.1.14393.576
    PSEdition                      Desktop
    PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
    BuildVersion                   10.0.14393.576
    CLRVersion                     4.0.30319.42000
    WSManStackVersion              3.0
    PSRemotingProtocolVersion      2.3
    SerializationVersion           1.1.0.1

[Technet - Windows PowerShell Profiles](https://technet.microsoft.com/en-us/library/bb613488(v=vs.85).aspx)
