### PR TITLE
Bug in Documentation: wrong path to import code for plugins

### DIFF
--- a/website/source/docs/extend/developing-plugins.html.md
+++ b/website/source/docs/extend/developing-plugins.html.md
@@ -55,7 +55,7 @@ dependencies.
 -   `github.com/mitchellh/packer` - Contains all the interfaces that you have to
     implement for any given plugin.
 
--   `github.com/mitchellh/packer/plugin` - Contains the code to serve
+-   `github.com/mitchellh/packer/packer/plugin` - Contains the code to serve
     the plugin. This handles all the inter-process communication stuff.
 
 There are two steps involved in creating a plugin:
@@ -71,7 +71,7 @@ implements the `packer.Builder` interface:
 
 ``` {.go}
 import (
-  "github.com/mitchellh/packer/plugin"
+  "github.com/mitchellh/packer/packer/plugin"
 )
 
 // Assume this implements packer.Builder


### PR DESCRIPTION

In file website/source/docs/extend/developing-plugins.html.md there is a wrong import path:

-  "github.com/mitchellh/packer/plugin"
+  "github.com/mitchellh/packer/packer/plugin"

