### PR TITLE
communicator/winrm: make directory upload behave more like scp

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/masterzen/winrm"
@@ -129,6 +131,9 @@ func (c *Communicator) Upload(path string, input io.Reader, _ *os.FileInfo) erro
 
 // UploadDir implementation of communicator.Communicator interface
 func (c *Communicator) UploadDir(dst string, src string, exclude []string) error {
+	if !strings.HasSuffix(src, "/") {
+		dst = fmt.Sprintf("%s\\%s", dst, filepath.Base(src))
+	}
 	log.Printf("Uploading dir '%s' to '%s'", src, dst)
 	wcp, err := c.newCopyClient()
 	if err != nil {


### PR DESCRIPTION
changes behavior to be in-line with the docs.
Resolves #3562