### PR TITLE
document how aws-sdk uses the shared credentials file

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -81,8 +81,8 @@ following steps:
     - Looks for the credentials file in the `AWS_SHARED_CREDENTIALS_FILE`
       environment variable, and if that's empty, use the default credentials
       file (`.aws/credentials`) in the user's home directory.
-    - Uses the profile set in the `AWS_PROFILE` environment variable. If the
-      environment variable is not set, uses "default" as the profile.
+    - Uses the profile name set in the `AWS_PROFILE` environment variable. If
+      the environment variable is not set, uses "default" as the profile name.
 
 3.  Lookup an IAM role for the current EC2 instance (if you're running in EC2)
 

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -27,7 +27,7 @@ Packer supports the following builders at the moment:
     that device. This is an **advanced builder and should not be used by
     newcomers**. However, it is also the fastest way to build an EBS-backed AMI
     since no new EC2 instance needs to be launched.
-    
+
 -   [amazon-ebssurrogate](/docs/builders/amazone-ebssurrogate.html) - Create EBS
     -backed AMIs from scratch. Works similarly to the `chroot` builder but does
     not require running in AWS. This is an **advanced builder and should not be
@@ -78,8 +78,11 @@ following steps:
 
 2.  Look for [local AWS configuration
     files](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files)
-    -   First `~/.aws/credentials`
-    -   Next based on `AWS_PROFILE`
+    - Looks for the credentials file in the `AWS_SHARED_CREDENTIALS_FILE`
+      environment variable, and if that's empty, use the default credentials
+      file (`.aws/credentials`) in the user's home directory.
+    - Uses the profile set in the `AWS_PROFILE` environment variable. If the
+      environment variable is not set, uses "default" as the profile.
 
 3.  Lookup an IAM role for the current EC2 instance (if you're running in EC2)
 


### PR DESCRIPTION
from https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/\#SharedCredentialsProvider

Closes #4553

The docs in master are a little confusing (bad copy & paste job I suspect), but I think generally correct.

I'm not sure I want to document the `"profile"` key in the aws builders, since I don't understand it. It looks like it was added in #3143