### PR TITLE
builder/parallels-iso: Configuration of disk type, plain or expanding

### DIFF
--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -37,6 +37,7 @@ type Config struct {
 
 	BootCommand        []string `mapstructure:"boot_command"`
 	DiskSize           uint     `mapstructure:"disk_size"`
+	DiskType           string   `mapstructure:"disk_type"`
 	GuestOSType        string   `mapstructure:"guest_os_type"`
 	HardDriveInterface string   `mapstructure:"hard_drive_interface"`
 	HostInterfaces     []string `mapstructure:"host_interfaces"`
@@ -87,6 +88,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		b.config.DiskSize = 40000
 	}
 
+	if b.config.DiskType == "" {
+		b.config.DiskType = "expand"
+	}
+
 	if b.config.HardDriveInterface == "" {
 		b.config.HardDriveInterface = "sata"
 	}
@@ -102,6 +107,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.VMName == "" {
 		b.config.VMName = fmt.Sprintf("packer-%s", b.config.PackerBuildName)
+	}
+
+	if b.config.DiskType != "expand" && b.config.DiskType != "plain" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("disk_type can only be expand, or plain"))
 	}
 
 	if b.config.HardDriveInterface != "ide" && b.config.HardDriveInterface != "sata" && b.config.HardDriveInterface != "scsi" {

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -114,6 +114,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			errs, errors.New("disk_type can only be expand, or plain"))
 	}
 
+	if b.config.DiskType == "plain" && !b.config.SkipCompaction {
+		b.config.SkipCompaction = true
+		warnings = append(warnings,
+			"'skip_compaction' is enforced to be true for plain disks.")
+	}
+
 	if b.config.HardDriveInterface != "ide" && b.config.HardDriveInterface != "sata" && b.config.HardDriveInterface != "scsi" {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("hard_drive_interface can only be ide, sata, or scsi"))

--- a/builder/parallels/iso/builder_test.go
+++ b/builder/parallels/iso/builder_test.go
@@ -130,6 +130,47 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_DiskType(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test a default boot_wait
+	delete(config, "disk_type")
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if b.config.DiskType != "expand" {
+		t.Fatalf("bad: %s", b.config.DiskType)
+	}
+
+	// Test with a bad
+	config["disk_type"] = "fake"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test with a good
+	config["disk_type"] = "plain"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_HardDriveInterface(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/parallels/iso/builder_test.go
+++ b/builder/parallels/iso/builder_test.go
@@ -134,7 +134,7 @@ func TestBuilderPrepare_DiskType(t *testing.T) {
 	var b Builder
 	config := testConfig()
 
-	// Test a default boot_wait
+	// Test a default disk_type
 	delete(config, "disk_type")
 	warns, err := b.Prepare(config)
 	if len(warns) > 0 {
@@ -159,8 +159,21 @@ func TestBuilderPrepare_DiskType(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
-	// Test with a good
+	// Test with plain disk with wrong setting for compaction
 	config["disk_type"] = "plain"
+	config["skip_compaction"] = false
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) == 0 {
+		t.Fatalf("should have warning")
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test with plain disk with correct setting for compaction
+	config["disk_type"] = "plain"
+	config["skip_compaction"] = true
 	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
@@ -169,6 +182,7 @@ func TestBuilderPrepare_DiskType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error: %s", err)
 	}
+
 }
 
 func TestBuilderPrepare_HardDriveInterface(t *testing.T) {

--- a/builder/parallels/iso/step_create_disk.go
+++ b/builder/parallels/iso/step_create_disk.go
@@ -22,6 +22,7 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 	command := []string{
 		"set", vmName,
 		"--device-add", "hdd",
+		"--type", config.DiskType,
 		"--size", strconv.FormatUint(uint64(config.DiskSize), 10),
 		"--iface", config.HardDriveInterface,
 	}

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -75,8 +75,8 @@ type PluginCommand struct {
 var Builders = map[string]packer.Builder{
 	"amazon-chroot":       new(amazonchrootbuilder.Builder),
 	"amazon-ebs":          new(amazonebsbuilder.Builder),
-	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
 	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
+	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
 	"amazon-instance":     new(amazoninstancebuilder.Builder),
 	"azure-arm":           new(azurearmbuilder.Builder),
 	"cloudstack":          new(cloudstackbuilder.Builder),

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -75,8 +75,8 @@ type PluginCommand struct {
 var Builders = map[string]packer.Builder{
 	"amazon-chroot":       new(amazonchrootbuilder.Builder),
 	"amazon-ebs":          new(amazonebsbuilder.Builder),
-	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
 	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
+	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
 	"amazon-instance":     new(amazoninstancebuilder.Builder),
 	"azure-arm":           new(azurearmbuilder.Builder),
 	"cloudstack":          new(cloudstackbuilder.Builder),

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -109,7 +109,7 @@ builder.
     defaults to `expand`. Valid options are `expand` (expanding disk) that the
     image file is small initially and grows in size as you add data to it, and
     `plain` (plain disk) that the image file has a fixed size from the moment it
-    is created (i.e the space is allocated for the drive fully). Plain disks
+    is created (i.e the space is allocated for the full drive). Plain disks
     perform faster than expanding disks. `skip_compaction` will be set to true
     automatically for plain disks.
 

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -105,6 +105,13 @@ builder.
 -   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
 
+-   `disk_type` (string) - The type for image file based virtual disk drives,
+    defaults to `expand`. Valid options are `expand` (expanding disk) that the
+    image file is small initially and grows in size as you add data to it, and
+    `plain` (plain disk) that the image file has a fixed size from the moment it
+    is created (i.e the space is allocated for the drive fully). Plain disks
+    perform faster than expanding disks.
+
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
     unattended Windows installs, which look for an `Autounattend.xml` file on
@@ -273,7 +280,7 @@ proper key:
 
 -   `<leftAltOn>` `<rightAltOn>`  - Simulates pressing and holding the alt key.
 
--   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key. 
+-   `<leftCtrlOn>` `<rightCtrlOn>` - Simulates pressing and holding the ctrl key.
 
 -   `<leftShiftOn>` `<rightShiftOn>` - Simulates pressing and holding the shift key.
 
@@ -287,9 +294,9 @@ proper key:
     sending any additional keys. This is useful if you have to generally wait
     for the UI to update before typing more.
 
-When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them, 
-otherwise they will be held down until the machine reboots. Use lowercase 
-characters as well inside modifiers. 
+When using modifier keys `ctrl`, `alt`, `shift` ensure that you release them,
+otherwise they will be held down until the machine reboots. Use lowercase
+characters as well inside modifiers.
 
 For example: to simulate ctrl+c use `<leftCtrlOn>c<leftCtrlOff>`.
 

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -110,7 +110,8 @@ builder.
     image file is small initially and grows in size as you add data to it, and
     `plain` (plain disk) that the image file has a fixed size from the moment it
     is created (i.e the space is allocated for the drive fully). Plain disks
-    perform faster than expanding disks.
+    perform faster than expanding disks. `skip_compaction` will be set to true
+    automatically for plain disks.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
@@ -225,9 +226,10 @@ builder.
     "5m", or five minutes.
 
 -   `skip_compaction` (boolean) - Virtual disk image is compacted at the end of
-    the build process using `prl_disk_tool` utility. In certain rare cases, this
-    might corrupt the resulting disk image. If you find this to be the case,
-    you can disable compaction using this configuration value.
+    the build process using `prl_disk_tool` utility (except for the case that
+    `disk_type` is set to `plain`). In certain rare cases, this might corrupt
+    the resulting disk image. If you find this to be the case, you can disable
+    compaction using this configuration value.
 
 -   `vm_name` (string) - This is the name of the PVM directory for the new
     virtual machine, without the file extension. By default this is


### PR DESCRIPTION
This PR adds the ability to configure the disk type when building a Parallels image from an ISO file.
Plain disks have better performance than expanding disks, which provides an option for users with more concerns on performance rather than disk space.

I checked there's no existing issues regarding this feature.
I ran `go fmt` before submitting this PR, which is why there're unrelated style changes as well.

Below is the information from [Parallels Command-Line Reference]( http://download.parallels.com/desktop/v12/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf)
```
 prlctl set ID|VM_name --device-add hdd [--image name] [--type expand|plain] [--size number] [--split] [--iface ide|scsi] [--position number] [--enable|--disable]

--type expand|plain        For image file based virtual disk drives, specified the disk type:
• expand -- expanding disk. The image file is small initially and grows in size as you add data to it. This is the default virtual disk type.
• plain -- plain disk. The image file has a fixed size from the moment it is created (i.e the space is allocated for the drive fully). Plain disks perform faster than expanding disks.
```

UPDATES:
`skip_compaction` will be set to true and a warning is added.
```
Warnings for build 'parallels-iso':

* A checksum type of 'none' was specified. Since ISO files are so big,
a checksum is highly recommended.
* 'skip_compaction' is enforced to be true for plain disks.

==> parallels-iso: Downloading or copying ISO
...
```