### PR TITLE
always check for an error first when walking a path

### DIFF
--- a/builder/hyperv/common/artifact.go
+++ b/builder/hyperv/common/artifact.go
@@ -23,11 +23,14 @@ type artifact struct {
 func NewArtifact(dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			files = append(files, path)
 		}
 
-		return err
+		return nil
 	}
 
 	if err := filepath.Walk(dir, visit); err != nil {

--- a/builder/parallels/common/artifact.go
+++ b/builder/parallels/common/artifact.go
@@ -28,6 +28,9 @@ type artifact struct {
 func NewArtifact(dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		for _, unnecessaryFile := range unnecessaryFiles {
 			if unnecessary, _ := regexp.MatchString(unnecessaryFile, path); unnecessary {
 				return os.RemoveAll(path)
@@ -38,7 +41,7 @@ func NewArtifact(dir string) (packer.Artifact, error) {
 			files = append(files, path)
 		}
 
-		return err
+		return nil
 	}
 
 	if err := filepath.Walk(dir, visit); err != nil {

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -444,11 +444,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Compile the artifact list
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			files = append(files, path)
 		}
 
-		return err
+		return nil
 	}
 
 	if err := filepath.Walk(b.config.OutputDir, visit); err != nil {

--- a/builder/virtualbox/common/artifact.go
+++ b/builder/virtualbox/common/artifact.go
@@ -23,6 +23,9 @@ type artifact struct {
 func NewArtifact(dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			files = append(files, path)
 		}

--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -23,11 +23,13 @@ type localArtifact struct {
 func NewLocalArtifact(dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			files = append(files, path)
 		}
-
-		return err
+		return nil
 	}
 
 	if err := filepath.Walk(dir, visit); err != nil {

--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -114,6 +114,9 @@ func (s *StepCreateFloppy) Run(state multistep.StateBag) multistep.StepAction {
 
 	var crawlDirectoryFiles []string
 	crawlDirectory := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			crawlDirectoryFiles = append(crawlDirectoryFiles, path)
 			ui.Message(fmt.Sprintf("Adding file: %s", path))

--- a/common/step_create_floppy_test.go
+++ b/common/step_create_floppy_test.go
@@ -21,6 +21,9 @@ const TestFixtures = "test-fixtures"
 func getDirectory(path string) []string {
 	var result []string
 	walk := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() && !strings.HasSuffix(path, "/") {
 			path = path + "/"
 		}


### PR DESCRIPTION
Closes #4465

unfortunately the behavior of `walk` isn't very clear in the docs. I assume that `info` will be nil if there's an error, so let's check for one before trying to access it.