### PR TITLE
WIP: builder/amazon: Interpolate {{ .BuildRegion }} and {{ .SourceAMI }}

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -64,6 +64,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		InterpolateContext: &b.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
+				"ami_description",
+				"snapshot_tags",
+				"tags",
 				"command_wrapper",
 				"post_mount_commands",
 				"pre_mount_commands",
@@ -263,10 +266,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes:   b.config.AMIProductCodes,
 			SnapshotUsers:  b.config.SnapshotUsers,
 			SnapshotGroups: b.config.SnapshotGroups,
+			Ctx:            b.config.ctx,
 		},
 		&awscommon.StepCreateTags{
 			Tags:         b.config.AMITags,
 			SnapshotTags: b.config.SnapshotTags,
+			Ctx:          b.config.ctx,
 		},
 	)
 

--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -1,0 +1,6 @@
+package common
+
+type BuildInfoTemplate struct {
+	SourceAMI   string
+	BuildRegion string
+}

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -278,22 +278,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 		s.Tags["Name"] = "Packer Builder"
 	}
 
-	ec2Tags := make([]*ec2.Tag, 1, len(s.Tags))
-	for k, v := range s.Tags {
-		s.Ctx.Data = &BuildInfoTemplate{
-			SourceAMI:   s.SourceAMI,
-			BuildRegion: *ec2conn.Config.Region,
-		}
-		interpolatedValue, err := interpolate.Render(v, &s.Ctx)
-		if err != nil {
-			err = fmt.Errorf("Error processing tag: %s:%s - %s", k, v, err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(interpolatedValue)})
-	}
-	ec2Tags, err = ConvertToEC2Tags(s.Tags, *ec2conn.Config.Region, s.SourceAMI, s.Ctx, ui)
+	ec2Tags, err := ConvertToEC2Tags(s.Tags, *ec2conn.Config.Region, s.SourceAMI, s.Ctx)
 	if err != nil {
 		err := fmt.Errorf("Error tagging source instance: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/template/interpolate"
 )
 
 type StepRunSourceInstance struct {
@@ -32,6 +33,7 @@ type StepRunSourceInstance struct {
 	Tags                              map[string]string
 	UserData                          string
 	UserDataFile                      string
+	Ctx                               interpolate.Context
 
 	instanceId  string
 	spotRequest *ec2.SpotInstanceRequest
@@ -275,7 +277,29 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 	if _, exists := s.Tags["Name"]; !exists {
 		s.Tags["Name"] = "Packer Builder"
 	}
-	ec2Tags := ConvertToEC2Tags(s.Tags)
+
+	ec2Tags := make([]*ec2.Tag, 1, len(s.Tags))
+	for k, v := range s.Tags {
+		s.Ctx.Data = &BuildInfoTemplate{
+			SourceAMI:   s.SourceAMI,
+			BuildRegion: *ec2conn.Config.Region,
+		}
+		interpolatedValue, err := interpolate.Render(v, &s.Ctx)
+		if err != nil {
+			err = fmt.Errorf("Error processing tag: %s:%s - %s", k, v, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(interpolatedValue)})
+	}
+	ec2Tags, err = ConvertToEC2Tags(s.Tags, *ec2conn.Config.Region, s.SourceAMI, s.Ctx, ui)
+	if err != nil {
+		err := fmt.Errorf("Error tagging source instance: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Tags:      ec2Tags,

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -44,6 +44,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	err := config.Decode(&b.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &b.config.ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"ami_description",
+				"run_tags",
+				"run_volume_tags",
+				"snapshot_tags",
+				"tags",
+			},
+		},
 	}, raws...)
 	if err != nil {
 		return nil, err
@@ -137,10 +146,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
+			Ctx:                      b.config.ctx,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 		},
 		&stepTagEBSVolumes{
 			VolumeRunTags: b.config.VolumeRunTags,
+			Ctx:           b.config.ctx,
 		},
 		&awscommon.StepGetPassword{
 			Debug:   b.config.PackerDebug,
@@ -184,10 +195,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes:   b.config.AMIProductCodes,
 			SnapshotUsers:  b.config.SnapshotUsers,
 			SnapshotGroups: b.config.SnapshotGroups,
+			Ctx:            b.config.ctx,
 		},
 		&awscommon.StepCreateTags{
 			Tags:         b.config.AMITags,
 			SnapshotTags: b.config.SnapshotTags,
+			Ctx:          b.config.ctx,
 		},
 	}
 

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -36,24 +36,8 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionContinue
 	}
 
-	tags := make([]*ec2.Tag, len(s.VolumeRunTags))
-	for key, value := range s.VolumeRunTags {
-		s.Ctx.Data = &common.BuildInfoTemplate{
-			SourceAMI:   *sourceAMI.ImageId,
-			BuildRegion: *ec2conn.Config.Region,
-		}
-		interpolatedValue, err := interpolate.Render(value, &s.Ctx)
-		if err != nil {
-			err = fmt.Errorf("Error processing volume tag: %s:%s - %s", key, value, err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		tags = append(tags, &ec2.Tag{Key: &key, Value: &interpolatedValue})
-	}
-
 	ui.Say("Adding tags to source EBS Volumes")
-	tags, err := common.ConvertToEC2Tags(s.VolumeRunTags, *ec2conn.Config.Region, *sourceAMI.ImageId, s.Ctx, ui)
+	tags, err := common.ConvertToEC2Tags(s.VolumeRunTags, *ec2conn.Config.Region, *sourceAMI.ImageId, s.Ctx)
 	if err != nil {
 		err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)
 		state.Put("error", err)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -44,7 +44,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"run_tags",
-				"tags",
+				"ebs_volumes",
 			},
 		},
 	}, raws...)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -41,6 +41,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	err := config.Decode(&b.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &b.config.ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"run_tags",
+				"tags",
+			},
+		},
 	}, raws...)
 	if err != nil {
 		return nil, err
@@ -128,10 +134,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             launchBlockDevices,
 			Tags:                     b.config.RunTags,
+			Ctx:                      b.config.ctx,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 		},
 		&stepTagEBSVolumes{
 			VolumeMapping: b.config.VolumeMappings,
+			Ctx:           b.config.ctx,
 		},
 		&awscommon.StepGetPassword{
 			Debug:   b.config.PackerDebug,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -63,8 +63,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		InterpolateContext: &b.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
+				"ami_description",
 				"bundle_upload_command",
 				"bundle_vol_command",
+				"run_tags",
+				"run_volume_tags",
+				"snapshot_tags",
+				"tags",
 			},
 		},
 	}, configs...)
@@ -223,6 +228,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
+			Ctx:                      b.config.ctx,
 		},
 		&awscommon.StepGetPassword{
 			Debug:   b.config.PackerDebug,
@@ -265,10 +271,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ProductCodes:   b.config.AMIProductCodes,
 			SnapshotUsers:  b.config.SnapshotUsers,
 			SnapshotGroups: b.config.SnapshotGroups,
+			Ctx:            b.config.ctx,
 		},
 		&awscommon.StepCreateTags{
 			Tags:         b.config.AMITags,
 			SnapshotTags: b.config.SnapshotTags,
+			Ctx:          b.config.ctx,
 		},
 	}
 

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -75,7 +75,11 @@ each category, the available configuration keys are alphabetized.
 ### Optional:
 
 -   `ami_description` (string) - The description to set for the
-    resulting AMI(s). By default this description is empty.
+    resulting AMI(s). By default this description is empty. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with name of the region where this
+    is built.
 
 -   `ami_groups` (array of strings) - A list of groups that have access to
     launch the resulting AMI(s). By default no groups have permission to launch
@@ -210,7 +214,11 @@ each category, the available configuration keys are alphabetized.
     validation of the `ami_regions` configuration option. Default `false`.
 
 -   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
-     They will override AMI tags if already applied to snapshot.
+    They will override AMI tags if already applied to snapshot. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with name of the region where this
+    is built.
 
 -   `snapshot_groups` (array of strings) - A list of groups that have access to
     create volumes from the snapshot(s). By default no groups have permission to create
@@ -250,7 +258,12 @@ each category, the available configuration keys are alphabetized.
     -   `most_recent` (bool) - Selects the newest created image when true.
          This is most useful for selecting a daily distro build.
 
--   `tags` (object of key/value strings) - Tags applied to the AMI.
+-   `tags` (object of key/value strings) - Tags applied to the AMI. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with name of the region where this
+    is built.
+
 
 ## Basic Example
 

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -105,7 +105,10 @@ builder.
         volumes
 
 -   `ami_description` (string) - The description to set for the
-    resulting AMI(s). By default this description is empty.
+    resulting AMI(s). By default this description is empty. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `ami_groups` (array of strings) - A list of groups that have access to
     launch the resulting AMI(s). By default no groups have permission to launch
@@ -182,11 +185,17 @@ builder.
 
 -   `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
-    resulting AMI unless they're duplicated in `tags`.
+    resulting AMI unless they're duplicated in `tags`. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `run_volume_tags` (object of key/value strings) - Tags to apply to the volumes
     that are *launched* to create the AMI. These tags are *not* applied to the
-    resulting AMI unless they're duplicated in `tags`.
+    resulting AMI unless they're duplicated in `tags`. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `security_group_id` (string) - The ID (*not* the name) of the security group
     to assign to the instance. By default this is not set and Packer will
@@ -214,7 +223,10 @@ builder.
     user creating the AMI has permissions to create volumes from the backing snapshot(s).
 
 -   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
-     They will override AMI tags if already applied to snapshot.
+     They will override AMI tags if already applied to snapshot. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
     Example:
@@ -283,7 +295,10 @@ builder.
     required if you are using an non-default VPC.
 
 -   `tags` (object of key/value strings) - Tags applied to the AMI and
-    relevant snapshots.
+    relevant snapshots. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `temporary_key_pair_name` (string) - The name of the temporary keypair
     to generate. By default, Packer generates a name with a UUID.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -79,7 +79,10 @@ builder.
         volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard` for Magnetic
         volumes
     -   `tags` (map) - Tags to apply to the volume. These are retained after the
-        builder completes.
+        builder completes. This is a [configuration template]
+        (/docs/templates/configuration-templates.html) where the `SourceAMI`
+        variable is replaced with the source AMI ID and `BuildRegion` variable
+        is replaced with the value of `region`.
 
 -   `associate_public_ip_address` (boolean) - If using a non-default VPC, public
     IP addresses are not provided by default. If this is toggled, your new
@@ -102,7 +105,10 @@ builder.
 
 -   `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
-    resulting AMI unless they're duplicated in `tags`.
+    resulting AMI unless they're duplicated in `tags`. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `security_group_id` (string) - The ID (*not* the name) of the security group
     to assign to the instance. By default this is not set and Packer will

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -127,7 +127,10 @@ builder.
         volumes
 
 -   `ami_description` (string) - The description to set for the
-    resulting AMI(s). By default this description is empty.
+    resulting AMI(s). By default this description is empty. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `ami_groups` (array of strings) - A list of groups that have access to
     launch the resulting AMI(s). By default no groups have permission to launch
@@ -198,7 +201,10 @@ builder.
 
 -   `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
-    resulting AMI unless they're duplicated in `tags`.
+    resulting AMI unless they're duplicated in `tags`. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `security_group_id` (string) - The ID (*not* the name) of the security group
     to assign to the instance. By default this is not set and Packer will
@@ -290,7 +296,10 @@ builder.
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is
     required if you are using an non-default VPC.
 
--   `tags` (object of key/value strings) - Tags applied to the AMI.
+-   `tags` (object of key/value strings) - Tags applied to the AMI. This is a
+    [configuration template](/docs/templates/configuration-templates.html)
+    where the `SourceAMI` variable is replaced with the source AMI ID and
+    `BuildRegion` variable is replaced with the value of `region`.
 
 -   `temporary_key_pair_name` (string) - The name of the temporary key pair
     to generate. By default, Packer generates a name with an UUID.


### PR DESCRIPTION
This adds `{{ .BuildRegion }}` and `{{ .SourceAMI }}` variables that will be available in `ami_description`, `tags`, `run_tags`, `snapshot_tags`, and `run_volume_tags`.

This is important after the introduction of `source_ami_filter`. With this change you can for example add:

```json
"tags": {
  "Source AMI ID": "{{ .SourceAMI }}",
  "AMI Build Region": "{{ .BuildRegion }}" 
}