### PR TITLE
amazon-chroot: Fixed indentation

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -184,7 +184,7 @@ each category, the available configuration keys are alphabetized.
         volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
         volumes
 
-    -   `root_device_name` (string) - The root device name. For example, `xvda`.
+-   `root_device_name` (string) - The root device name. For example, `xvda`.
 
 -   `mount_path` (string) - The path where the volume will be mounted. This is
     where the chroot environment will be. This defaults to

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -49,15 +49,15 @@ builder.
 -   `source_ami` (string) - The initial AMI used as a base for the newly
     created machine. `source_ami_filter` may be used instead to populate this
     automatically.
-    
+
 -   `ami_root_device` (block device mapping) - A block device mapping describing
     the root device of the AMI. This looks like the mappings in `ami_block_device_mapping`,
     except with an additional field:
-    
-    - `source_device_name` (string) - The device name of the block device on the
-      source instance to be used as the root device for the AMI. This must correspond
-      to a block device in `launch_block_device_mapping`.
-    
+
+    -   `source_device_name` (string) - The device name of the block device on the
+        source instance to be used as the root device for the AMI. This must correspond
+        to a block device in `launch_block_device_mapping`.
+
 ### Optional:
 
 -   `ami_block_device_mappings` (array of block device mappings) - Add one or


### PR DESCRIPTION
`root_device_name` was not properly indented and thus showed up under `ami_block_device_mappings`. 