### PR TITLE
builder/amazon: validate ssh key name/file

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -75,6 +75,14 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	// Validation
 	errs := c.Comm.Prepare(ctx)
+	if c.SSHKeyPairName != "" {
+		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" && c.Comm.SSHPrivateKey == "" {
+			errs = append(errs, errors.New("A private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
+		} else if c.Comm.SSHPrivateKey == "" && !c.Comm.SSHAgentAuth {
+			errs = append(errs, errors.New("A private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
+		}
+	}
+
 	if c.SourceAmi == "" && c.SourceAmiFilter.Empty() {
 		errs = append(errs, errors.New("A source_ami or source_ami_filter must be specified"))
 	}


### PR DESCRIPTION
When using ssh_key_name, ssh_private_key file must be given,
or ssh_agent_auth enabled.

When automatically retrieving the winrm password, if ssh_key_name is
given, ssh_private_key_file must also be given.

Closes #4164