### PR TITLE
build/amazon-ebssurrogate: Add region copy, attributes, tags steps

### DIFF
--- a/builder/amazon/common/step_tag_ebs_volumes.go
+++ b/builder/amazon/common/step_tag_ebs_volumes.go
@@ -1,21 +1,20 @@
-package ebs
+package common
 
 import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/builder/amazon/common"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/template/interpolate"
 )
 
-type stepTagEBSVolumes struct {
+type StepTagEBSVolumes struct {
 	VolumeRunTags map[string]string
 	Ctx           interpolate.Context
 }
 
-func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
+func (s *StepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	instance := state.Get("instance").(*ec2.Instance)
 	sourceAMI := state.Get("source_image").(*ec2.Image)
@@ -37,7 +36,7 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ui.Say("Adding tags to source EBS Volumes")
-	tags, err := common.ConvertToEC2Tags(s.VolumeRunTags, *ec2conn.Config.Region, *sourceAMI.ImageId, s.Ctx)
+	tags, err := ConvertToEC2Tags(s.VolumeRunTags, *ec2conn.Config.Region, *sourceAMI.ImageId, s.Ctx)
 	if err != nil {
 		err := fmt.Errorf("Error tagging source EBS Volumes on %s: %s", *instance.InstanceId, err)
 		state.Put("error", err)
@@ -59,6 +58,6 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepTagEBSVolumes) Cleanup(state multistep.StateBag) {
+func (s *StepTagEBSVolumes) Cleanup(state multistep.StateBag) {
 	// No cleanup...
 }

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -149,7 +149,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:                      b.config.ctx,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 		},
-		&stepTagEBSVolumes{
+		&awscommon.StepTagEBSVolumes{
 			VolumeRunTags: b.config.VolumeRunTags,
 			Ctx:           b.config.ctx,
 		},

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -163,6 +163,14 @@ builder.
 -   `force_delete_snapshot` (boolean) - Force Packer to delete snapshots associated with
     AMIs, which have been deregistered by `force_deregister`. Default `false`.
 
+-   `encrypt_boot` (boolean) - Instruct packer to automatically create a copy of the
+    AMI with an encrypted boot volume (discarding the initial unencrypted AMI in the
+    process). Default `false`.
+
+-   `kms_key_id` (string) - The ID of the KMS key to use for boot volume encryption.
+    This only applies to the main `region`, other regions where the AMI will be copied
+    will be encrypted by the default EBS KMS key.
+
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
     to launch the EC2 instance with.


### PR DESCRIPTION
As pointed out in the initial code review of #4351, some of the steps from the standard EBS builder were (intetionally) omitted. It turns out that these actually are useful, and the original rationale for the omission was wrong. Consequently, this commit adds in the following steps:

- `StepPrevalidate`
- `StepTagEBSVolumes`
- `StepDeregisterAMI`
- `StepCreateEncryptedAMICopy`
- `StepAMIRegionCopy`
- `StepModifyAMIAttribute`
- `StepCreateTags`

We also fix the interpolation filter and documentation to reflect these additions, though the majority were already documented and just not functional.

Should be applied in conjunction with #4600 to make the builder work correctly.