### PR TITLE
Update parallel-builds.html.md

### DIFF
--- a/website/source/intro/getting-started/parallel-builds.html.md
+++ b/website/source/intro/getting-started/parallel-builds.html.md
@@ -67,7 +67,8 @@ array.
   "api_token": "{{user `do_api_token`}}",
   "image": "ubuntu-14-04-x64",
   "region": "nyc3",
-  "size": "512mb"
+  "size": "512mb",
+  "ssh_username": "ubuntu"
 }
 ```
 
@@ -104,7 +105,8 @@ The entire template should now look like this:
     "api_token": "{{user `do_api_token`}}",
     "image": "ubuntu-14-04-x64",
     "region": "nyc3",
-    "size": "512mb"
+    "size": "512mb",
+    "ssh_username": "ubuntu"
   }],
   "provisioners": [{
     "type": "shell",


### PR DESCRIPTION
It seems that `ssh_username` is required from the packer binary.

