### PR TITLE
Clean up puppet provisioner documentation

### DIFF
--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -30,7 +30,7 @@ this.
 ## Basic Example
 
 The example below is fully functional and expects the configured manifest file
-to exist relative to your working directory:
+to exist relative to your working directory.
 
 ``` {.javascript}
 {
@@ -86,10 +86,10 @@ Optional parameters:
 This option was deprecated in puppet 3.6, and removed in puppet 4.0. If you have
 multiple manifests you should use `manifest_file` instead.
 
--   `puppet_bin_dir` (string) - The path to the binary for running `puppet apply`.
-    Usually, this would be found via the `$PATH` or `%PATH%` environment variable,
-    but some builders (notably, the Docker one) do not run profile-setup scripts,
-    therefore the Path is usually empty.
+-   `puppet_bin_dir` (string) - The path to the directory that contains the puppet
+    binary for running `puppet apply`. Usually, this would be found via the `$PATH`
+    or `%PATH%` environment variable, but some builders (notably, the Docker one) do
+    not run profile-setup scripts, therefore the path is usually empty.
 
 -   `module_paths` (array of strings) - This is an array of paths to module
     directories on your local filesystem. These will be uploaded to the
@@ -123,9 +123,10 @@ cd {{.WorkingDir}} && \
 {{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet apply \
   --verbose \
   --modulepath='{{.ModulePath}}' \
-  {{if ne .HieraConfigPath ""}}--hiera_config='{{.HieraConfigPath}}' {{end}} \
-  {{if ne .ManifestDir ""}}--manifestdir='{{.ManifestDir}}' {{end}} \
+  {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} \
+  {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} \
   --detailed-exitcodes \
+  {{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}} \
   {{.ManifestFile}}
 ```
 

--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -123,10 +123,10 @@ cd {{.WorkingDir}} && \
 {{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}{{end}}puppet apply \
   --verbose \
   --modulepath='{{.ModulePath}}' \
-  {{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}} \
-  {{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}} \
+  {{if ne .HieraConfigPath ""}}--hiera_config='{{.HieraConfigPath}}' {{end}} \
+  {{if ne .ManifestDir ""}}--manifestdir='{{.ManifestDir}}' {{end}} \
   --detailed-exitcodes \
-  {{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}} \
+  {{if ne .ExtraArguments ""}}{{.ExtraArguments}} {{end}} \
   {{.ManifestFile}}
 ```
 

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -22,7 +22,7 @@ this.
 ## Basic Example
 
 The example below is fully functional and expects a Puppet server to be
-accessible from your network.:
+accessible from your network.
 
 ``` {.javascript}
 {
@@ -41,13 +41,13 @@ The reference of available configuration options is listed below.
 The provisioner takes various options. None are strictly required. They are
 listed below:
 
--   `client_cert_path` (string) - Path to the client certificate for the node on
-    your disk. This defaults to nothing, in which case a client cert won't
-    be uploaded.
+-   `client_cert_path` (string) - Path to the directory on your disk that
+    contains the client certificate for the node. This defaults to nothing,
+    in which case a client cert won't be uploaded.
 
--   `client_private_key_path` (string) - Path to the client private key for the
-    node on your disk. This defaults to nothing, in which case a client private
-    key won't be uploaded.
+-   `client_private_key_path` (string) - Path to the directory on your disk that
+    contains the client private key for the node. This defaults to nothing, in
+    which case a client private key won't be uploaded.
 
 -   `facter` (object of key/value strings) - Additional Facter facts to make
     available to the Puppet run.
@@ -56,7 +56,7 @@ listed below:
     provisioner a failure.
 
 -   `options` (string) - Additional command line options to pass to
-    `puppet agent` when Puppet is ran.
+    `puppet agent` when Puppet is run.
 
 -   `prevent_sudo` (boolean) - By default, the configured commands that are
     executed to run Puppet are executed with `sudo`. If this is true, then the
@@ -70,15 +70,15 @@ listed below:
 
 -   `staging_dir` (string) - This is the directory where all the
     configuration of Puppet by Packer will be placed. By default this
-    is "/tmp/packer-puppet-server". This directory doesn't need to exist but
+    is /tmp/packer-puppet-server. This directory doesn't need to exist but
     must have proper permissions so that the SSH user that Packer uses is able
     to create directories and write into this folder. If the permissions are not
     correct, use a shell provisioner prior to this to configure it properly.
 
--   `puppet_bin_dir` (string) - The path to the binary for running `puppet apply`.
-    Usually, this would be found via the `$PATH` or `%PATH%` environment variable,
-    but some builders (notably, the Docker one) do not run profile-setup scripts,
-    therefore the Path is usually empty.
+-   `puppet_bin_dir` (string) - The path to the directory that contains the puppet
+    binary for running `puppet agent`. Usually, this would be found via the `$PATH`
+    or `%PATH%` environment variable, but some builders (notably, the Docker one) do
+    not run profile-setup scripts, therefore the path is usually empty.
 
 -   `execute_command` (string) - This is optional. The command used to execute Puppet. This has
     various [configuration template
@@ -87,7 +87,7 @@ listed below:
 
 ```
 {{.FacterVars}} {{if .Sudo}} sudo -E {{end}} \
-  puppet agent --onetime --no-daemonize \
+  {{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet agent --onetime --no-daemonize \
   {{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}} \
   {{if ne .Options \"\"}}{{.Options}} {{end}} \
   {{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}} \


### PR DESCRIPTION
Clarify that the puppet_bin_dir options is the path to the directory that contains the puppet binary. Update default execute command. Clarify that the client_cert_path and the client_private_key_path options are paths to directories not regular files.