### PR TITLE
Contributing: Precise that GOPATH contain workspace folder not the golang folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,11 @@ following steps in order to be able to compile and test Packer. These instructio
 1. [Download](https://golang.org/dl) and install Go. The instructions below
    are for go 1.6. Earlier versions of Go are no longer supported.
 
-2. Set and export the `GOPATH` environment variable and update your `PATH`. For
+2. Create your workspace folder (for example `$HOME/work`). Set and export the `GOPATH` environment variable and update your `PATH`. For
    example, you can add to your `.bash_profile`.
 
     ```
-    export GOPATH=$HOME/go
+    export GOPATH=$HOME/work
     export PATH=$PATH:$GOPATH/bin
     ```
 


### PR DESCRIPTION
Following blindly the current document may mislead people like me about the content of GOPATH.
Making reference to the workspace terminology and change its name in the example from go to something else could avoid this error.