### PR TITLE
provisioner/puppet-server: Fixed formatting for execute_command

### DIFF
--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -85,14 +85,15 @@ listed below:
     variables](/docs/templates/configuration-templates.html) available. See
     below for more information. By default, Packer uses the following command:
 
-    ``` {{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
-		"puppet agent --onetime --no-daemonize " +
-		"{{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}}" +
-		"{{if ne .Options \"\"}}{{.Options}} {{end}}" +
-		"{{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}}" +
-		"{{if ne .ClientCertPath \"\"}}--certdir='{{.ClientCertPath}}' {{end}}" +
-		"{{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' {{end}}" +
-		"--detailed-exitcodes
+```
+{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} \
+  puppet agent --onetime --no-daemonize \
+  {{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}} \
+  {{if ne .Options \"\"}}{{.Options}} {{end}} \
+  {{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}} \
+  {{if ne .ClientCertPath \"\"}}--certdir='{{.ClientCertPath}}' {{end}} \
+  {{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' \
+  {{end}} --detailed-exitcodes
 ```
 
 ## Default Facts


### PR DESCRIPTION
Fixed formatting of code under [execute_command](https://www.packer.io/docs/provisioners/puppet-server.html#execute_command).