### PR TITLE
Always set both SRIOV and ENA when Enhanced Networking is enabled

### DIFF
--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -75,9 +75,14 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		registerOpts = buildRegisterOpts(config, image, newMappings)
 	}
 
-	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
+		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
+		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
+
+		// Set EnaSupport to true
+		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
+		registerOpts.EnaSupport = aws.Bool(true)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/builder/amazon/common/step_modify_ebs_instance.go
+++ b/builder/amazon/common/step_modify_ebs_instance.go
@@ -17,16 +17,32 @@ func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.St
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packer.Ui)
 
-	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if s.EnableEnhancedNetworking {
-		ui.Say("Enabling Enhanced Networking...")
+		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
+		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
+		ui.Say("Enabling Enhanced Networking (SR-IOV)...")
 		simple := "simple"
-		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
+		_, err_iov := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 			InstanceId:      instance.InstanceId,
 			SriovNetSupport: &ec2.AttributeValue{Value: &simple},
 		})
-		if err != nil {
-			err := fmt.Errorf("Error enabling Enhanced Networking on %s: %s", *instance.InstanceId, err)
+		if err_iov != nil {
+			err := fmt.Errorf("Error enabling Enhanced Networking (SR-IOV) on %s: %s", *instance.InstanceId, err_iov)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		// Set EnaSupport to true.
+		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
+		ui.Say("Enabling Enhanced Networking (ENA)...")
+		truthy := true
+		_, err_ena := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
+			InstanceId: instance.InstanceId,
+			EnaSupport: &ec2.AttributeBooleanValue{Value: &truthy},
+		})
+		if err_ena != nil {
+			err := fmt.Errorf("Error enabling Enhanced Networking (ENA) on %s: %s", *instance.InstanceId, err_ena)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -101,7 +101,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Message(fmt.Sprintf("Found Image ID: %s", *image.ImageId))
 
-	// Enhanced Networking (SriovNetSupport) can only be enabled on HVM AMIs.
+	// Enhanced Networking can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5
 	if s.EnhancedNetworking && *image.VirtualizationType != "hvm" {
 		err := fmt.Errorf("Cannot enable enhanced networking, source AMI '%s' is not HVM", s.SourceAmi)

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -35,9 +35,14 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		BlockDeviceMappings: blockDevices,
 	}
 
-	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
+		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
+		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
+
+		// Set EnaSupport to true
+		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
+		registerOpts.EnaSupport = aws.Bool(true)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -29,9 +29,14 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		registerOpts.VirtualizationType = aws.String(config.AMIVirtType)
 	}
 
-	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	if config.AMIEnhancedNetworking {
+		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
+		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
+
+		// Set EnaSupport to true.
+		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
+		registerOpts.EnaSupport = aws.Bool(true)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -122,7 +122,7 @@ each category, the available configuration keys are alphabetized.
     forces Packer to find an open device automatically.
 
 -   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport) on HVM-compatible AMIs. If true, add
+    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -161,7 +161,7 @@ builder.
     Default `false`.
 
 -   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport) on HVM-compatible AMIs. If true, add
+    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -100,7 +100,7 @@ builder.
     Default `false`.
 
 -   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport) on HVM-compatible AMIs. If true, add
+    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
 
 -   `iam_instance_profile` (string) - The name of an [IAM instance

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -185,7 +185,7 @@ builder.
     Default `false`.
 
 -   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport) on HVM-compatible AMIs. If true, add
+    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing


### PR DESCRIPTION
Following up from #4312 - observing that there is no overlap between instances that support the SR-IOV network driver and the ENA network driver, and that a single AMI can support both drivers, it seems the simplest solution is that both types of networking should be enabled when Enhanced Networking = true.

Set SriovNetSupport to "simple". As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge).

Set EnaSupport to true. As of February 2017, this applies to P2, R4, X1, and m4.16xlarge.