### PR TITLE
Conditional ignore `force` flag for `docker-tag`

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -284,27 +284,25 @@ func (d *DockerDriver) TagImage(id string, repo string, force bool) error {
 	// for more detail, please refer to the following links:
 	// - https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag
 	// - https://github.com/docker/docker/pull/23090
-	output, err := exec.Command("docker", "--version").Output()
+	version_running, err := d.Version()
 	if err != nil {
 		return err
 	}
 
-	match := regexp.MustCompile(version.VersionRegexpRaw).FindSubmatch(output)
-	if match == nil {
-		return fmt.Errorf("Unknown Docker version: %s", output)
+	version_deprecated, err := version.NewVersion(string("1.12.0"))
+	if err != nil {
+		// should never reach this line
+		return err
 	}
 
-	version_running, _ := version.NewVersion(string(match[0]))
-	version_deprecated, _ := version.NewVersion("1.12.0")
-
-	if version_running.LessThan(version_deprecated) {
-		if force {
+	if force {
+		if version_running.LessThan(version_deprecated) {
 			args = append(args, "-f")
+		} else {
+			// do nothing if Docker version >= 1.12.0
+			log.Printf("[WARN] option: \"force\" will be ignored here")
+			log.Printf("since it was removed after Docker 1.12.0 released")
 		}
-	} else {
-		// do nothing if Docker version >= 1.12.0
-		log.Printf("[WARN] option: \"force\" will be ignored here")
-		log.Printf("since it was removed after Docker 1.12.0 released")
 	}
 	args = append(args, id, repo)
 

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -303,7 +303,8 @@ func (d *DockerDriver) TagImage(id string, repo string, force bool) error {
 		}
 	} else {
 		// do nothing if Docker version >= 1.12.0
-		log.Printf("[WARN] force is removed since Docker 1.12.0")
+		log.Printf("[WARN] option: \"force\" will be ignored here")
+		log.Printf("since it was removed after Docker 1.12.0 released")
 	}
 	args = append(args, id, repo)
 

--- a/website/source/docs/post-processors/docker-tag.html.md
+++ b/website/source/docs/post-processors/docker-tag.html.md
@@ -33,7 +33,7 @@ repository is required.
 
 -   `force` (boolean) - If true, this post-processor forcibly tag the image even
     if tag name is collided. Default to `false`.
-    But it will be ignore if Docker version greater or equal than 1.12.0,
+    But it will be ignored if Docker &gt;= 1.12.0 was detected,
     since the `force` option was removed after 1.12.0. [reference](https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag)
 
 ## Example

--- a/website/source/docs/post-processors/docker-tag.html.md
+++ b/website/source/docs/post-processors/docker-tag.html.md
@@ -33,6 +33,8 @@ repository is required.
 
 -   `force` (boolean) - If true, this post-processor forcibly tag the image even
     if tag name is collided. Default to `false`.
+    But it will be ignore if Docker version greater or equal than 1.12.0,
+    since the `force` option was removed after 1.12.0. [reference](https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag)
 
 ## Example
 


### PR DESCRIPTION
`docker tag -f` will now become an error, since it was removed after
upgrading docker daemon to 1.12.0 (or later)

this PR is to bypass `force` flag if docker >= 1.12.0 was detected

reference:
- https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag
- https://github.com/docker/docker/pull/23090

Closes #3771 