### PR TITLE
Add support for including parts of templates.

### DIFF
--- a/template/parse_hook_include.go
+++ b/template/parse_hook_include.go
@@ -1,0 +1,147 @@
+package template
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/mapstructure"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+const includeTag = "_include"
+
+type includeResolverConfig struct {
+	// Base path for includes specified with relative path.
+	basePath string
+}
+
+type includeResolver struct {
+	config *includeResolverConfig
+
+	result map[string]interface{}
+}
+
+func includeHookFunc(config *includeResolverConfig) mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.Map {
+			return data, nil
+		}
+
+		dataMapView, ok := data.(map[string]interface{})
+		if !ok {
+			return data, nil
+		}
+
+		return data, resolveIncludeInPlace(config, dataMapView)
+	}
+}
+
+func resolveIncludeInPlace(config *includeResolverConfig, data map[string]interface{}) error {
+	resolver := includeResolver{config: config, result: data}
+
+	var errs error
+	// Loop to resolve nested includes.
+	// TODO Add discovering include cycles.
+	for include, ok := data[includeTag]; ok; {
+		delete(data, includeTag)
+
+		err := resolver.resolve(include)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+		}
+		include, ok = data[includeTag]
+	}
+	return errs
+}
+
+func (resolver *includeResolver) resolve(include interface{}) error {
+	switch path := include.(type) {
+	case string:
+		return resolver.includeFromFile(path)
+	case []interface{}:
+		return resolver.includeFromFiles(path)
+	default:
+		return errors.New(fmt.Sprintf("Trying to include '%v' which is neither a string nor an array", path))
+	}
+}
+
+func (resolver *includeResolver) includeFromFiles(paths []interface{}) error {
+	var errs error
+	for _, path := range paths {
+		pathStr, ok := path.(string)
+		if !ok {
+			errs = multierror.Append(errs, fmt.Errorf("Trying to include '%v' which is not a string", path))
+			continue
+		}
+
+		if err := resolver.includeFromFile(pathStr); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs
+}
+
+func (resolver *includeResolver) includeFromFile(path string) error {
+	file, err := os.Open(resolver.resolvePath(path))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var content interface{}
+	if err := json.NewDecoder(file).Decode(&content); err != nil {
+		return err
+	}
+
+	contentMapView, ok := content.(map[string]interface{})
+	if !ok {
+		return errors.New(fmt.Sprintf("Included content is not a JSON object"))
+	}
+
+	resolver.include(contentMapView)
+
+	return nil
+}
+
+func (resolver *includeResolver) resolvePath(path string) string {
+	if resolver.config.basePath != "" && !filepath.IsAbs(path) {
+		return filepath.Join(resolver.config.basePath, path)
+	}
+	return path
+}
+
+func (resolver *includeResolver) include(src map[string]interface{}) {
+	for srcKey, srcValue := range src {
+		if destValue, ok := resolver.result[srcKey]; !ok {
+			// Do not overwrite value if it is already present (mitigates the risk of accidentally overwriting
+			// values defined in base template by values from included templates). As a side effect, it makes
+			// ordering of includes important.
+			resolver.result[srcKey] = srcValue
+		} else {
+			if srcKey == includeTag {
+				// Gather include paths from all included templates.
+				resolver.result[srcKey] = appendAny(toSlice(&destValue), srcValue)
+			}
+		}
+	}
+}
+
+func toSlice(value *interface{}) []interface{} {
+	result, ok := (*value).([]interface{})
+	if !ok {
+		result = []interface{}{*value}
+	}
+	return result
+}
+
+func appendAny(dest []interface{}, value interface{}) []interface{} {
+	switch value := value.(type) {
+	case []interface{}:
+		return append(dest, value...)
+	default:
+		return append(dest, value)
+	}
+}

--- a/template/parse_hook_include_test.go
+++ b/template/parse_hook_include_test.go
@@ -1,0 +1,79 @@
+package template
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseHookInclude(t *testing.T) {
+	cases := []struct {
+		File   string
+		Result *Template
+		Err    bool
+	}{
+		{
+			"parse-hook-include-main.json",
+			&Template{
+				Variables: map[string]*Variable{
+					"builder_type": {
+						Default: "builder-one",
+					},
+					"with_gui": {
+						Default: "yes",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"parse-hook-include-main-override.json",
+			&Template{
+				Variables: map[string]*Variable{
+					"builder_type": {
+						Default: "builder-overriden",
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		path, _ := filepath.Abs(fixtureDir(tc.File))
+		tpl, err := ParseFile(fixtureDir(tc.File))
+		if (err != nil) != tc.Err {
+			t.Fatalf("err: %#v", err)
+		}
+
+		if tc.Result != nil {
+			tc.Result.Path = path
+		}
+		if tpl != nil {
+			tpl.RawContents = nil
+		}
+		if !reflect.DeepEqual(tpl, tc.Result) {
+			t.Fatalf("bad: %s\n\n%#v\n\n%#v", tc.File, tpl, tc.Result)
+		}
+	}
+}
+
+func TestParseHookInclude_bad(t *testing.T) {
+	cases := []struct {
+		File     string
+		Expected string
+	}{
+		{"parse-hook-include-main-invalid-value.json", "neither a string nor an array"},
+		{"parse-hook-include-main-invalid-value-in-array.json", "not a string"},
+	}
+	for _, tc := range cases {
+		_, err := ParseFile(fixtureDir(tc.File))
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if !strings.Contains(err.Error(), tc.Expected) {
+			t.Fatalf("file: %s\nExpected: %s\n%s\n", tc.File, tc.Expected, err.Error())
+		}
+	}
+}

--- a/template/test-fixtures/parse-hook-include-main-invalid-value-in-array.json
+++ b/template/test-fixtures/parse-hook-include-main-invalid-value-in-array.json
@@ -1,0 +1,8 @@
+{
+    "variables" : {
+        "_include": [
+            "parse-hook-include-vars.json",
+            10
+        ]
+    }
+}

--- a/template/test-fixtures/parse-hook-include-main-invalid-value.json
+++ b/template/test-fixtures/parse-hook-include-main-invalid-value.json
@@ -1,0 +1,5 @@
+{
+    "variables" : {
+        "_include": 10
+    }
+}

--- a/template/test-fixtures/parse-hook-include-main-override.json
+++ b/template/test-fixtures/parse-hook-include-main-override.json
@@ -1,0 +1,6 @@
+{
+    "_include": "parse-hook-include-vars.json",
+    "variables": {
+        "builder_type": "builder-overriden"
+    }
+}

--- a/template/test-fixtures/parse-hook-include-main.json
+++ b/template/test-fixtures/parse-hook-include-main.json
@@ -1,0 +1,3 @@
+{
+    "_include": "parse-hook-include-vars.json"
+}

--- a/template/test-fixtures/parse-hook-include-vars-one.json
+++ b/template/test-fixtures/parse-hook-include-vars-one.json
@@ -1,0 +1,3 @@
+{
+    "builder_type": "builder-one"
+}

--- a/template/test-fixtures/parse-hook-include-vars-two.json
+++ b/template/test-fixtures/parse-hook-include-vars-two.json
@@ -1,0 +1,4 @@
+{
+    "builder_type": "builder-two",
+    "with_gui": "yes"
+}

--- a/template/test-fixtures/parse-hook-include-vars.json
+++ b/template/test-fixtures/parse-hook-include-vars.json
@@ -1,0 +1,8 @@
+{
+    "variables": {
+        "_include": [
+            "parse-hook-include-vars-one.json",
+            "parse-hook-include-vars-two.json"
+        ]
+    }
+}


### PR DESCRIPTION
This change adds support for including into templates JSON objects specified in separate files, e.g.:

file `user.json`:
<pre>
{
   "username": "packer",
   "password": "packer"
}
</pre>

file `virtulabox.json`:
<pre>
{
   "variables": {
      "_include": "user.json"
   },
   "builders": [{
      "type": "virtualbox-iso",
      "ssh_username": "{{user `username`}}",
      "ssh_password": "{{user `password`}}"
   }]
}
</pre>

file `vmware.json`:
<pre>
{
   "variables": {
      "_include": "user.json"
   },
   "builders": [{
      "type": "vmware-iso",
      "ssh_username": "{{user `username`}}",
      "ssh_password": "{{user `password`}}"
   }]
}
</pre>

* JSON objects are included into a raw template so they can contain references to template functions, user variables, etc.
* __include_ can be a single path or an array of paths
* __include_ can be specified at any level, including root
* values specified explicitly in a template have higher precedence over included ones
* included files can contain __include_ calls (includes can be nested)