### PR TITLE
builder/amazon-ebsvolume: Fix interpolation of block_device

### DIFF
--- a/builder/amazon/ebsvolume/block_device.go
+++ b/builder/amazon/ebsvolume/block_device.go
@@ -2,6 +2,7 @@ package ebsvolume
 
 import (
 	awscommon "github.com/mitchellh/packer/builder/amazon/common"
+	"github.com/mitchellh/packer/template/interpolate"
 )
 
 type BlockDevice struct {
@@ -9,15 +10,20 @@ type BlockDevice struct {
 	Tags                  map[string]string `mapstructure:"tags"`
 }
 
-func commonBlockDevices(mappings []BlockDevice) awscommon.BlockDevices {
+func commonBlockDevices(mappings []BlockDevice, ctx *interpolate.Context) (awscommon.BlockDevices, error) {
 	result := make([]awscommon.BlockDevice, len(mappings))
+
 	for i, mapping := range mappings {
-		result[i] = mapping.BlockDevice
+		interpolateBlockDev, err := interpolate.RenderInterface(&mapping.BlockDevice, ctx)
+		if err != nil {
+			return awscommon.BlockDevices{}, err
+		}
+		result[i] = *interpolateBlockDev.(*awscommon.BlockDevice)
 	}
 
 	return awscommon.BlockDevices{
 		LaunchBlockDevices: awscommon.LaunchBlockDevices{
 			LaunchMappings: result,
 		},
-	}
+	}, nil
 }

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -28,7 +28,8 @@ type Config struct {
 	VolumeMappings        []BlockDevice `mapstructure:"ebs_volumes"`
 	AMIEnhancedNetworking bool          `mapstructure:"enhanced_networking"`
 
-	ctx interpolate.Context
+	launchBlockDevices awscommon.BlockDevices
+	ctx                interpolate.Context
 }
 
 type Builder struct {
@@ -56,6 +57,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	var errs *packer.MultiError
 	errs = packer.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.RunConfig.Prepare(&b.config.ctx)...)
+
+	b.config.launchBlockDevices, err = commonBlockDevices(b.config.VolumeMappings, &b.config.ctx)
+	if err != nil {
+		errs = packer.MultiErrorAppend(errs, err)
+	}
 
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, errs
@@ -96,8 +102,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put("hook", hook)
 	state.Put("ui", ui)
 
-	launchBlockDevices := commonBlockDevices(b.config.VolumeMappings)
-
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepSourceAMIInfo{
@@ -132,7 +136,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
 			EbsOptimized:             b.config.EbsOptimized,
 			AvailabilityZone:         b.config.AvailabilityZone,
-			BlockDevices:             launchBlockDevices,
+			BlockDevices:             b.config.launchBlockDevices,
 			Tags:                     b.config.RunTags,
 			Ctx:                      b.config.ctx,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,


### PR DESCRIPTION
In #4399 interpolation of `ebs_volumes` was reomved but this stoppes user variables from be interpolated there, excpet for in `tags`. This fixes that.