### PR TITLE
Eol handling for the Repo and build process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-
+* text=auto
+*.go text eol=lf
+*.sh text eol=lf
 common/test-fixtures/root/*	eol=lf

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VET?=$(shell ls -d */ | grep -v vendor | grep -v website)
 GITSHA:=$(shell git rev-parse HEAD)
 # Get the current local branch name from git (if we can, this may be blank)
 GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
-GOFMT_FILES?=$$(find . -not -path "./vendor/*" -name "*.go")
+GOFMT_FILES?=find . -path ./vendor -prune -o -name "*.go"
 
 default: deps generate test dev
 
@@ -41,10 +41,13 @@ dev: deps ## Build and install a development build
 	@PACKER_DEV=1 GO15VENDOREXPERIMENT=1 sh -c "$(CURDIR)/scripts/build.sh"
 
 fmt: ## Format Go code
-	@gofmt -w -s $(GOFMT_FILES)
+	@$(GOFMT_FILES) | xargs gofmt -w -s
 
 fmt-check: ## Check go code formatting
-	$(CURDIR)/scripts/gofmtcheck.sh $(GOFMT_FILES)
+	@echo "==> Checking that code complies with gofmt requirements..."
+	@echo "You can use the command: \`make fmt\` to reformat code."
+	@$(GOFMT_FILES) | xargs $(CURDIR)/scripts/gofmtcheck.sh
+	@echo "Check complete."
 
 # Install js-beautify with npm install -g js-beautify
 fmt-examples:

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 
-# Check gofmt
-echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -s -l ${@})
-if [[ -n ${gofmt_files} ]]; then
-    echo 'gofmt needs running on the following files:'
-    echo "${gofmt_files}"
-    echo "You can use the command: \`make fmt\` to reformat code."
-    exit 1
-fi
-echo "Check passed."
+for f in $@; do
+  [ -n "`dos2unix 2>/dev/null < $f | gofmt -s -d`" ] && echo $f
+done
 
+# always return success or else 'make' will abort
 exit 0


### PR DESCRIPTION
Use .gitattributes to force unix style line endings for shell scripts and Go files. Build scripts do not run on Windows+Cygwin otherwise and the gofmt tool considers every file as needing format changes because of CRLF. This last should probably be taken as an upstream bug for the DOS/Win version of Go not properly handling this very common issue.

The Makefile overloads the command line length so replaced with an xargs call.
Gox is also not likely to be on the user's PATH. It appears to land in $GOPATH/bin.

This helps address and provide solutions to #2735 
