### PR TITLE
add reuse_ips option for openstack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -102,6 +102,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepAllocateIp{
 			FloatingIpPool: b.config.FloatingIpPool,
 			FloatingIp:     b.config.FloatingIp,
+			ReuseIps:       b.config.ReuseIps,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -23,6 +23,7 @@ type RunConfig struct {
 	RackconnectWait  bool              `mapstructure:"rackconnect_wait"`
 	FloatingIpPool   string            `mapstructure:"floating_ip_pool"`
 	FloatingIp       string            `mapstructure:"floating_ip"`
+	ReuseIps         bool              `mapstructure:"reuse_ips"`
 	SecurityGroups   []string          `mapstructure:"security_groups"`
 	Networks         []string          `mapstructure:"networks"`
 	UserData         string            `mapstructure:"user_data"`

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -122,6 +122,13 @@ builder.
     launch the server to create the AMI. If not specified, Packer will use the
     environment variable `OS_REGION_NAME`, if set.
 
+-   `reuse_ips` (boolean) - Whether or not to attempt to reuse existing
+    unassigned floating ips in the project before allocating a new one. Note
+    that it is not possible to safely do this concurrently, so if you are
+    running multiple openstack builds concurrently, or if other processes are
+    assigning and using floating IPs in the same openstack project while packer
+    is running, you should not set this to true. Defaults to false.
+
 -   `security_groups` (array of strings) - A list of security groups by name to
     add to this instance.
 


### PR DESCRIPTION
add reuse_ips option for the openstack builder and use it to control whether it will attempt to reuse existing unassigned floating ips rather than allocating a new one. the default value is for `reuse_ips` to be `false` which represents a change in the default behavior in order to fix the issue of running concurrent packer builds against the same openstack project, in which sometimes the packer openstack builder attempts to assign multiple instances to the same floating ip. if `reuse_ips` is set to `true`, the openstack builder should behave identically to how it did before this change. 

the `reuse_ips` option has no effect if `floating_ip` is set, and the behavior will be identical to before this change - the openstack builder will attempt to assign the specific floating ip according to the value of `floating_ip`. 

Closes #4551 
