### PR TITLE
step_http_server: make port range inclusive

### DIFF
--- a/common/step_http_server.go
+++ b/common/step_http_server.go
@@ -45,7 +45,8 @@ func (s *StepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
 
 		if portRange > 0 {
 			// Intn will panic if portRange == 0, so we do a check.
-			offset = uint(rand.Intn(portRange))
+			// Intn is from [0, n), so add 1 to make from [0, n]
+			offset = uint(rand.Intn(portRange + 1))
 		}
 
 		httpPort = offset + s.HTTPPortMin


### PR DESCRIPTION
before, setting min/max port to N and N+1 would always result in port N. This changes it so it would be a random value between [N, N+1].

Bug discovered in #4319