### PR TITLE
support OpenStack instance (not image) metadata

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -90,6 +90,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
 			ConfigDrive:      b.config.ConfigDrive,
+			InstanceMetadata: b.config.InstanceMetadata,
 		},
 		&StepGetPassword{
 			Debug: b.config.PackerDebug,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/mitchellh/packer/helper/communicator"
 	"github.com/mitchellh/packer/template/interpolate"
@@ -15,17 +16,18 @@ type RunConfig struct {
 	SSHInterface   string              `mapstructure:"ssh_interface"`
 	SSHIPVersion   string              `mapstructure:"ssh_ip_version"`
 
-	SourceImage      string   `mapstructure:"source_image"`
-	SourceImageName  string   `mapstructure:"source_image_name"`
-	Flavor           string   `mapstructure:"flavor"`
-	AvailabilityZone string   `mapstructure:"availability_zone"`
-	RackconnectWait  bool     `mapstructure:"rackconnect_wait"`
-	FloatingIpPool   string   `mapstructure:"floating_ip_pool"`
-	FloatingIp       string   `mapstructure:"floating_ip"`
-	SecurityGroups   []string `mapstructure:"security_groups"`
-	Networks         []string `mapstructure:"networks"`
-	UserData         string   `mapstructure:"user_data"`
-	UserDataFile     string   `mapstructure:"user_data_file"`
+	SourceImage      string            `mapstructure:"source_image"`
+	SourceImageName  string            `mapstructure:"source_image_name"`
+	Flavor           string            `mapstructure:"flavor"`
+	AvailabilityZone string            `mapstructure:"availability_zone"`
+	RackconnectWait  bool              `mapstructure:"rackconnect_wait"`
+	FloatingIpPool   string            `mapstructure:"floating_ip_pool"`
+	FloatingIp       string            `mapstructure:"floating_ip"`
+	SecurityGroups   []string          `mapstructure:"security_groups"`
+	Networks         []string          `mapstructure:"networks"`
+	UserData         string            `mapstructure:"user_data"`
+	UserDataFile     string            `mapstructure:"user_data_file"`
+	InstanceMetadata map[string]string `mapstructure:"instance_metadata"`
 
 	ConfigDrive bool `mapstructure:"config_drive"`
 
@@ -54,6 +56,15 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.SSHIPVersion != "" && c.SSHIPVersion != "4" && c.SSHIPVersion != "6" {
 		errs = append(errs, errors.New("SSH IP version must be either 4 or 6"))
+	}
+
+	for key, value := range c.InstanceMetadata {
+		if len(key) > 255 {
+			errs = append(errs, fmt.Errorf("Instance metadata key too long (max 255 bytes): %s", key))
+		}
+		if len(value) > 255 {
+			errs = append(errs, fmt.Errorf("Instance metadata value too long (max 255 bytes): %s", value))
+		}
 	}
 
 	return errs

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -21,6 +21,7 @@ type StepRunSourceServer struct {
 	UserData         string
 	UserDataFile     string
 	ConfigDrive      bool
+	InstanceMetadata map[string]string
 	server           *servers.Server
 }
 
@@ -65,6 +66,7 @@ func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction
 		UserData:         userData,
 		ConfigDrive:      &s.ConfigDrive,
 		ServiceClient:    computeClient,
+		Metadata:         s.InstanceMetadata,
 	}
 
 	var serverOptsExt servers.CreateOptsBuilder

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -106,6 +106,11 @@ builder.
 -   `metadata` (object of key/value strings) - Glance metadata that will be
     applied to the image.
 
+-   `instance_metadata` (object of key/value strings) - Metadata that is
+    applied to the server instance created by Packer. Also called server
+    properties in some documentation. The strings have a max size of 255 bytes
+    each.
+
 -   `networks` (array of strings) - A list of networks by UUID to attach to
     this instance.
 


### PR DESCRIPTION
This PR adds the ability to define metadata for the OpenStack instance started by packer. This is different from the `image_metadata` already supported, and can be useful for being able to 'tag' the instances being run by packer (that's my use-case anyway). Defining instance metadata was already supported by gophercloud so it was a straightforward addition.

I've put in some validation on the key and value lengths as if they are overly long the instance will fail to create (with an obtuse error message).

Hope this is alright, never used Go before so just muddled through this. Let me know what needs changing/adding.