### PR TITLE
builder/qemu: allow to convert from any supported format

### DIFF
--- a/builder/qemu/step_convert_disk.go
+++ b/builder/qemu/step_convert_disk.go
@@ -38,7 +38,6 @@ func (s *stepConvertDisk) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	command = append(command, []string{
-		"-f", config.Format,
 		"-O", config.Format,
 		sourcePath,
 		targetPath,

--- a/builder/qemu/step_copy_disk.go
+++ b/builder/qemu/step_copy_disk.go
@@ -22,7 +22,6 @@ func (s *stepCopyDisk) Run(state multistep.StateBag) multistep.StepAction {
 
 	command := []string{
 		"convert",
-		"-f", config.Format,
 		"-O", config.Format,
 		isoPath,
 		path,


### PR DESCRIPTION
In case of disk_image: true user can have raw image, but in packer
template specify qcow2 image format.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>
