### PR TITLE
Change EC2 WindowsPasswordTimeout to 20 minutes

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -66,7 +66,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if c.WindowsPasswordTimeout == 0 {
-		c.WindowsPasswordTimeout = 10 * time.Minute
+		c.WindowsPasswordTimeout = 20 * time.Minute
 	}
 
 	if c.RunTags == nil {


### PR DESCRIPTION
10 minutes is often exceeded when using a custom source AMI which has been sysprepped.

Packer's log message already reads:

"It is normal for this process to take up to 15 minutes, but it usually takes around 5."

Increasing the timeout to 20 minutes allows this to work more often. The packer documentation already states that this timeout defaults to 20 minutes (but is currently incorrect - the default is actually 10 minutes).