### PR TITLE
Change example windows shutdown_command

### DIFF
--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -41,7 +41,7 @@ the settings here.
   "source_path": "source.ovf",
   "ssh_username": "packer",
   "ssh_password": "packer",
-  "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
+  "shutdown_command": "shutdown /s"
 }
 ```
 


### PR DESCRIPTION
Why would sudo be expected to work on windows?
Tested this "shutdown /s" version with Edge VM image
