### PR TITLE
qemu builder and vbox builders now need to explicitly set WinRMPort for StepConnect

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -398,6 +398,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				Host:      commHost,
 				SSHConfig: sshConfig,
 				SSHPort:   commPort,
+				WinRMPort: commPort,
 			},
 		)
 	}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -242,6 +242,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Host:      vboxcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: vboxcommon.SSHConfigFunc(b.config.SSHConfig),
 			SSHPort:   vboxcommon.SSHPort,
+			WinRMPort: vboxcommon.SSHPort,
 		},
 		&vboxcommon.StepUploadVersion{
 			Path: b.config.VBoxVersionFile,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -116,6 +116,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Host:      vboxcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: vboxcommon.SSHConfigFunc(b.config.SSHConfig),
 			SSHPort:   vboxcommon.SSHPort,
+			WinRMPort: vboxcommon.SSHPort,
 		},
 		&vboxcommon.StepUploadVersion{
 			Path: b.config.VBoxVersionFile,


### PR DESCRIPTION
#2576 introduced a bug that broke WinRM for Virtualbox builders since it made changes to the way ```WinRMPort``` was defined in helper/communicator/step_connect.go - see #4310. Hopefully this change aligns the Virtualbox builders to the new way of doing things.

I've tested the changes with the Virtualbox iso builder and communication over WinRM is now working again. I've also tested a Linux build to ensure the ssh communicator is still working as expected.

Note that the Virtualbox ovf builder should also be affected by the changes #2576 made. I haven't been able to perform any checks that this is actually the case as I don't have an ovf template to hand...

Closes #4310
