### PR TITLE
Allow equals sign in value of environment variable for Powershell provisioner

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -347,7 +347,7 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string, e
 
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
-		keyValue := strings.Split(envVar, "=")
+		keyValue := strings.SplitN(envVar, "=", 2)
 
 		if len(keyValue) != 2 || keyValue[0] == "" {
 			err = errors.New(fmt.Sprintf("Shell provisioner environment variables must be in key=value format. Currently it is '%s'", envVar))


### PR DESCRIPTION
Currently the Powershell provisioner will error and halt the build if there is an equals sign in the value of an environment variable. The changes ensure that supplied environment variables are split on the first occurrence of an equals sign, treating everything before the equals as the key and everything after as the value. This applies the same code used previously [here](https://github.com/mitchellh/packer/blob/master/provisioner/powershell/provisioner.go#L190-L197).

Closes #3108
