### PR TITLE
Fix example in documentation

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -367,7 +367,7 @@ provisioning commands to install the os and bootloader.
 ``` {.javascript}
 {
   "type": "amazon-chroot",
-  "ami_name": "packer-from-scratch {{timestamp}}"
+  "ami_name": "packer-from-scratch {{timestamp}}",
   "from_scratch": true,
   "ami_virtualization_type": "hvm",
   "pre_mount_commands": [

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -370,7 +370,7 @@ provisioning commands to install the os and bootloader.
   "ami_name": "packer-from-scratch {{timestamp}}"
   "from_scratch": true,
   "ami_virtualization_type": "hvm",
-  "device_setup_commands": [
+  "pre_mount_commands": [
     "parted {{.Device}} mklabel msdos mkpart primary 1M 100% set 1 boot on print",
     "mkfs.ext4 {{.Device}}1"
   ],


### PR DESCRIPTION
`device_setup_commands` appears to no longer be the right key to use to list device setup commands.