### PR TITLE
Vmware vsphere vnc port timeout increased (issue #3205)

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -205,7 +205,7 @@ func (d *ESX5Driver) VNCAddress(_ string, portMin, portMax uint) (string, uint, 
 		}
 		address := fmt.Sprintf("%s:%d", d.Host, port)
 		log.Printf("Trying address: %s...", address)
-		l, err := net.DialTimeout("tcp", address, 1*time.Second)
+		l, err := net.DialTimeout("tcp", address, 5*time.Second)
 
 		if err != nil {
 			if e, ok := err.(*net.OpError); ok {


### PR DESCRIPTION
Increase the vmware vsphere timeout for detecting if a network port is unused.
Esxi did not respond with a refused connection answer in a timely manner.

Should close issue #3205