### PR TITLE
Better Windows support in puppet-server

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -63,8 +63,8 @@ type Config struct {
 	// If true, packer will ignore all exit-codes from a puppet run
 	IgnoreExitCodes bool `mapstructure:"ignore_exit_codes"`
 
-	GuestOSType    string `mapstructure:"guest_os_type"`
-	ConfigTemplate string `mapstructure:"config_template"`
+	// The Guest OS Type (unix or windows)
+	GuestOSType string `mapstructure:"guest_os_type"`
 }
 
 type guestOSTypeConfig struct {
@@ -73,7 +73,7 @@ type guestOSTypeConfig struct {
 }
 
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
-	provisioner.UnixOSType: guestOSTypeConfig{
+	provisioner.UnixOSType: {
 		stagingDir: "/tmp/packer-puppet-masterless",
 		executeCommand: "cd {{.WorkingDir}} && " +
 			"{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
@@ -84,7 +84,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 			"{{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}}" +
 			"{{.ManifestFile}}",
 	},
-	provisioner.WindowsOSType: guestOSTypeConfig{
+	provisioner.WindowsOSType: {
 		stagingDir: "C:/Windows/Temp/packer-puppet-masterless",
 		executeCommand: "cd {{.WorkingDir}} && " +
 			"{{.FacterVars}} && " +
@@ -212,17 +212,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = p.guestOSTypeConfig.executeCommand
-	}
-
-	if p.config.ConfigTemplate != "" {
-		fi, err := os.Stat(p.config.ConfigTemplate)
-		if err != nil {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Bad config template path: %s", err))
-		} else if fi.IsDir() {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Config template path must be a file: %s", err))
-		}
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -68,12 +68,13 @@ listed below:
 -   `puppet_server` (string) - Hostname of the Puppet server. By default
     "puppet" will be used.
 
--   `staging_dir` (string) - This is the directory where all the
-    configuration of Puppet by Packer will be placed. By default this
-    is /tmp/packer-puppet-server. This directory doesn't need to exist but
-    must have proper permissions so that the SSH user that Packer uses is able
-    to create directories and write into this folder. If the permissions are not
-    correct, use a shell provisioner prior to this to configure it properly.
+-   `staging_dir` (string) - This is the directory where all the configuration
+    of Puppet by Packer will be placed. By default this is "/tmp/packer-puppet-server"
+    when guest_os_type unix and "C:/Windows/Temp/packer-puppet-server" when windows.
+    This directory doesn't need to exist but must have proper permissions so that
+    the SSH user that Packer uses is able to create directories and write into this
+    folder. If the permissions are not correct, use a shell provisioner prior to this
+    to configure it properly.
 
 -   `puppet_bin_dir` (string) - The path to the directory that contains the puppet
     binary for running `puppet agent`. Usually, this would be found via the `$PATH`
@@ -83,18 +84,11 @@ listed below:
 -   `execute_command` (string) - This is optional. The command used to execute Puppet. This has
     various [configuration template
     variables](/docs/templates/configuration-templates.html) available. See
-    below for more information. By default, Packer uses the following command:
+    below for more information.
 
-```
-{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} \
-  {{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet agent --onetime --no-daemonize \
-  {{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}} \
-  {{if ne .Options \"\"}}{{.Options}} {{end}} \
-  {{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}} \
-  {{if ne .ClientCertPath \"\"}}--certdir='{{.ClientCertPath}}' {{end}} \
-  {{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' \
-  {{end}} --detailed-exitcodes
-```
+-   `guest_os_type` (string) - The target guest OS type, either "unix" or
+    "windows". Setting this to "windows" will cause the provisioner to use
+     Windows friendly paths and commands. By default, this is "unix".
 
 ## Default Facts
 


### PR DESCRIPTION
Reworking the puppet-server provisioner based on chef-client.

Paging @seanmalloy for review.

I've tested this against my Windows template, it works quite well and I was able to remove a lot of yucky workarounds from my packer template and do away with my mkdir patch.

@seanmalloy maybe you have time to give similar treatment to puppet-masterless?

Closes #4384
Closes mkdir issues described in #3850
