### PR TITLE
fix list display on chrome

### DIFF
--- a/website/source/assets/stylesheets/_components.scss
+++ b/website/source/assets/stylesheets/_components.scss
@@ -197,19 +197,22 @@ header .header {
         }
       }
 
-      ul, ol {
-        list-style-position: inside;
-        margin-top: $baseline;
-        margin-left: 20px;
-        margin-right: 20px;
+    ul, ol {
+      list-style-position: inside;
+      margin-top: $baseline;
+      margin-left: 20px;
+      margin-right: 20px;
 
-        li {
-          font-family: $serif;
-          font-size: 17px;
-          line-height: (30/17) !important;
-          margin-bottom: $baseline;
+      li {
+        font-family: $serif;
+        font-size: 17px;
+        line-height: (30/17) !important;
+        margin-bottom: $baseline;
+        p {
+          display: inline;
         }
       }
+    }
 
       ul {
         list-style-type: circle;


### PR DESCRIPTION
tested on safari and chrome on osx

before: 
<img width="342" alt="screen shot 2017-01-04 at 2 00 11 pm" src="https://cloud.githubusercontent.com/assets/15618/21662362/25c45248-d28e-11e6-90a4-cca4c712fb08.png">

after:

<img width="665" alt="screen shot 2017-01-04 at 2 58 12 pm" src="https://cloud.githubusercontent.com/assets/15618/21662383/3a6fa350-d28e-11e6-861c-f266e5e93d8b.png">

ignore width
