### PR TITLE
Removed merge conflict from Docker example web page

### DIFF
--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -83,59 +83,31 @@ Example uses of all of the options, assuming one is building an NGINX image from
 
 Allowed metadata fields that can be changed are:
 
-<<<<<<< HEAD
-- `CMD`
-  - String, supports both array (escaped) and string form
-  - EX: `”CMD [\"nginx\", \"-g\", \"daemon off;\"]"`
-  - EX: `"CMD nginx -g daemon off;”`
-- `ENTRYPOINT`
-  - String
-  - EX: `“ENTRYPOINT /var/www/start.sh”`
-- `ENV`
-  - String, note there is no equal sign:
-  - EX: `“ENV HOSTNAME www.example.com”` not `“ENV HOSTNAME=www.example.com”`
-- `EXPOSE`
-  - String, space separated ports
-  - EX: `“EXPOSE 80 443”`
-- `MAINTAINER`
-  - String
-  - EX: `“MAINTAINER NAME”`
-- `USER`
-  - String
-  - EX: `“USER USERNAME”`
-- `VOLUME`
-  - String
-  - EX: `“VOLUME FROM TO“`
-- `WORKDIR`
-  - String
-  - EX: `“WORKDIR PATH”`
-=======
 - CMD
 	- String, supports both array (escaped) and string form
 	- EX: `"CMD [\"nginx\", \"-g\", \"daemon off;\"]"`
 	- EX: `"CMD nginx -g daemon off;"`
 - ENTRYPOINT
-	- String 
+	- String
 	- EX: `"ENTRYPOINT /var/www/start.sh"`
 - ENV
-	- String, note there is no equal sign: 
+	- String, note there is no equal sign:
 	- EX: `"ENV HOSTNAME www.example.com"` not `"ENV HOSTNAME=www.example.com"`
 - EXPOSE
-	- String, space separated ports 
+	- String, space separated ports
 	- EX: `"EXPOSE 80 443"`
 - MAINTAINER
-	- String 
+	- String
 	- EX: `"MAINTAINER NAME"`
 - USER
-	- String 
+	- String
 	- EX: `"USER USERNAME"`
 - VOLUME
-	- String 
+	- String
 	- EX: `"VOLUME FROM TO"`
 - WORKDIR
 	- String
 	- EX: `"WORKDIR PATH"`
->>>>>>> mitchellh/master
 
 ## Configuration Reference
 


### PR DESCRIPTION
My coworker noticed that there seems to be a merge conflict message that shows up on the Docker documentation page here: https://www.packer.io/docs/builders/docker.html

![packer](https://cloud.githubusercontent.com/assets/5024679/24434752/4ee4a350-13e6-11e7-934f-6928f4864aa3.png)

This was introduced earlier by this commit https://github.com/mitchellh/packer/commit/6cbb137883ff0c2513d2845c29de3ea635bb38eb.

@jasoncostello and @sethvargo? Not sure if it's improper or not but I cc you guys as a heads up. 