### PR TITLE
Don't wait for the shutdown command for Hyper-V and VMware builders

### DIFF
--- a/builder/hyperv/common/step_shutdown.go
+++ b/builder/hyperv/common/step_shutdown.go
@@ -51,11 +51,6 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
-		// Wait for the command to run so we can print std{err,out}
-		// We don't care if the command errored, since we'll notice
-		// if the vm didn't shut down.
-		cmd.Wait()
-
 		log.Printf("Shutdown stdout: %s", stdout.String())
 		log.Printf("Shutdown stderr: %s", stderr.String())
 

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -57,11 +57,6 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionHalt
 		}
 
-		// Wait for the command to run so we can print std{err,out}
-		// We don't care if the command errored, since we'll notice
-		// if the vm didn't shut down.
-		cmd.Wait()
-
 		log.Printf("Shutdown stdout: %s", stdout.String())
 		log.Printf("Shutdown stderr: %s", stderr.String())
 


### PR DESCRIPTION
Fixes hang when running sysprep from the shutdown command for the VMware and Hyper-V builders. See comments in #4134.

Fixes #4134
