### PR TITLE
Fix no return of output when running Powershell elevated command

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -82,11 +82,7 @@ do {
 } while (!($t.state -eq 3))
 $result = $t.LastTaskResult
 if (Test-Path $log) {
-  try {
-    Takeown /F $log | Out-Null
-    Icacls $log /Grant:r Administrators:F /c /q 2>&1 | Out-Null
     Remove-Item $log -Force -ErrorAction SilentlyContinue | Out-Null
-  } catch { $Global:Error.RemoveAt(0) }
 }
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($s) | Out-Null
 exit $result`))


### PR DESCRIPTION
Using $env:Temp and %TEMP% to specify the path for storing output from the elevated command causes issues when the elevated command is being run as a different user from the user the provisioner is being run under.

Since $env:Temp (and %TEMP) will be evaluated differently for the two users we end up with the output from the elevated command being written to one location, while the provisioner looks in another. Clearly, since the two locations are different, the provisioner will not be able to read and subsequently display the output from the elevated command.

Using an environment variable valid in the system context means the path will be the same for both users. As such the provisioner will be able to read the output file and pass the contents back to the Packer console.

Fixes #4271 