### PR TITLE
Update docs for deprovision and defaults

### DIFF
--- a/examples/azure/debian.json
+++ b/examples/azure/debian.json
@@ -41,6 +41,7 @@
       "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
     ],
     "inline_shebang": "/bin/sh -x",
+    "skip_clean": true,
     "type": "shell"
   }]
 }

--- a/examples/azure/windows.json
+++ b/examples/azure/windows.json
@@ -17,32 +17,29 @@
     "subscription_id": "{{user `subscription_id`}}",
     "object_id": "{{user `object_id`}}",
 
+    "capture_container_name": "images",
+    "capture_name_prefix": "packer",
 
-            "capture_container_name": "images",
-            "capture_name_prefix": "packer",
+    "os_type": "Windows",
+    "image_publisher": "MicrosoftWindowsServer",
+    "image_offer": "WindowsServer",
+    "image_sku": "2012-R2-Datacenter",
 
-            "os_type": "Windows",
-            "image_publisher": "MicrosoftWindowsServer",
-            "image_offer": "WindowsServer",
-            "image_sku": "2012-R2-Datacenter",
+    "communicator": "winrm",
+    "winrm_use_ssl": "true",
+    "winrm_insecure": "true",
+    "winrm_timeout": "3m",
+    "winrm_username": "packer",
 
-            "communicator": "winrm",
-            "winrm_use_ssl": "true",
-            "winrm_insecure": "true",
-            "winrm_timeout": "3m",
-            "winrm_username": "packer",
-
-            "location": "West US",
-            "vm_size": "Standard_A2"
-        }
-    ],
-    "provisioners": [
-        {
-            "type": "powershell",
-            "inline": [
-                "dir c:\\"
-            ]
-        }
+    "location": "West US",
+    "vm_size": "Standard_A2"
+  }],
+  "provisioners": [{
+    "type": "powershell",
+    "inline": [
+      "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
+      "& $Env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /shutdown /quiet"
     ]
+  }]
 }
 

--- a/examples/azure/windows_custom_image.json
+++ b/examples/azure/windows_custom_image.json
@@ -32,9 +32,10 @@
     }
   ],
   "provisioners": [{
-      "type": "powershell",
-      "inline": [
-        "dir c:\\"
-      ]
+    "type": "powershell",
+    "inline": [
+      "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
+      "& $Env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /shutdown /quiet"
+    ]
   }]
 }


### PR DESCRIPTION
Change the Windows samples to include sysprep.

Document the default user name for Linux, and why it was chosen.

Document temp_compute_name and temp_resource_group_name, and provide a
reason why you would want to override them.

Document the deprovision process for Windows and Linux.

Document the skip_clean option as it pertains to Linux deprovision.