### PR TITLE
azure: Use a more long term image sku

### DIFF
--- a/examples/azure/ubuntu_quickstart.json
+++ b/examples/azure/ubuntu_quickstart.json
@@ -17,10 +17,10 @@
     "os_type": "Linux",
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
-    "image_sku": "16.04.0-LTS",
+    "image_sku": "16.04-LTS",
 
     "location": "West US",
-    "vm_size": "Standard_A2"
+    "vm_size": "Standard_DS1_v2"
   }],
   "provisioners": [{
     "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",


### PR DESCRIPTION
Move from 16.04.0-LTS to 16.04-LTS, which should track the latest LTS
changes better.

Move to a recommended VM size.
