### PR TITLE
[googlecompute] fix bug of creating image from custom image_family

### DIFF
--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -67,7 +67,7 @@ func getImage(c *Config, d Driver) (*Image, error) {
 	if c.SourceImageProjectId == "" {
 		return d.GetImage(name, fromFamily)
 	} else {
-		return d.GetImageFromProject(c.SourceImageProjectId, c.SourceImage, fromFamily)
+		return d.GetImageFromProject(c.SourceImageProjectId, name, fromFamily)
 	}
 }
 


### PR DESCRIPTION
Hi
This PR fixes the following error:
```
==> userverlua-node: Error getting source image for instance creation: googleapi: Error 404: The resource 'projects/bidswitch/global/images/family' was not found, notFound
Build 'userverlua-node' errored: Error getting source image for instance creation: googleapi: Error 404: The resource 'projects/bidswitch/global/images/family' was not found, notFound
```

It happens when both parameters `source_image_family` and `source_image_project_id` are set. And prevents to create google image from custom image family.
