### PR TITLE
builder/virtualbox: allow skipping upload of version file

### DIFF
--- a/builder/virtualbox/common/vbox_version_config.go
+++ b/builder/virtualbox/common/vbox_version_config.go
@@ -5,12 +5,13 @@ import (
 )
 
 type VBoxVersionConfig struct {
-	VBoxVersionFile string `mapstructure:"virtualbox_version_file"`
+	VBoxVersionFile *string `mapstructure:"virtualbox_version_file"`
 }
 
 func (c *VBoxVersionConfig) Prepare(ctx *interpolate.Context) []error {
-	if c.VBoxVersionFile == "" {
-		c.VBoxVersionFile = ".vbox_version"
+	if c.VBoxVersionFile == nil {
+		default_file := ".vbox_version"
+		c.VBoxVersionFile = &default_file
 	}
 
 	return nil

--- a/builder/virtualbox/common/vbox_version_config_test.go
+++ b/builder/virtualbox/common/vbox_version_config_test.go
@@ -15,19 +15,50 @@ func TestVBoxVersionConfigPrepare_BootWait(t *testing.T) {
 		t.Fatalf("should not have error: %s", errs)
 	}
 
-	if c.VBoxVersionFile != ".vbox_version" {
-		t.Fatalf("bad value: %s", c.VBoxVersionFile)
+	if *c.VBoxVersionFile != ".vbox_version" {
+		t.Fatalf("bad value: %s", *c.VBoxVersionFile)
 	}
 
 	// Test with a good one
 	c = new(VBoxVersionConfig)
-	c.VBoxVersionFile = "foo"
+	filename := "foo"
+	c.VBoxVersionFile = &filename
 	errs = c.Prepare(testConfigTemplate(t))
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}
 
-	if c.VBoxVersionFile != "foo" {
-		t.Fatalf("bad value: %s", c.VBoxVersionFile)
+	if *c.VBoxVersionFile != "foo" {
+		t.Fatalf("bad value: %s", *c.VBoxVersionFile)
+	}
+}
+
+func TestVBoxVersionConfigPrepare_empty(t *testing.T) {
+	var c *VBoxVersionConfig
+	var errs []error
+
+	// Test with nil value
+	c = new(VBoxVersionConfig)
+	c.VBoxVersionFile = nil
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("should not have error: %s", errs)
+	}
+
+	if *c.VBoxVersionFile != ".vbox_version" {
+		t.Fatalf("bad value: %s", *c.VBoxVersionFile)
+	}
+
+	// Test with empty name
+	c = new(VBoxVersionConfig)
+	filename := ""
+	c.VBoxVersionFile = &filename
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("should not have error: %s", errs)
+	}
+
+	if *c.VBoxVersionFile != "" {
+		t.Fatalf("bad value: %s", *c.VBoxVersionFile)
 	}
 }

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -246,7 +246,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			WinRMPort: vboxcommon.SSHPort,
 		},
 		&vboxcommon.StepUploadVersion{
-			Path: b.config.VBoxVersionFile,
+			Path: *b.config.VBoxVersionFile,
 		},
 		&vboxcommon.StepUploadGuestAdditions{
 			GuestAdditionsMode: b.config.GuestAdditionsMode,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -119,7 +119,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			WinRMPort: vboxcommon.SSHPort,
 		},
 		&vboxcommon.StepUploadVersion{
-			Path: b.config.VBoxVersionFile,
+			Path: *b.config.VBoxVersionFile,
 		},
 		&vboxcommon.StepUploadGuestAdditions{
 			GuestAdditionsMode: b.config.GuestAdditionsMode,

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -304,7 +304,8 @@ builder.
     upload a file that contains the VirtualBox version that was used to create
     the machine. This information can be useful for provisioning. By default
     this is ".vbox\_version", which will generally be upload it into the
-    home directory.
+    home directory. Set to an empty string to skip uploading this file, which
+    can be useful when using the `none` communicator.
 
 -   `vm_name` (string) - This is the name of the OVF file for the new virtual
     machine, without the file extension. By default this is "packer-BUILDNAME",

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -266,7 +266,8 @@ builder.
     upload a file that contains the VirtualBox version that was used to create
     the machine. This information can be useful for provisioning. By default
     this is ".vbox\_version", which will generally be upload it into the
-    home directory.
+    home directory. Set to an empty string to skip uploading this file, which
+    can be useful when using the `none` communicator.
 
 -   `vm_name` (string) - This is the name of the virtual machine when it is
     imported as well as the name of the OVF file when the virtual machine


### PR DESCRIPTION
Closes #3619 


I tried to get it to auto-skip uploading the version file if the communicator is none, but you need to set so much stuff explicitly to get the none communicator to work that I thought it was best to continue the tradition. I also wanted to favor explicit over implicit, especially as this is a "power user" feature.

Here's the config I used to get it to work in the end

```json
{
    "builders": [
        {
            "checksum": "4e2cfccfd5b8d2da87d10bc3a760e2aca1f4841f86241a85b2c9858716bde9d8",
            "checksum_type": "sha256",
            "shutdown_command": "echo ubuntu | sudo -S shutdown now",
            "source_path": "/Users/mwhooker/images/ubuntu.ova",
            "ssh_password": "ubuntu",
            "ssh_username": "ubuntu",
            "type": "virtualbox-ovf",
            "ssh_skip_nat_mapping": true,
            "virtualbox_version_file": "",
            "guest_additions_mode": "disable",
            "communicator": "none"
        }
    ]
}
```