### PR TITLE
Output error causing ebs volume deletion failure

### DIFF
--- a/builder/amazon/ebs/step_cleanup_volumes.go
+++ b/builder/amazon/ebs/step_cleanup_volumes.go
@@ -106,6 +106,7 @@ func (s *stepCleanupVolumes) Cleanup(state multistep.StateBag) {
 		_, err := ec2conn.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: aws.String(k)})
 		if err != nil {
 			ui.Say(fmt.Sprintf("Error deleting volume: %s", k))
+			ui.Say(fmt.Sprintf("The error is: %s", err))
 		}
 
 	}


### PR DESCRIPTION
When an ebs volume fails to delete, Packer reports that there
was an error deleting the volume and the volume id. But it doesn't
give you the details of what that error is. This commit adds the
error reported back to the standard output.

I'm a total newbie to Go and contributing to open source projects, so 
apologies in advance for any faux pas or errors.