### PR TITLE
Incorrect return 4486

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -97,12 +97,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	// Set some defaults
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = "cd {{.WorkingDir}} && " +
-			"{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
+			"{{.FacterVars}} {{if .Sudo}} sudo -iE {{end}}" +
 			"{{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet apply " +
-			"--verbose --modulepath='{{.ModulePath}}' " +
+			"--detailed-exitcodes " +
+			"--modulepath='{{.ModulePath}}' " +
 			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
-			"--detailed-exitcodes " +
 			"{{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}}" +
 			"{{.ManifestFile}}"
 	}
@@ -227,8 +227,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		facterVars = append(facterVars, fmt.Sprintf("FACTER_%s='%s'", k, v))
 	}
 
-	// Execute Puppet
-	p.config.ctx.Data = &ExecuteTemplate{
+	data := ExecuteTemplate{
 		FacterVars:      strings.Join(facterVars, " "),
 		HieraConfigPath: remoteHieraConfigPath,
 		ManifestDir:     remoteManifestDir,
@@ -237,13 +236,22 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		PuppetBinDir:    p.config.PuppetBinDir,
 		Sudo:            !p.config.PreventSudo,
 		WorkingDir:      p.config.WorkingDir,
-		ExtraArguments:  strings.Join(p.config.ExtraArguments, " "),
+		ExtraArguments:  "",
 	}
+
+	p.config.ctx.Data = &data
+	_ExtraArguments, err := interpolate.Render(strings.Join(p.config.ExtraArguments, " "), &p.config.ctx)
+	if err != nil {
+		return err
+	}
+	data.ExtraArguments = _ExtraArguments
+
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {
 		return err
 	}
 
+	// Execute command
 	cmd := &packer.RemoteCmd{
 		Command: command,
 	}

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -86,6 +86,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"execute_command",
+				"extra_arguments",
 			},
 		},
 	}, raws...)

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -20,6 +20,9 @@ type Config struct {
 	// The command used to execute Puppet.
 	ExecuteCommand string `mapstructure:"execute_command"`
 
+	// Additional arguments to pass when executing Puppet
+	ExtraArguments []string `mapstructure:"extra_arguments"`
+
 	// Additional facts to set when executing Puppet
 	Facter map[string]string
 
@@ -66,6 +69,7 @@ type ExecuteTemplate struct {
 	Options              string
 	PuppetBinDir         string
 	Sudo                 bool
+	ExtraArguments       string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
@@ -75,6 +79,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"execute_command",
+				"extra_arguments",
 			},
 		},
 	}, raws...)
@@ -173,7 +178,9 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		Options:              p.config.Options,
 		PuppetBinDir:         p.config.PuppetBinDir,
 		Sudo:                 !p.config.PreventSudo,
+		ExtraArguments:       strings.Join(p.config.ExtraArguments, " "),
 	}
+
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {
 		return err
@@ -240,5 +247,6 @@ func (p *Provisioner) commandTemplate() string {
 		"{{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}}" +
 		"{{if ne .ClientCertPath \"\"}}--certdir='{{.ClientCertPath}}' {{end}}" +
 		"{{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' {{end}}" +
-		"--detailed-exitcodes"
+		"--detailed-exitcodes " +
+		"{{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}}"
 }

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -119,7 +119,7 @@ func (c *CLI) Run() (int, error) {
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
-		return 1, nil
+		return 0, nil
 	}
 
 	// Attempt to get the factory function for creating the command
@@ -127,7 +127,7 @@ func (c *CLI) Run() (int, error) {
 	raw, ok := c.commandTree.Get(c.Subcommand())
 	if !ok {
 		c.HelpWriter.Write([]byte(c.HelpFunc(c.helpCommands(c.subcommandParent())) + "\n"))
-		return 1, nil
+		return 2, nil
 	}
 
 	command, err := raw.(CommandFactory)()
@@ -138,7 +138,7 @@ func (c *CLI) Run() (int, error) {
 	// If we've been instructed to just print the help, then print it
 	if c.IsHelp() {
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	// If there is an invalid flag, then error
@@ -147,14 +147,14 @@ func (c *CLI) Run() (int, error) {
 			"Invalid flags before the subcommand. If these flags are for\n" +
 				"the subcommand, please put them after the subcommand.\n\n"))
 		c.commandHelp(command)
-		return 1, nil
+		return 2, nil
 	}
 
 	code := command.Run(c.SubcommandArgs())
 	if code == RunResultHelp {
 		// Requesting help
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	return code, nil


### PR DESCRIPTION
Changes shell exit codes to be 'zero' on benign commands like version and help. Return '2' on syntax/parameter errors.

Closes #4486 