### PR TITLE
builder/hyper-v: validate output dir in step, not in config

### DIFF
--- a/builder/hyperv/common/output_config.go
+++ b/builder/hyperv/common/output_config.go
@@ -2,9 +2,9 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/template/interpolate"
-	"os"
 )
 
 type OutputConfig struct {
@@ -16,13 +16,5 @@ func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		c.OutputDir = fmt.Sprintf("output-%s", pc.PackerBuildName)
 	}
 
-	var errs []error
-	if !pc.PackerForce {
-		if _, err := os.Stat(c.OutputDir); err == nil {
-			errs = append(errs, fmt.Errorf(
-				"Output directory '%s' already exists. It must not exist.", c.OutputDir))
-		}
-	}
-
-	return errs
+	return nil
 }

--- a/builder/hyperv/common/output_config_test.go
+++ b/builder/hyperv/common/output_config_test.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/packer/common"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/packer/common"
 )
 
 func TestOutputConfigPrepare(t *testing.T) {
@@ -39,7 +40,7 @@ func TestOutputConfigPrepare_exists(t *testing.T) {
 		PackerForce:     false,
 	}
 	errs := c.Prepare(testConfigTemplate(t), pc)
-	if len(errs) == 0 {
-		t.Fatal("should have errors")
+	if len(errs) != 0 {
+		t.Fatal("should not have errors")
 	}
 }


### PR DESCRIPTION
essentially same work as #2233

Closes #4515