### PR TITLE
vmware/esx: try for longer to connect to vnc port

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -205,7 +205,7 @@ func (d *ESX5Driver) VNCAddress(_ string, portMin, portMax uint) (string, uint, 
 		}
 		address := fmt.Sprintf("%s:%d", d.Host, port)
 		log.Printf("Trying address: %s...", address)
-		l, err := net.DialTimeout("tcp", address, 5*time.Second)
+		l, err := net.DialTimeout("tcp", address, 30*time.Second)
 
 		if err != nil {
 			if e, ok := err.(*net.OpError); ok {


### PR DESCRIPTION
Closes #2676

It's unclear to me that the above issue is still a problem, but there was a comment indicating that this patch fixed it.

It seems like the original ticket was maybe to do with how go on windows handled dial timeouts. I looked a bit at the go source, and it just uses context deadlines, so if there was an OS problem it's likely been fixed.

I'm not sure the comment about increasing the timeout is related to the original issue, but there's no harm in increasing it, since the dial will error right away if nothing's listening on the port. Will let someone open another issue if the original problem creeps up again