### PR TITLE
Adding OnHostMaintenance option for googlecompute builder

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Network              string            `mapstructure:"network"`
 	NetworkProjectId     string            `mapstructure:"network_project_id"`
 	OmitExternalIP       bool              `mapstructure:"omit_external_ip"`
+	OnHostMaintenance    string            `mapstructure:"on_host_maintenance"`
 	Preemptible          bool              `mapstructure:"preemptible"`
 	RawStateTimeout      string            `mapstructure:"state_timeout"`
 	Region               string            `mapstructure:"region"`
@@ -91,6 +92,12 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.ImageDescription == "" {
 		c.ImageDescription = "Created by Packer"
+	}
+	// Possible values:
+	//   "MIGRATE"
+	//   "TERMINATE"
+	if c.OnHostMaintenance == "" {
+		c.OnHostMaintenance = "MIGRATE"
 	}
 
 	if c.ImageName == "" {

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -93,11 +93,21 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.ImageDescription == "" {
 		c.ImageDescription = "Created by Packer"
 	}
-	// Possible values:
-	//   "MIGRATE"
-	//   "TERMINATE"
-	if c.OnHostMaintenance == "" {
+	// Setting OnHostMaintenance Correct Defaults
+	//   "MIGRATE" : Possible if Preemptible is false
+	//   "TERMINATE": Posssible if Preemptible is true
+	if c.OnHostMaintenance == "" && c.Preemptible {
 		c.OnHostMaintenance = "MIGRATE"
+	}
+
+	if c.OnHostMaintenance == "" && !c.Preemptible {
+		c.OnHostMaintenance = "TERMINATE"
+	}
+
+	// Make sure user sets a valid value for on_host_maintenance option
+	if !(c.OnHostMaintenance == "MIGRATE" || c.OnHostMaintenance == "TERMINATE") {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("on_host_maintenance must be one of MIGRATE or TERMINATE."))
 	}
 
 	if c.ImageName == "" {

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -105,6 +105,21 @@ func TestConfigPrepare(t *testing.T) {
 			true,
 		},
 		{
+			"on_host_maintenance",
+			nil,
+			false,
+		},
+		{
+			"on_host_maintenance",
+			"TERMINATE",
+			false,
+		},
+		{
+			"on_host_maintenance",
+			"SO VERY BAD",
+			false,
+		},
+		{
 			"preemptible",
 			nil,
 			false,

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -117,7 +117,7 @@ func TestConfigPrepare(t *testing.T) {
 		{
 			"on_host_maintenance",
 			"SO VERY BAD",
-			false,
+			true,
 		},
 		{
 			"preemptible",

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -69,6 +69,7 @@ type InstanceConfig struct {
 	Network             string
 	NetworkProjectId    string
 	OmitExternalIP      bool
+	OnHostMaintenance   string
 	Preemptible         bool
 	Region              string
 	Scopes              []string

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -386,7 +386,8 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 			},
 		},
 		Scheduling: &compute.Scheduling{
-			Preemptible: c.Preemptible,
+			OnHostMaintenance: c.OnHostMaintenance,
+			Preemptible:       c.Preemptible,
 		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			{

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -110,6 +110,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		Network:             c.Network,
 		NetworkProjectId:    c.NetworkProjectId,
 		OmitExternalIP:      c.OmitExternalIP,
+		OnHostMaintenance:   c.OnHostMaintenance,
 		Preemptible:         c.Preemptible,
 		Region:              c.Region,
 		ServiceAccountEmail: c.Account.ClientEmail,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -178,6 +178,13 @@ builder.
     `use_internal_ip` must be true if this property is true.
 
 -   `preemptible` (boolean) - If true, launch a preembtible instance.
+-   'on_host_maintenance' (string) - Sets Host Maintenance Option
+     valid strings "MIGRATE" and "TERMINATE" please see
+     [GCE Instance Scheduling Options](https://cloud.google.com/compute/docs/instances/setting-instance-scheduling-options)
+     Not all machine_type in google support MIGRATE (machines with gpu)
+     also preemptiblity will impact available options
+     - preemptible == true , defaults to TERMINATE
+     - preemptible == false , defaults to MIGRATE
 
 -   `region` (string) - The region in which to launch the instance. Defaults to
     to the region hosting the specified `zone`.


### PR DESCRIPTION
Adding ability for googlecompute builder to set OnHostMaintenance option when creating instances. Using default "MIGRATE" does not work with all google Machine Types. 