### PR TITLE
Make rdp and vnc links clickable by adding the protocol

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -116,7 +116,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 			ui.Message(fmt.Sprintf(
 				"The VM will be run headless, without a GUI. If you want to\n"+
 					"view the screen of the VM, connect via VNC without a password to\n"+
-					"%s:%d", vncIp, vncPort))
+					"vnc://%s:%d", vncIp, vncPort))
 		} else {
 			ui.Message("The VM will be run headless, without a GUI, as configured.\n" +
 				"If the run isn't succeeding as you expect, please enable the GUI\n" +

--- a/builder/virtualbox/common/step_run.go
+++ b/builder/virtualbox/common/step_run.go
@@ -40,7 +40,7 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 			ui.Message(fmt.Sprintf(
 				"The VM will be run headless, without a GUI. If you want to\n"+
 					"view the screen of the VM, connect via VRDP without a password to\n"+
-					"%s:%d", vrdpIp, vrdpPort))
+					"rdp://%s:%d", vrdpIp, vrdpPort))
 		} else {
 			ui.Message("The VM will be run headless, without a GUI, as configured.\n" +
 				"If the run isn't succeeding as you expect, please enable the GUI\n" +

--- a/builder/vmware/common/step_run.go
+++ b/builder/vmware/common/step_run.go
@@ -48,7 +48,7 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 			ui.Message(fmt.Sprintf(
 				"The VM will be run headless, without a GUI. If you want to\n"+
 					"view the screen of the VM, connect via VNC with the password \"%s\" to\n"+
-					"%s:%d", vncPassword, vncIp, vncPort))
+					"vnc://%s:%d", vncPassword, vncIp, vncPort))
 		} else {
 			ui.Message("The VM will be run headless, without a GUI, as configured.\n" +
 				"If the run isn't succeeding as you expect, please enable the GUI\n" +


### PR DESCRIPTION
iTerm2 (and I suspect other terminals) will automatically parse a protocol://ip pattern and turn it into a clickable link. If the OS has a program registered to handle that type of URL it will open automatically. This saves a few extra clicks when you want to attach to a remote session during a build.