### PR TITLE
make note about using UUIDs vs timestamps

### DIFF
--- a/website/source/docs/templates/configuration-templates.html.md
+++ b/website/source/docs/templates/configuration-templates.html.md
@@ -17,6 +17,8 @@ For example, the `{{timestamp}}` function can be used in any string to generate
 the current timestamp. This is useful for configurations that require unique
 keys, such as AMI names. By setting the AMI name to something like
 `My Packer AMI {{timestamp}}`, the AMI name will be unique down to the second.
+If you need greater than one second granularity, you should use `{{uuid}}`, as
+when you have multiple builders in the same template.
 
 In addition to globally available functions like timestamp shown before, some
 configurations have special local variables that are available only for that


### PR DESCRIPTION
Closes #4446

Not going to note PACKER_RUNTIME_UUID since it's kind of a power-user feature, and it would require restructuring the docs a bit.