### PR TITLE
amazon-chroot builder snapshot interface panic

### DIFF
--- a/builder/amazon/chroot/step_snapshot.go
+++ b/builder/amazon/chroot/step_snapshot.go
@@ -71,6 +71,12 @@ func (s *StepSnapshot) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	state.Put("snapshot_id", s.snapshotId)
+
+	snapshots := map[string][]string{
+		*ec2conn.Config.Region: {s.snapshotId},
+	}
+	state.Put("snapshots", snapshots)
+
 	return multistep.ActionContinue
 }
 


### PR DESCRIPTION
The snapshots map is never created when following the amazon-chroot tree. Added shapshots map to step_snapshot.go. 

Closes #4340

Im still pretty new to Go not sure how to write a test for this.