### PR TITLE
docs/qemu: Build on RHEL/RHEL variants errors if scsi disk interface is used

### DIFF
--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -146,10 +146,17 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     source, resize it according to `disk_size` and boot the image.
 
 -   `disk_interface` (string) - The interface to use for the disk. Allowed
-    values include any of "ide", "scsi", "virtio" or "virtio-scsi". Note also
+    values include any of "ide", "scsi", "virtio" or "virtio-scsi"^* . Note also
     that any boot commands or kickstart type scripts must have proper
     adjustments for resulting device names. The Qemu builder uses "virtio" by
     default.
+
+    ^* Please be aware that use of the "scsi" disk interface has been disabled
+    by Red Hat due to a bug described
+    [here](https://bugzilla.redhat.com/show_bug.cgi?id=1019220).
+    If you are running Qemu on RHEL or a RHEL variant such as CentOS, you
+    *must* choose one of the other listed interfaces. Using the "scsi"
+    interface under these circumstances will cause the build to fail.
 
 -   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
@@ -384,7 +391,7 @@ by the proper key:
 
 -   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
 
--   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key.
 
 -   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
 


### PR DESCRIPTION
Update the docs to make users aware that using `"disk_interface": "scsi"` will cause their build to fail when running Qemu on RHEL or RHEL variants. Red Hat disabled use of the scsi interface due to the bug described [here](https://bugzilla.redhat.com/show_bug.cgi?id=1019220).

Closes #4278
