### PR TITLE
new default template function

### DIFF
--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -139,11 +139,16 @@ func funcGenTimestamp(ctx *Context) interface{} {
 }
 
 func funcGenDefault(ctx *Context) interface{} {
-	return func(def, input string) string {
-		if input == "" {
-			return def
+	return func(def, input string) (string, error) {
+		if !ctx.EnableEnv {
+			// The error message doesn't have to be that detailed since
+			// semantic checks should catch this.
+			return "", errors.New("env vars are not allowed here")
 		}
-		return input
+		if input == "" {
+			return def, nil
+		}
+		return input, nil
 	}
 }
 

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -26,13 +26,14 @@ func init() {
 var FuncGens = map[string]FuncGenerator{
 	"build_name":   funcGenBuildName,
 	"build_type":   funcGenBuildType,
+	"default":      funcGenDefault,
 	"env":          funcGenEnv,
 	"isotime":      funcGenIsotime,
 	"pwd":          funcGenPwd,
 	"template_dir": funcGenTemplateDir,
 	"timestamp":    funcGenTimestamp,
-	"uuid":         funcGenUuid,
 	"user":         funcGenUser,
+	"uuid":         funcGenUuid,
 
 	"upper": funcGenPrimitive(strings.ToUpper),
 	"lower": funcGenPrimitive(strings.ToLower),
@@ -134,6 +135,15 @@ func funcGenTemplateDir(ctx *Context) interface{} {
 func funcGenTimestamp(ctx *Context) interface{} {
 	return func() string {
 		return strconv.FormatInt(InitTime.Unix(), 10)
+	}
+}
+
+func funcGenDefault(ctx *Context) interface{} {
+	return func(def, input string) string {
+		if input == "" {
+			return def
+		}
+		return input
 	}
 }
 

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -318,7 +318,7 @@ func TestFuncDefault_disable(t *testing.T) {
 		i := &I{Value: tc.Input}
 		result, err := i.Render(ctx)
 		if err == nil {
-			t.Fatalf("Input: %s\n\nerr: %s", tc.Input, err)
+			t.Fatalf("Input: %s\n\nexpected an error", tc.Input)
 		}
 
 		if result != tc.Output {

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -278,6 +278,7 @@ func TestFuncDefault(t *testing.T) {
 
 	for _, tc := range cases {
 		ctx := &Context{
+			EnableEnv: true,
 			UserVariables: map[string]string{
 				"foo": tc.UserValue,
 			},
@@ -285,6 +286,38 @@ func TestFuncDefault(t *testing.T) {
 		i := &I{Value: tc.Input}
 		result, err := i.Render(ctx)
 		if err != nil {
+			t.Fatalf("Input: %s\n\nerr: %s", tc.Input, err)
+		}
+
+		if result != tc.Output {
+			t.Fatalf("Input: %s\n\nGot: %s", tc.Input, result)
+		}
+	}
+}
+func TestFuncDefault_disable(t *testing.T) {
+	cases := []struct {
+		UserValue string
+		Input     string
+		Output    string
+	}{
+		{
+			"foo",
+			`{{user "foo" | default "bar"}}`,
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		ctx := &Context{
+			EnableEnv: false,
+			UserVariables: map[string]string{
+				"foo": tc.UserValue,
+			},
+		}
+
+		i := &I{Value: tc.Input}
+		result, err := i.Render(ctx)
+		if err == nil {
 			t.Fatalf("Input: %s\n\nerr: %s", tc.Input, err)
 		}
 

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -257,3 +257,39 @@ func TestFuncUser(t *testing.T) {
 		}
 	}
 }
+
+func TestFuncDefault(t *testing.T) {
+	cases := []struct {
+		UserValue string
+		Input     string
+		Output    string
+	}{
+		{
+			"foo",
+			`{{user "foo" | default "bar"}}`,
+			"foo",
+		},
+		{
+			"",
+			`{{user "foo" | default "bar"}}`,
+			"bar",
+		},
+	}
+
+	for _, tc := range cases {
+		ctx := &Context{
+			UserVariables: map[string]string{
+				"foo": tc.UserValue,
+			},
+		}
+		i := &I{Value: tc.Input}
+		result, err := i.Render(ctx)
+		if err != nil {
+			t.Fatalf("Input: %s\n\nerr: %s", tc.Input, err)
+		}
+
+		if result != tc.Output {
+			t.Fatalf("Input: %s\n\nGot: %s", tc.Input, result)
+		}
+	}
+}

--- a/website/source/docs/templates/user-variables.html.md
+++ b/website/source/docs/templates/user-variables.html.md
@@ -162,6 +162,11 @@ results in the following variables:
 | aws_access_key | foo |
 | aws_secret_key | baz |
 
+## Defaults
+
+The default function allows you to specify a default value for a given 
+
+
 # Recipes
 
 ## Making a provisioner step conditional on the value of a variable

--- a/website/source/docs/templates/user-variables.html.md
+++ b/website/source/docs/templates/user-variables.html.md
@@ -94,6 +94,28 @@ single source of input to a template that a user can easily discover using
 that is evaluated by shell during a variable expansion. As packer doesn't run
 inside a shell, it won't expand `~`.
 
+
+## Default function
+
+The default function allows you to specify a default value for a given
+environment variable. As with the `env` function, the `default` function is
+available *only* within the `variables` section. Here's how the above example
+would look with a default:
+
+``` {.javascript}
+{
+  "variables": {
+    "my_foo": "{{env `MY_FOO` | default `bar`}}",
+  },
+
+  // ...
+}
+```
+
+If `MY_FOO` is available in the environment, this would act as usual. If it
+were not set, the value of `my_foo` would become `bar`.
+
+
 ## Setting Variables
 
 Now that we covered how to define and use variables within a template, the next
@@ -161,11 +183,6 @@ results in the following variables:
 | --- | --- |
 | aws_access_key | foo |
 | aws_secret_key | baz |
-
-## Defaults
-
-The default function allows you to specify a default value for a given 
-
 
 # Recipes
 


### PR DESCRIPTION
Closes #3457

Allows setting defaults for env vars. 

```
variables: {
    foo: {{ env `FOO` | default `bar`}}
}
```

If `${FOO}` is not set, the value of `foo` will be `bar`.