### PR TITLE
builder/amazon: report tag creation

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -289,6 +289,8 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 		return multistep.ActionHalt
 	}
 
+	ReportTags(ui, ec2Tags)
+
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Tags:      ec2Tags,
 		Resources: []*string{instance.InstanceId},

--- a/builder/amazon/common/step_tag_ebs_volumes.go
+++ b/builder/amazon/common/step_tag_ebs_volumes.go
@@ -44,6 +44,8 @@ func (s *StepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
+	ReportTags(ui, tags)
+
 	_, err = ec2conn.CreateTags(&ec2.CreateTagsInput{
 		Resources: volumeIds,
 		Tags:      tags,

--- a/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
@@ -50,6 +50,7 @@ func (s *stepTagEBSVolumes) Run(state multistep.StateBag) multistep.StepAction {
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
+			awscommon.ReportTags(ui, tags)
 
 			for _, v := range instance.BlockDeviceMappings {
 				if *v.DeviceName == mapping.DeviceName {


### PR DESCRIPTION
Closes #4697 

output looks like

```
1490310682,,ui,say,==> amazon-ebs: Prevalidating AMI Name...
1490310685,,ui,message,    amazon-ebs: Found Image ID: ami-fce3c696
1490310685,,ui,say,==> amazon-ebs: Creating temporary keypair: packer_58d4561a-3366-9f67-4881-c226e68a7ce7
1490310685,,ui,say,==> amazon-ebs: Creating temporary security group for this instance...
1490310686,,ui,say,==> amazon-ebs: Authorizing access to port 22 the temporary security group...
1490310686,,ui,say,==> amazon-ebs: Launching a source AWS instance...
1490310688,,ui,message,    amazon-ebs: Instance ID: i-0246a985be560c3de
1490310688,,ui,say,==> amazon-ebs: Waiting for instance (i-0246a985be560c3de) to become ready...
1490310703,,ui,say,==> amazon-ebs: Adding tags to source instance
1490310703,,ui,message,    amazon-ebs: Adding tag: "Name": "Packer Builder"
1490310704,,ui,say,==> amazon-ebs: Waiting for SSH to become available...
1490310738,,ui,say,==> amazon-ebs: Connected to SSH!
1490310738,,ui,say,==> amazon-ebs: Stopping the source instance...
1490310739,,ui,say,==> amazon-ebs: Waiting for the instance to stop...
1490310796,,ui,say,==> amazon-ebs: Creating the AMI: packer-qs-1490310682
1490310796,,ui,message,    amazon-ebs: AMI: ami-0b36851d
1490310796,,ui,say,==> amazon-ebs: Waiting for AMI to become ready...
1490310839,,ui,say,==> amazon-ebs: Adding tags to AMI (ami-0b36851d)...
1490310839,,ui,say,==> amazon-ebs: Tagging snapshot: snap-03660ee8b769482f4
1490310839,,ui,say,==> amazon-ebs: Creating AMI tags
1490310839,,ui,message,    amazon-ebs: Adding tag: "OS_Version": "Ubuntu"
1490310839,,ui,message,    amazon-ebs: Adding tag: "Release": "Latest"
1490310839,,ui,say,==> amazon-ebs: Creating snapshot tags
1490310839,,ui,say,==> amazon-ebs: Terminating the source AWS instance...
1490310847,,ui,say,==> amazon-ebs: Cleaning up any extra volumes...
1490310848,,ui,say,==> amazon-ebs: No volumes to clean up%!(PACKER_COMMA) skipping
1490310848,,ui,say,==> amazon-ebs: Deleting temporary security group...
1490310848,,ui,say,==> amazon-ebs: Deleting temporary keypair...
1490310848,,ui,say,Build 'amazon-ebs' finished.
1490310848,,ui,say,\n==> Builds finished. The artifacts of successful builds are:
1490310848,amazon-ebs,artifact-count,1
1490310848,amazon-ebs,artifact,0,builder-id,mitchellh.amazonebs
1490310848,amazon-ebs,artifact,0,id,us-east-1:ami-0b36851d
1490310848,amazon-ebs,artifact,0,string,AMIs were created:\n\nus-east-1: ami-0b36851d
1490310848,amazon-ebs,artifact,0,files-count,0
1490310848,amazon-ebs,artifact,0,end
1490310848,,ui,say,--> amazon-ebs: AMIs were created:\n\nus-east-1: ami-0b36851d
```