### PR TITLE
New Provisioner: Converge

### DIFF
--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -1,0 +1,130 @@
+// This package implements a provisioner for Packer that executes
+// Converge to provision a remote machine
+
+package converge
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"strings"
+
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/helper/config"
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/template/interpolate"
+)
+
+// Config for Converge provisioner
+type Config struct {
+	common.PackerConfig `mapstructure:",squash"`
+
+	NoBootstrap bool `mapstructure:"no_bootstrap"` // TODO: add a way to specify bootstrap version
+
+	ctx interpolate.Context
+}
+
+// Provisioner for Converge
+type Provisioner struct {
+	config Config
+}
+
+// Prepare provisioner somehow. TODO: actual docs
+func (p *Provisioner) Prepare(raws ...interface{}) error {
+	err := config.Decode(
+		&p.config,
+		&config.DecodeOpts{
+			Interpolate:        true,
+			InterpolateContext: &p.config.ctx,
+		},
+		raws...,
+	)
+
+	return err
+}
+
+// Provision node somehow. TODO: actual docs
+func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	ui.Say("Provisioning with Converge")
+
+	// bootstrapping
+	if err := p.maybeBootstrap(ui, comm); err != nil {
+		return err // error messages are already user-friendly
+	}
+
+	// check version (really, this make sure that Converge is installed before we try to run it)
+	if err := p.checkVersion(ui, comm); err != nil {
+		return err // error messages are already user-friendly
+	}
+
+	return nil
+}
+
+func (p *Provisioner) maybeBootstrap(ui packer.Ui, comm packer.Communicator) error {
+	if p.config.NoBootstrap {
+		return nil
+	}
+	ui.Message("bootstrapping converge")
+
+	bootstrap, err := http.Get("https://get.converge.sh")
+	defer bootstrap.Body.Close()
+	if err != nil {
+		return fmt.Errorf("Error downloading bootstrap script: %s", err) // TODO: is github.com/pkg/error allowed?
+	}
+	if err := comm.Upload("/tmp/install-converge.sh", bootstrap.Body, nil); err != nil {
+		return fmt.Errorf("Error uploading script: %s", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &packer.RemoteCmd{
+		Command: "/bin/sh /tmp/install-converge.sh",
+		Stdin:   nil,
+		Stdout:  &out,
+		Stderr:  &out,
+	}
+
+	if err = comm.Start(cmd); err != nil {
+		return fmt.Errorf("Error bootstrapping converge: %s", err)
+	}
+
+	cmd.Wait()
+	if cmd.ExitStatus != 0 {
+		ui.Error(out.String())
+		return errors.New("Error bootstrapping converge")
+	}
+
+	ui.Message(strings.TrimSpace(out.String()))
+	return nil
+}
+
+func (p *Provisioner) checkVersion(ui packer.Ui, comm packer.Communicator) error {
+	var versionOut bytes.Buffer
+	cmd := &packer.RemoteCmd{
+		Command: "converge version",
+		Stdin:   nil,
+		Stdout:  &versionOut,
+		Stderr:  &versionOut,
+	}
+	if err := comm.Start(cmd); err != nil || cmd.ExitStatus != 0 {
+		return fmt.Errorf("Error running `converge version`: %s", err)
+	}
+
+	cmd.Wait()
+	if cmd.ExitStatus != 0 {
+		ui.Error(versionOut.String())
+		ui.Error(fmt.Sprintf("exited with error code %d", cmd.ExitStatus)) // TODO: check for 127
+		return errors.New("Error running `converge version`")
+	}
+
+	ui.Say(fmt.Sprintf("Provisioning with %s", strings.TrimSpace(versionOut.String())))
+
+	return nil
+}
+
+// Cancel the provisioning process
+func (p *Provisioner) Cancel() {
+	log.Println("cancel called in Converge provisioner")
+}

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -137,12 +137,14 @@ func (p *Provisioner) maybeBootstrap(ui packer.Ui, comm packer.Communicator) err
 	ui.Message("bootstrapping converge")
 
 	bootstrap, err := http.Get("https://get.converge.sh")
-	defer bootstrap.Body.Close()
 	if err != nil {
 		return fmt.Errorf("Error downloading bootstrap script: %s", err) // TODO: is github.com/pkg/error allowed?
 	}
 	if err := comm.Upload("/tmp/install-converge.sh", bootstrap.Body, nil); err != nil {
 		return fmt.Errorf("Error uploading script: %s", err)
+	}
+	if err := bootstrap.Body.Close(); err != nil {
+		return fmt.Errorf("Error getting bootstrap script: %s", err)
 	}
 
 	// construct command

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -23,7 +23,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	// Bootstrapping
-	SkipBootstrap    bool   `mapstructure:"skip_bootstrap"`
+	Bootstrap        bool   `mapstructure:"bootstrap"`
 	Version          string `mapstructure:"version"`
 	BootstrapCommand string `mapstructure:"bootstrap_command"`
 
@@ -126,7 +126,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 }
 
 func (p *Provisioner) maybeBootstrap(ui packer.Ui, comm packer.Communicator) error {
-	if p.config.SkipBootstrap {
+	if !p.config.Bootstrap {
 		return nil
 	}
 	ui.Message("bootstrapping converge")
@@ -210,7 +210,7 @@ func (p *Provisioner) applyModules(ui packer.Ui, comm packer.Communicator) error
 	cmd.Wait()
 	if cmd.ExitStatus == 127 {
 		ui.Error("Could not find Converge. Is it installed and in PATH?")
-		if p.config.SkipBootstrap {
+		if !p.config.Bootstrap {
 			ui.Error("Bootstrapping was disabled for this run. That might be why Converge isn't present.")
 		}
 

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -48,9 +48,9 @@ type ModuleDir struct {
 
 // Module contains information needed to run a module
 type Module struct {
-	Module    string            `mapstructure:"module"`
-	Directory string            `mapstructure:"directory"`
-	Params    map[string]string `mapstucture:"params"`
+	Module           string            `mapstructure:"module"`
+	WorkingDirectory string            `mapstructure:"working_directory"`
+	Params           map[string]string `mapstucture:"params"`
 }
 
 // Provisioner for Converge
@@ -95,8 +95,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		if module.Module == "" {
 			return fmt.Errorf("Module (\"module\" key) is required in Converge module #%d", i)
 		}
-		if module.Directory == "" {
-			p.config.Modules[i].Directory = "/tmp"
+		if module.WorkingDirectory == "" {
+			p.config.Modules[i].WorkingDirectory = "/tmp"
 		}
 	}
 
@@ -194,7 +194,7 @@ func (p *Provisioner) applyModules(ui packer.Ui, comm packer.Communicator) error
 		cmd := &packer.RemoteCmd{
 			Command: fmt.Sprintf(
 				"cd %s && converge apply --local --log-level=WARNING --paramsJSON '%s' %s",
-				module.Directory,
+				module.WorkingDirectory,
 				string(params),
 				module.Module,
 			),

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -27,7 +27,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	// Bootstrapping
-	Bootstrap        bool   `mapstructure:"bootstrap"`
+	SkipBootstrap    bool   `mapstructure:"skip_bootstrap"`
 	Version          string `mapstructure:"version"`
 	BootstrapCommand string `mapstructure:"bootstrap_command"`
 
@@ -135,7 +135,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 }
 
 func (p *Provisioner) maybeBootstrap(ui packer.Ui, comm packer.Communicator) error {
-	if !p.config.Bootstrap {
+	if p.config.SkipBootstrap {
 		return nil
 	}
 	ui.Message("bootstrapping converge")
@@ -219,7 +219,7 @@ func (p *Provisioner) applyModules(ui packer.Ui, comm packer.Communicator) error
 	cmd.Wait()
 	if cmd.ExitStatus == 127 {
 		ui.Error("Could not find Converge. Is it installed and in PATH?")
-		if !p.config.Bootstrap {
+		if p.config.SkipBootstrap {
 			ui.Error("Bootstrapping was disabled for this run. That might be why Converge isn't present.")
 		}
 

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -113,9 +113,17 @@ func (p *Provisioner) checkVersion(ui packer.Ui, comm packer.Communicator) error
 	}
 
 	cmd.Wait()
-	if cmd.ExitStatus != 0 {
+	if cmd.ExitStatus == 127 {
+		ui.Error("Could not determine Converge version. Is it installed and in PATH?")
+		if p.config.NoBootstrap {
+			ui.Error("Bootstrapping was disabled for this run. That might be why Converge isn't present.")
+		}
+
+		return errors.New("could not determine Converge version")
+
+	} else if cmd.ExitStatus != 0 {
 		ui.Error(versionOut.String())
-		ui.Error(fmt.Sprintf("exited with error code %d", cmd.ExitStatus)) // TODO: check for 127
+		ui.Error(fmt.Sprintf("exited with error code %d", cmd.ExitStatus))
 		return errors.New("Error running `converge version`")
 	}
 

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -12,15 +12,11 @@ import (
 
 	"encoding/json"
 
-	"regexp"
-
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/helper/config"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/template/interpolate"
 )
-
-var versionRegex = regexp.MustCompile(`^[\.\-\da-zA-Z]*$`)
 
 // Config for Converge provisioner
 type Config struct {
@@ -92,11 +88,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.BootstrapCommand == "" {
 		p.config.BootstrapCommand = "curl -s https://get.converge.sh | sh {{if ne .Version \"\"}}-s -- -v {{.Version}}{{end}}"
-	}
-
-	// validate version
-	if !versionRegex.Match([]byte(p.config.Version)) {
-		return fmt.Errorf("Invalid Converge version %q specified. Valid versions include only letters, numbers, dots, and dashes", p.config.Version)
 	}
 
 	// validate sources and destinations

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -229,5 +229,6 @@ func (p *Provisioner) applyModules(ui packer.Ui, comm packer.Communicator) error
 
 // Cancel the provisioning process
 func (p *Provisioner) Cancel() {
-	log.Println("cancel called in Converge provisioner")
+	// there's not an awful lot we can do to cancel Converge at the moment.
+	// The default semantics are fine.
 }

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -29,8 +29,8 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	// Bootstrapping
-	NoBootstrap bool   `mapstructure:"no_bootstrap"`
-	Version     string `mapstructure:"version"`
+	Bootstrap bool   `mapstructure:"bootstrap"`
+	Version   string `mapstructure:"version"`
 
 	// Modules
 	ModuleDirs []ModuleDir `mapstructure:"module_dirs"`
@@ -131,7 +131,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 }
 
 func (p *Provisioner) maybeBootstrap(ui packer.Ui, comm packer.Communicator) error {
-	if p.config.NoBootstrap {
+	if !p.config.Bootstrap {
 		return nil
 	}
 	ui.Message("bootstrapping converge")
@@ -188,7 +188,7 @@ func (p *Provisioner) checkVersion(ui packer.Ui, comm packer.Communicator) error
 	cmd.Wait()
 	if cmd.ExitStatus == 127 {
 		ui.Error("Could not determine Converge version. Is it installed and in PATH?")
-		if p.config.NoBootstrap {
+		if !p.config.Bootstrap {
 			ui.Error("Bootstrapping was disabled for this run. That might be why Converge isn't present.")
 		}
 

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
-var versionRegex = regexp.MustCompile(`[\.\-\d\w]*`)
+var versionRegex = regexp.MustCompile(`^[\.\-\da-zA-Z]*$`)
 
 // Config for Converge provisioner
 type Config struct {
@@ -96,7 +96,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			return fmt.Errorf("Module (\"module\" key) is required in Converge module #%d", i)
 		}
 		if module.Directory == "" {
-			module.Directory = "/tmp"
+			p.config.Modules[i].Directory = "/tmp"
 		}
 	}
 

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -53,6 +53,19 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		},
 		raws...,
 	)
+	if err != nil {
+		return err
+	}
+
+	// validate sources and destinations
+	for i, dir := range p.config.ModuleDirs {
+		if dir.Source == "" {
+			return fmt.Errorf("Source (\"source\" key) is required in Converge module dir #%d", i)
+		}
+		if dir.Destination == "" {
+			return fmt.Errorf("Destination (\"destination\" key) is required in Converge module dir #%d", i)
+		}
+	}
 
 	return err
 }

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -17,11 +17,7 @@ func testConfig() map[string]interface{} {
 				"destination": "/opt/converge",
 			},
 		},
-		"modules": []map[string]interface{}{
-			{
-				"module": "/opt/converge/test.hcl",
-			},
-		},
+		"module": "/opt/converge/test.hcl",
 	}
 }
 
@@ -40,14 +36,14 @@ func TestProvisionerPrepare(t *testing.T) {
 
 		// delete any keys that we're testing here to make sure they're actually
 		// being set by `Prepare`
-		delete(config["modules"].([]map[string]interface{})[0], "directory")
+		delete(config, "working_directory")
 
 		if err := p.Prepare(config); err != nil {
 			t.Errorf("err: %s", err)
 		}
 
-		if p.config.Modules[0].WorkingDirectory != "/tmp" {
-			t.Errorf("unexpected module directory: %s", p.config.Modules[0].WorkingDirectory)
+		if p.config.WorkingDirectory != "/tmp" {
+			t.Errorf("unexpected module directory: %s", p.config.WorkingDirectory)
 		}
 	})
 
@@ -93,32 +89,17 @@ func TestProvisionerPrepare(t *testing.T) {
 			})
 		})
 
-		t.Run("modules", func(t *testing.T) {
-			t.Run("none specified", func(t *testing.T) {
-				var p Provisioner
-				config := testConfig()
-				delete(config, "modules")
+		t.Run("no module specified", func(t *testing.T) {
+			var p Provisioner
+			config := testConfig()
+			delete(config, "module")
 
-				err := p.Prepare(config)
-				if err == nil {
-					t.Error("expected error")
-				} else if err.Error() != "Converge requires at least one module (\"modules\" key) to provision the system" {
-					t.Errorf("bad error message: %s", err)
-				}
-			})
-
-			t.Run("missing module", func(t *testing.T) {
-				var p Provisioner
-				config := testConfig()
-				delete(config["modules"].([]map[string]interface{})[0], "module")
-
-				err := p.Prepare(config)
-				if err == nil {
-					t.Error("expected error")
-				} else if err.Error() != "Module (\"module\" key) is required in Converge module #0" {
-					t.Errorf("bad error message: %s", err)
-				}
-			})
+			err := p.Prepare(config)
+			if err == nil {
+				t.Error("expected error")
+			} else if err.Error() != "Converge requires a module to provision the system" {
+				t.Errorf("bad error message: %s", err)
+			}
 		})
 	})
 }

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -1,0 +1,124 @@
+package converge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/packer/packer"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"bootstrap": false,
+		"version":   "",
+		"module_dirs": []map[string]interface{}{
+			{
+				"source":      "from",
+				"destination": "/opt/converge",
+			},
+		},
+		"modules": []map[string]interface{}{
+			{
+				"module": "/opt/converge/test.hcl",
+			},
+		},
+	}
+}
+
+func TestProvisioner_Impl(t *testing.T) {
+	var raw interface{}
+	raw = &Provisioner{}
+	if _, ok := raw.(packer.Provisioner); !ok {
+		t.Fatal("must be a Provisioner")
+	}
+}
+
+func TestProvisionerPrepare(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		var p Provisioner
+		config := testConfig()
+
+		// delete any keys that we're testing here to make sure they're actually
+		// being set by `Prepare`
+		delete(config["modules"].([]map[string]interface{})[0], "directory")
+
+		if err := p.Prepare(config); err != nil {
+			t.Errorf("err: %s", err)
+		}
+
+		if p.config.Modules[0].Directory != "/tmp" {
+			t.Errorf("unexpected module directory: %s", p.config.Modules[0].Directory)
+		}
+	})
+
+	t.Run("validate", func(t *testing.T) {
+		t.Run("bad version", func(t *testing.T) {
+			var p Provisioner
+			config := testConfig()
+			config["version"] = "bad version with spaces"
+
+			err := p.Prepare(config)
+			if err == nil {
+				t.Error("expected error")
+			} else if !strings.HasPrefix(err.Error(), "Invalid Converge version") {
+				t.Errorf("expected error starting with \"Invalid Converge version\". Got: %s", err)
+			}
+		})
+
+		t.Run("module dir", func(t *testing.T) {
+			t.Run("missing source", func(t *testing.T) {
+				var p Provisioner
+				config := testConfig()
+				delete(config["module_dirs"].([]map[string]interface{})[0], "source")
+
+				err := p.Prepare(config)
+				if err == nil {
+					t.Error("expected error")
+				} else if err.Error() != "Source (\"source\" key) is required in Converge module dir #0" {
+					t.Errorf("bad error message: %s", err)
+				}
+			})
+
+			t.Run("missing destination", func(t *testing.T) {
+				var p Provisioner
+				config := testConfig()
+				delete(config["module_dirs"].([]map[string]interface{})[0], "destination")
+
+				err := p.Prepare(config)
+				if err == nil {
+					t.Error("expected error")
+				} else if err.Error() != "Destination (\"destination\" key) is required in Converge module dir #0" {
+					t.Errorf("bad error message: %s", err)
+				}
+			})
+		})
+
+		t.Run("modules", func(t *testing.T) {
+			t.Run("none specified", func(t *testing.T) {
+				var p Provisioner
+				config := testConfig()
+				delete(config, "modules")
+
+				err := p.Prepare(config)
+				if err == nil {
+					t.Error("expected error")
+				} else if err.Error() != "Converge requires at least one module (\"modules\" key) to provision the system" {
+					t.Errorf("bad error message: %s", err)
+				}
+			})
+
+			t.Run("missing module", func(t *testing.T) {
+				var p Provisioner
+				config := testConfig()
+				delete(config["modules"].([]map[string]interface{})[0], "module")
+
+				err := p.Prepare(config)
+				if err == nil {
+					t.Error("expected error")
+				} else if err.Error() != "Module (\"module\" key) is required in Converge module #0" {
+					t.Errorf("bad error message: %s", err)
+				}
+			})
+		})
+	})
+}

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -9,8 +9,6 @@ import (
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"bootstrap": false,
-		"version":   "",
 		"module_dirs": []map[string]interface{}{
 			{
 				"source":      "from",

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -46,8 +46,8 @@ func TestProvisionerPrepare(t *testing.T) {
 			t.Errorf("err: %s", err)
 		}
 
-		if p.config.Modules[0].Directory != "/tmp" {
-			t.Errorf("unexpected module directory: %s", p.config.Modules[0].Directory)
+		if p.config.Modules[0].WorkingDirectory != "/tmp" {
+			t.Errorf("unexpected module directory: %s", p.config.Modules[0].WorkingDirectory)
 		}
 	})
 

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -60,6 +60,21 @@ func TestProvisionerPrepare(t *testing.T) {
 				t.Fatal("execute command unexpectedly blank")
 			}
 		})
+
+		t.Run("bootstrap_command", func(t *testing.T) {
+			var p Provisioner
+			config := testConfig()
+
+			delete(config, "bootstrap_command")
+
+			if err := p.Prepare(config); err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			if p.config.BootstrapCommand == "" {
+				t.Fatal("bootstrap command unexpectedly blank")
+			}
+		})
 	})
 
 	t.Run("validate", func(t *testing.T) {

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -31,20 +31,35 @@ func TestProvisioner_Impl(t *testing.T) {
 
 func TestProvisionerPrepare(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
-		var p Provisioner
-		config := testConfig()
+		t.Run("working_directory", func(t *testing.T) {
+			var p Provisioner
+			config := testConfig()
 
-		// delete any keys that we're testing here to make sure they're actually
-		// being set by `Prepare`
-		delete(config, "working_directory")
+			delete(config, "working_directory")
 
-		if err := p.Prepare(config); err != nil {
-			t.Errorf("err: %s", err)
-		}
+			if err := p.Prepare(config); err != nil {
+				t.Fatalf("err: %s", err)
+			}
 
-		if p.config.WorkingDirectory != "/tmp" {
-			t.Errorf("unexpected module directory: %s", p.config.WorkingDirectory)
-		}
+			if p.config.WorkingDirectory != "/tmp" {
+				t.Fatalf("unexpected module directory: %s", p.config.WorkingDirectory)
+			}
+		})
+
+		t.Run("execute_command", func(t *testing.T) {
+			var p Provisioner
+			config := testConfig()
+
+			delete(config, "execute_command")
+
+			if err := p.Prepare(config); err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			if p.config.ExecuteCommand == "" {
+				t.Fatal("execute command unexpectedly blank")
+			}
+		})
 	})
 
 	t.Run("validate", func(t *testing.T) {

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -1,7 +1,6 @@
 package converge
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mitchellh/packer/packer"
@@ -76,19 +75,6 @@ func TestProvisionerPrepare(t *testing.T) {
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		t.Run("bad version", func(t *testing.T) {
-			var p Provisioner
-			config := testConfig()
-			config["version"] = "bad version with spaces"
-
-			err := p.Prepare(config)
-			if err == nil {
-				t.Error("expected error")
-			} else if !strings.HasPrefix(err.Error(), "Invalid Converge version") {
-				t.Errorf("expected error starting with \"Invalid Converge version\". Got: %s", err)
-			}
-		})
-
 		t.Run("module dir", func(t *testing.T) {
 			t.Run("missing source", func(t *testing.T) {
 				var p Provisioner

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -57,6 +57,9 @@ Optional parameters:
   various
   [configuration template variables](/docs/templates/configuration-templates.html) available.
 
+- `prevent_sudo` (bool) - stop Converge from running with adminstrator
+  privileges via sudo
+
 ### Module Directories
 
 The provisioner can transfer module directories to the remote host for
@@ -76,7 +79,7 @@ By default, Packer uses the following command (broken across multiple lines for 
 
 ``` {.liquid}
 cd {{.WorkingDirectory}} && \
-sudo converge apply \
+{{if .Sudo}}sudo {{end}}converge apply \
   --local \
   --log-level=WARNING \
   --paramsJSON '{{.ParamsJSON}}' \
@@ -87,6 +90,7 @@ This command can be customized using the `execute_command` configuration. As you
 can see from the default value above, the value of this configuration can
 contain various template variables:
 
-- `WorkingDirectory` - `directory` from the configuration
+- `WorkingDirectory` - `directory` from the configuration.
+- `Sudo` - the opposite of `prevent_sudo` from the configuration.
 - `ParamsJSON` - The unquoted JSONified form of `params` from the configuration.
 - `Module` - `module` from the configuration.

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -23,25 +23,19 @@ The example below is fully functional.
 ``` {.javascript}
 {
   "type": "converge",
-  "modules": [
-    {
-      "module": "https://raw.githubusercontent.com/asteris-llc/converge/master/samples/fileContent.hcl",
-      "params": {
-        "message": "Hello, Packer!"
-      }
-    }
-  ]
+  "module": "https://raw.githubusercontent.com/asteris-llc/converge/master/samples/fileContent.hcl",
+  "params": {
+    "message": "Hello, Packer!"
+  }
 }
 ```
 
 ## Configuration Reference
 
 The reference of available configuration options is listed below. The only
-required element is "modules", of which there must be at least one. Every other
-option is optional.
+required element is "module". Every other option is optional.
 
-- `modules` (array of module specifications) - The root modules to run by
-  Converge. See below for the specification.
+- `module` (string) - Path (or URL) to the root module that Converge will apply.
 
 Optional parameters:
 
@@ -54,18 +48,14 @@ Optional parameters:
 - `module_dirs` (array of directory specifications) - Module directories to
   transfer to the remote host for execution. See below for the specification.
 
-### Modules
-
-Modules control what Converge applies to your system. The `modules` key should
-be a list of objects with the following keys. Of these, only `module` is
-required.
-
-- `module` (string) - the path (or URL) to the root module.
-
-- `directory` (string) - the directory to run Converge in. If not set, the
-  provisioner will use `/tmp` by default.
+- `working_directory` (string) - The directory that Converge will change to
+  before execution.
 
 - `params` (maps of string to string) - parameters to pass into the root module.
+
+- `execute_command` (string) - the command used to execute Converge. This has
+  various
+  [configuration template variables](/docs/templates/configuration-templates.html) available.
 
 ### Module Directories
 
@@ -79,3 +69,24 @@ directory.
   directories will not be created; use the shell module to do this.
 
 - `exclude` (array of string) - files and directories to exclude from transfer.
+
+### Execute Command
+
+By default, Packer uses the following command (broken across multiple lines for readability) to execute Converge:
+
+``` {.liquid}
+cd {{.WorkingDirectory}} && \
+sudo converge apply \
+  --local \
+  --log-level=WARNING \
+  --paramsJSON '{{.ParamsJSON}}' \
+  {{.Module}}
+```
+
+This command can be customized using the `execute_command` configuration. As you
+can see from the default value above, the value of this configuration can
+contain various template variables:
+
+- `WorkingDirectory` - `directory` from the configuration
+- `ParamsJSON` - The unquoted JSONified form of `params` from the configuration.
+- `Module` - `module` from the configuration.

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -60,6 +60,10 @@ Optional parameters:
 - `prevent_sudo` (bool) - stop Converge from running with adminstrator
   privileges via sudo
 
+- `bootstrap_command` (string) - the command used to bootstrap Converge. This
+  has various
+  [configuration template variables](/docs/templates/configuration-templates.html) available.
+
 ### Module Directories
 
 The provisioner can transfer module directories to the remote host for
@@ -94,3 +98,17 @@ contain various template variables:
 - `Sudo` - the opposite of `prevent_sudo` from the configuration.
 - `ParamsJSON` - The unquoted JSONified form of `params` from the configuration.
 - `Module` - `module` from the configuration.
+
+### Bootstrap Command
+
+By default, Packer uses the following command to bootstrap Converge:
+
+``` {.liquid}
+curl -s https://get.converge.sh | sh {{if ne .Version ""}}-s -- -v {{.Version}}{{end}}
+```
+
+This command can be customized using the `bootstrap_command` configuration. As you
+can see from the default values above, the value of this configuration can
+contain various template variables:
+
+- `Version` - `version` from the configuration.

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -64,6 +64,9 @@ Optional parameters:
   has various
   [configuration template variables](/docs/templates/configuration-templates.html) available.
 
+- `prevent_bootstrap_sudo` (bool) - stop Converge from bootstrapping with
+  administrator privileges via sudo
+
 ### Module Directories
 
 The provisioner can transfer module directories to the remote host for
@@ -104,11 +107,12 @@ contain various template variables:
 By default, Packer uses the following command to bootstrap Converge:
 
 ``` {.liquid}
-curl -s https://get.converge.sh | sh {{if ne .Version ""}}-s -- -v {{.Version}}{{end}}
+curl -s https://get.converge.sh | {{if .Sudo}}sudo {{end}}sh {{if ne .Version ""}}-s -- -v {{.Version}}{{end}}
 ```
 
 This command can be customized using the `bootstrap_command` configuration. As you
 can see from the default values above, the value of this configuration can
 contain various template variables:
 
+- `Sudo` - the opposite of `prevent_bootstrap_sudo` from the configuration.
 - `Version` - `version` from the configuration.

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -39,9 +39,9 @@ required element is "module". Every other option is optional.
 
 Optional parameters:
 
-- `skip_bootstrap` (boolean) - If unset or `false`, the provisioner will
-  download the latest Converge bootstrap script and the specified `version` of
-  Converge from the internet.
+- `bootstrap` (boolean) - Set to allow the provisioner to download the latest
+  Converge bootstrap script and the specified `version` of Converge from the
+  internet.
 
 - `version` (string) - Set to a [released Converge version](https://github.com/asteris-llc/converge/releases) for bootstrap.
 

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -39,9 +39,9 @@ required element is "module". Every other option is optional.
 
 Optional parameters:
 
-- `bootstrap` (boolean) - Set to allow the provisioner to download the latest
-  Converge bootstrap script and the specified `version` of Converge from the
-  internet.
+- `skip_bootstrap` (boolean) - If unset or `false`, the provisioner will
+  download the latest Converge bootstrap script and the specified `version` of
+  Converge from the internet.
 
 - `version` (string) - Set to a [released Converge version](https://github.com/asteris-llc/converge/releases) for bootstrap.
 

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -39,9 +39,9 @@ required element is "module". Every other option is optional.
 
 Optional parameters:
 
-- `bootstrap` (boolean) - Set to allow the provisioner to download the latest
-  Converge bootstrap script and the specified `version` of Converge from the
-  internet.
+- `bootstrap` (boolean, defaults to false) - Set to allow the provisioner to
+  download the latest Converge bootstrap script and the specified `version` of
+  Converge from the internet.
 
 - `version` (string) - Set to a [released Converge version](https://github.com/asteris-llc/converge/releases) for bootstrap.
 

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -1,0 +1,81 @@
+---
+description: |-
+    The Converge Packer provisioner uses Converge modules to provision the machine.
+layout: docs
+page_title: Converge Provisioner
+...
+
+# Converge Provisioner
+
+Type: `converge`
+
+The [Converge](http://converge.aster.is) Packer provisioner uses Converge
+modules to provision the machine. It uploads module directories to use as
+source, or you can use remote modules.
+
+The provisioner can optionally bootstrap the Converge client/server binary onto
+new images.
+
+## Basic Example
+
+The example below is fully functional.
+
+``` {.javascript}
+{
+  "type": "converge",
+  "modules": [
+    {
+      "module": "https://raw.githubusercontent.com/asteris-llc/converge/master/samples/fileContent.hcl",
+      "params": {
+        "message": "Hello, Packer!"
+      }
+    }
+  ]
+}
+```
+
+## Configuration Reference
+
+The reference of available configuration options is listed below. The only
+required element is "modules", of which there must be at least one. Every other
+option is optional.
+
+- `modules` (array of module specifications) - The root modules to run by
+  Converge. See below for the specification.
+
+Optional parameters:
+
+- `bootstrap` (boolean) - Set to allow the provisioner to download the latest
+  Converge bootstrap script and the specified `version` of Converge from the
+  internet.
+
+- `version` (string) - Set to a [released Converge version](https://github.com/asteris-llc/converge/releases) for bootstrap.
+
+- `module_dirs` (array of directory specifications) - Module directories to
+  transfer to the remote host for execution. See below for the specification.
+
+### Modules
+
+Modules control what Converge applies to your system. The `modules` key should
+be a list of objects with the following keys. Of these, only `module` is
+required.
+
+- `module` (string) - the path (or URL) to the root module.
+
+- `directory` (string) - the directory to run Converge in. If not set, the
+  provisioner will use `/tmp` by default.
+
+- `params` (maps of string to string) - parameters to pass into the root module.
+
+### Module Directories
+
+The provisioner can transfer module directories to the remote host for
+provisioning. Of these fields, `source` and `destination` are required in every
+directory.
+
+- `source` (string) - the path to the folder on the local machine.
+
+- `destination` (string) - the path to the folder on the remote machine. Parent
+  directories will not be created; use the shell module to do this.
+
+- `exclude` (array of string) - files and directories to exclude from transfer.


### PR DESCRIPTION
This patch adds a [Converge](http://converge.aster.is) provisioner. I've tested it on DigitalOcean and didn't have any problems. It uses the regular Packer primitives for communication.

I've included tests for the Prepare section of the provisioner. That looks like the extent of the tests that most provisioners include, unless I'm missing something?

Happy to make any style changes necessary. This PR doesn't add any external dependencies, although I sure would like to use https://github.com/pkg/errors if it's allowed.

Tested with the following harness:

```go
package main

import (
	"log"

	"github.com/asteris-llc/packer/packer/plugin"
	"github.com/asteris-llc/packer/provisioner/converge"
)

func main() {
	server, err := plugin.Server()
	if err != nil {
		log.Fatalf("Error starting plugin server: %s", err)
	}

	server.RegisterProvisioner(new(converge.Provisioner))

	server.Serve()
}
```

This code was written in my role as an Asteris employee. We're happy to release it under the MPL. Converge is Apache 2.0 licensed. As far as I can tell, there are no conflicts.