### PR TITLE
builder/amazon: fix run volume tagging

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -69,6 +69,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.WindowsPasswordTimeout = 10 * time.Minute
 	}
 
+	if c.RunTags == nil {
+		c.RunTags = make(map[string]string)
+	}
+
 	// Validation
 	errs := c.Comm.Prepare(ctx)
 	if c.SourceAmi == "" && c.SourceAmiFilter.Empty() {

--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -31,9 +31,9 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 		ui.Say(fmt.Sprintf("Adding tags to AMI (%s)...", ami))
 
 		// Convert tags to ec2.Tag format
-		amiTags := ConvertToEC2Tags(s.Tags, ui)
+		amiTags := ConvertToEC2Tags(s.Tags)
 		ui.Say(fmt.Sprintf("Snapshot tags:"))
-		snapshotTags := ConvertToEC2Tags(s.SnapshotTags, ui)
+		snapshotTags := ConvertToEC2Tags(s.SnapshotTags)
 
 		// Declare list of resources to tag
 		awsConfig := aws.Config{
@@ -128,10 +128,9 @@ func (s *StepCreateTags) Cleanup(state multistep.StateBag) {
 	// No cleanup...
 }
 
-func ConvertToEC2Tags(tags map[string]string, ui packer.Ui) []*ec2.Tag {
+func ConvertToEC2Tags(tags map[string]string) []*ec2.Tag {
 	var amiTags []*ec2.Tag
 	for key, value := range tags {
-		ui.Message(fmt.Sprintf("Adding tag: \"%s\": \"%s\"", key, value))
 		amiTags = append(amiTags, &ec2.Tag{
 			Key:   aws.String(key),
 			Value: aws.String(value),

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -295,7 +295,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 	if _, exists := s.Tags["Name"]; !exists {
 		s.Tags["Name"] = "Packer Builder"
 	}
-	ec2Tags := ConvertToEC2Tags(s.Tags, ui)
+	ec2Tags := ConvertToEC2Tags(s.Tags)
 
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Tags:      ec2Tags,

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -292,7 +292,9 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 	instance := latestInstance.(*ec2.Instance)
 
 	ui.Say(fmt.Sprintf("Adding tags to source instance:"))
-	s.Tags["Name"] = "Packer Builder"
+	if _, exists := s.Tags["Name"]; !exists {
+		s.Tags["Name"] = "Packer Builder"
+	}
 	ec2Tags := ConvertToEC2Tags(s.Tags, ui)
 
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -291,11 +291,9 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 
 	instance := latestInstance.(*ec2.Instance)
 
-	ec2Tags := make([]*ec2.Tag, 1, len(s.Tags)+1)
-	ec2Tags[0] = &ec2.Tag{Key: aws.String("Name"), Value: aws.String("Packer Builder")}
-	for k, v := range s.Tags {
-		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
-	}
+	ui.Say(fmt.Sprintf("Adding tags to source instance:"))
+	s.Tags["Name"] = "Packer Builder"
+	ec2Tags := ConvertToEC2Tags(s.Tags, ui)
 
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Tags:      ec2Tags,

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -302,8 +302,10 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 		Resources: []*string{instance.InstanceId},
 	})
 	if err != nil {
-		ui.Message(
-			fmt.Sprintf("Failed to tag a Name on the builder instance: %s", err))
+		err := fmt.Errorf("Error tagging source instance: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
 	}
 
 	if s.Debug {

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -34,7 +34,7 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ui.Say(fmt.Sprintf("Adding tags to source EBS Volumes:"))
-	tags := common.ConvertToEC2Tags(s.VolumeRunTags, ui)
+	tags := common.ConvertToEC2Tags(s.VolumeRunTags)
 
 	_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Resources: []*string{

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/builder/amazon/common"
 	"github.com/mitchellh/packer/packer"
 )
 
@@ -18,7 +19,6 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	if len(s.VolumeRunTags) > 0 {
-		ui.Say("Tagging source EBS volumes...")
 
 		volumeIds := make([]*string, 0)
 		for _, v := range instance.BlockDeviceMappings {
@@ -31,10 +31,8 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 			return multistep.ActionContinue
 		}
 
-		tags := make([]*ec2.Tag, len(s.VolumeRunTags))
-		for key, value := range s.VolumeRunTags {
-			tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
-		}
+		ui.Say(fmt.Sprintf("Adding tags to source EBS Volumes:"))
+		tags := common.ConvertToEC2Tags(s.VolumeRunTags, ui)
 
 		_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
 			Resources: []*string{

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -37,10 +37,8 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	tags := common.ConvertToEC2Tags(s.VolumeRunTags)
 
 	_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{
-			instance.BlockDeviceMappings[0].Ebs.VolumeId,
-		},
-		Tags: tags,
+		Resources: volumeIds,
+		Tags:      tags,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)

--- a/builder/amazon/ebs/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebs/step_tag_ebs_volumes.go
@@ -18,34 +18,35 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packer.Ui)
 
-	if len(s.VolumeRunTags) > 0 {
+	if len(s.VolumeRunTags) == 0 {
+		return multistep.ActionContinue
+	}
 
-		volumeIds := make([]*string, 0)
-		for _, v := range instance.BlockDeviceMappings {
-			if ebs := v.Ebs; ebs != nil {
-				volumeIds = append(volumeIds, ebs.VolumeId)
-			}
+	volumeIds := make([]*string, 0)
+	for _, v := range instance.BlockDeviceMappings {
+		if ebs := v.Ebs; ebs != nil {
+			volumeIds = append(volumeIds, ebs.VolumeId)
 		}
+	}
 
-		if len(volumeIds) == 0 {
-			return multistep.ActionContinue
-		}
+	if len(volumeIds) == 0 {
+		return multistep.ActionContinue
+	}
 
-		ui.Say(fmt.Sprintf("Adding tags to source EBS Volumes:"))
-		tags := common.ConvertToEC2Tags(s.VolumeRunTags, ui)
+	ui.Say(fmt.Sprintf("Adding tags to source EBS Volumes:"))
+	tags := common.ConvertToEC2Tags(s.VolumeRunTags, ui)
 
-		_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{
-				instance.BlockDeviceMappings[0].Ebs.VolumeId,
-			},
-			Tags: tags,
-		})
-		if err != nil {
-			err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
+	_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{
+			instance.BlockDeviceMappings[0].Ebs.VolumeId,
+		},
+		Tags: tags,
+	})
+	if err != nil {
+		err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION
replaces #4419

correctly tags source volumes

closes ##3573 