### PR TITLE
Fix link to GitHub project page on website

### DIFF
--- a/website/source/layouts/_sidebar.erb
+++ b/website/source/layouts/_sidebar.erb
@@ -21,7 +21,7 @@
       </a>
     </li>
     <li>
-      <a href="https://github.com/mitchellh/vagrant">
+      <a href="https://github.com/mitchellh/packer">
         <%= inline_svg "github.svg" %> GitHub
       </a>
     </li>


### PR DESCRIPTION
The link to the GitHub project was incorrect. The URL was point to the vagrant project page instead of the packer project page.