### PR TITLE
Add floppy size limitation notice.

### DIFF
--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -172,13 +172,13 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     is attached as the first floppy device. Currently, no support exists for
     creating sub-directories on the floppy. Wildcard characters (\*, ?,
     and \[\]) are allowed. Directory names are also allowed, which will add all
-    the files found in the directory to the floppy.
+    the files found in the directory to the floppy. The summary size of the listed files must not exceed 1.44 MB. The supported ways to move large files into the OS are using `http_directory` or [the file provisioner]( https://www.packer.io/docs/provisioners/file.html).
 
 -   `floppy_dirs` (array of strings) - A list of directories to place onto
     the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when
     your floppy disk includes drivers or if you just want to organize it's
-    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
+    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed. The maximum summary size of all files in the listed directories are the same as in `floppy_files`.
 
 -   `format` (string) - Either "qcow2" or "raw", this specifies the output
     format of the virtual machine image. This defaults to `qcow2`.


### PR DESCRIPTION
Should help people dealing with #4570 and #3328 because packer copies `floppy_files` to floppy without any error even if they exceed 1.44 MB limit. `floppy_dirs`throws error about FAT size limit exceeded but without mentioning that real issue is the floppy size limit:
```
Build 'qemu' errored: Error adding path virtio_iso to floppy: FAT FULL
```